### PR TITLE
refactor(frontend): convert the render-only inject18n classes to function components (#17967)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_cards/ListCards.jsx
+++ b/opencti-platform/opencti-front/src/components/list_cards/ListCards.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose, toPairs } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
@@ -14,13 +14,13 @@ import ToggleButton from '@mui/material/ToggleButton';
 import { UserContext } from '../../utils/hooks/useAuth';
 import Filters from '../../private/components/common/lists/Filters';
 import SearchInput from '../SearchInput';
-import inject18n from '../i18n';
 import StixDomainObjectsExports from '../../private/components/common/stix_domain_objects/StixDomainObjectsExports';
 import Security from '../../utils/Security';
 import { KNOWLEDGE_KNGETEXPORT } from '../../utils/hooks/useGranted';
 import FilterIconButton from '../FilterIconButton';
 import { export_max_size } from '../../utils/utils';
 import { Stack } from '@mui/material';
+import { useFormatter } from '../i18n';
 
 const styles = (theme) => ({
   parameters: {
@@ -47,229 +47,248 @@ const styles = (theme) => ({
   },
 });
 
-class ListCards extends Component {
-  sortBy(event) {
-    this.props.handleSort(event.target.value, this.props.orderAsc);
-  }
+const ListCards = (props) => {
+  const { t_i18n } = useFormatter();
+  const handleSortBy = (event) => {
+    props.handleSort(event.target.value, props.orderAsc);
+  };
 
-  reverse() {
-    this.props.handleSort(this.props.sortBy, !this.props.orderAsc);
-  }
+  const reverse = () => {
+    props.handleSort(props.sortBy, !props.orderAsc);
+  };
 
-  render() {
-    const {
-      t,
-      classes,
-      handleSearch,
-      handleChangeView,
-      handleAddFilter,
-      handleRemoveFilter,
-      handleSwitchGlobalMode,
-      handleSwitchLocalMode,
-      handleToggleExports,
-      openExports,
-      dataColumns,
-      paginationOptions,
-      keyword,
-      filters,
-      sortBy,
-      orderAsc,
-      children,
-      exportContext,
-      numberOfElements,
-      helpers,
-      createButton,
-      additionalHeaderButtons,
-    } = this.props;
-    const exportDisabled = numberOfElements && numberOfElements.number > export_max_size;
-    const entityType = exportContext?.entity_type;
-    return (
-      <UserContext.Consumer>
-        {({ schema }) => {
-          const filterKeysMap = schema.filterKeysSchema.get(entityType) ?? new Map();
-          const availableFilterKeys = Array.from(filterKeysMap.keys());
-          return (
-            <>
-              <div className={classes.parameters}>
-                <SearchInput
-                  variant="small"
-                  onSubmit={handleSearch.bind(this)}
-                  keyword={keyword}
-                />
-                {availableFilterKeys.length > 0 && (
-                  <Filters
-                    helpers={helpers}
-                    availableFilterKeys={availableFilterKeys}
-                    handleAddFilter={handleAddFilter}
-                    handleSwitchGlobalMode={handleSwitchGlobalMode}
-                    handleSwitchLocalMode={handleSwitchLocalMode}
-                    searchContext={{
-                      entityTypes: entityType ? [entityType] : [],
-                    }}
-                  />
-                )}
-                <div className={classes.sortFieldContainer}>
-                  <InputLabel classes={{ root: classes.sortFieldLabel }}>
-                    {t('Sort by')}
-                  </InputLabel>
-                  <FormControl>
-                    <Select
-                      name="sort-by"
-                      value={sortBy}
-                      size="small"
-                      variant="outlined"
-                      onChange={this.sortBy.bind(this)}
-                      inputProps={{
-                        name: 'sort-by',
-                        id: 'sort-by',
-                      }}
-                    >
-                      <MenuItem key="_score" value="_score">
-                        {t('Score')}
-                      </MenuItem>
-                      {toPairs(dataColumns).map((dataColumn) => (
-                        <MenuItem key={dataColumn[0]} value={dataColumn[0]}>
-                          {t(dataColumn[1].label)}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <IconButton
-                    aria-label="Sort by"
-                    onClick={this.reverse.bind(this)}
-                    size="small"
-                  >
-                    {orderAsc ? (
-                      <ArrowDownward fontSize="small" />
-                    ) : (
-                      <ArrowUpward fontSize="small" />
-                    )}
-                  </IconButton>
-                </div>
-                <div className={classes.filler} />
-                <Stack direction="row" gap={1}>
-                  {numberOfElements && (
-                    <div style={{ alignSelf: 'center' }}>
-                      <strong>{`${numberOfElements.number}${numberOfElements.symbol}`}</strong>{' '}
-                      {t('entitie(s)')}
-                    </div>
-                  )}
-                  {(typeof handleChangeView === 'function'
-                    || typeof handleToggleExports === 'function') && (
-                    <ToggleButtonGroup
-                      size="small"
-                      value="cards"
-                      exclusive={true}
-                      onChange={(_, value) => {
-                        if (value && value === 'export') {
-                          handleToggleExports();
-                        } else if (value) {
-                          handleChangeView(value);
-                        }
-                      }}
-                    >
-                      {typeof handleChangeView === 'function' && (
-                        <Tooltip title={t('Cards view')}>
-                          <ToggleButton value="cards" aria-label="cards">
-                            <ViewModuleOutlined fontSize="small" color="primary" />
-                          </ToggleButton>
-                        </Tooltip>
-                      )}
-                      {typeof handleChangeView === 'function' && (
-                        <Tooltip title={t('Lines view')}>
-                          <ToggleButton value="lines" aria-label="lines">
-                            <ViewListOutlined fontSize="small" color="primary" />
-                          </ToggleButton>
-                        </Tooltip>
-                      )}
-                      {typeof handleToggleExports === 'function'
-                        && !exportDisabled && (
-                        <Tooltip title={t('Open export panel')}>
-                          <ToggleButton value="export" aria-label="export">
-                            <FileDownloadOutlined
-                              color="primary"
-                              fontSize="small"
-                            />
-                          </ToggleButton>
-                        </Tooltip>
-                      )}
-                      {typeof handleToggleExports === 'function'
-                        && exportDisabled && (
-                        <Tooltip
-                          title={`${
-                            t(
-                              'Export is disabled because too many entities are targeted (maximum number of entities is: ',
-                            ) + export_max_size
-                          })`}
-                        >
-                          <span>
-                            <ToggleButton
-                              size="small"
-                              value="export"
-                              aria-label="export"
-                              disabled={true}
-                            >
-                              <FileDownloadOutlined fontSize="small" />
-                            </ToggleButton>
-                          </span>
-                        </Tooltip>
-                      )}
-                    </ToggleButtonGroup>
-                  )}
+  const {
 
-                  {
-                    additionalHeaderButtons && (
-                      <Stack
-                        direction="row"
-                        gap={1}
-                        sx={{
-                          '&:empty': {
-                            display: 'none',
-                          },
-                        }}
-                      >
-                        {[...additionalHeaderButtons]}
-                      </Stack>
-                    )
-                  }
+    classes,
 
-                  {createButton}
-                </Stack>
-              </div>
-              <FilterIconButton
-                helpers={helpers}
-                filters={filters}
-                handleRemoveFilter={handleRemoveFilter}
-                handleSwitchGlobalMode={handleSwitchGlobalMode}
-                handleSwitchLocalMode={handleSwitchLocalMode}
-                redirection
-                entityTypes={entityType ? [entityType] : undefined}
-                searchContext={{
-                  entityTypes: entityType ? [entityType] : [],
-                }}
+    handleSearch,
+
+    handleChangeView,
+
+    handleAddFilter,
+
+    handleRemoveFilter,
+
+    handleSwitchGlobalMode,
+
+    handleSwitchLocalMode,
+
+    handleToggleExports,
+
+    openExports,
+
+    dataColumns,
+
+    paginationOptions,
+
+    keyword,
+
+    filters,
+
+    sortBy,
+
+    orderAsc,
+
+    children,
+
+    exportContext,
+
+    numberOfElements,
+
+    helpers,
+
+    createButton,
+
+    additionalHeaderButtons,
+
+  } = props;
+  const exportDisabled = numberOfElements && numberOfElements.number > export_max_size;
+  const entityType = exportContext?.entity_type;
+  return (
+    <UserContext.Consumer>
+      {({ schema }) => {
+        const filterKeysMap = schema.filterKeysSchema.get(entityType) ?? new Map();
+        const availableFilterKeys = Array.from(filterKeysMap.keys());
+        return (
+          <>
+            <div className={classes.parameters}>
+              <SearchInput
+                variant="small"
+                onSubmit={handleSearch.bind(this)}
+                keyword={keyword}
               />
-              {typeof handleToggleExports === 'function' && (
-                <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
-                  <StixDomainObjectsExports
-                    open={openExports}
-                    handleToggle={handleToggleExports.bind(this)}
-                    paginationOptions={paginationOptions}
-                    exportContext={exportContext}
-                  />
-                </Security>
+              {availableFilterKeys.length > 0 && (
+                <Filters
+                  helpers={helpers}
+                  availableFilterKeys={availableFilterKeys}
+                  handleAddFilter={handleAddFilter}
+                  handleSwitchGlobalMode={handleSwitchGlobalMode}
+                  handleSwitchLocalMode={handleSwitchLocalMode}
+                  searchContext={{
+                    entityTypes: entityType ? [entityType] : [],
+                  }}
+                />
               )}
-              <div className={classes.cardsContainer}>{children}</div>
-            </>
-          );
-        }}
-      </UserContext.Consumer>
-    );
-  }
-}
+              <div className={classes.sortFieldContainer}>
+                <InputLabel classes={{ root: classes.sortFieldLabel }}>
+                  {t_i18n('Sort by')}
+                </InputLabel>
+                <FormControl>
+                  <Select
+                    name="sort-by"
+                    value={sortBy}
+                    size="small"
+                    variant="outlined"
+                    onChange={handleSortBy}
+                    inputProps={{
+                      name: 'sort-by',
+                      id: 'sort-by',
+                    }}
+                  >
+                    <MenuItem key="_score" value="_score">
+                      {t_i18n('Score')}
+                    </MenuItem>
+                    {toPairs(dataColumns).map((dataColumn) => (
+                      <MenuItem key={dataColumn[0]} value={dataColumn[0]}>
+                        {t_i18n(dataColumn[1].label)}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <IconButton
+                  aria-label="Sort by"
+                  onClick={reverse}
+                  size="small"
+                >
+                  {orderAsc ? (
+                    <ArrowDownward fontSize="small" />
+                  ) : (
+                    <ArrowUpward fontSize="small" />
+                  )}
+                </IconButton>
+              </div>
+              <div className={classes.filler} />
+              <Stack direction="row" gap={1}>
+                {numberOfElements && (
+                  <div style={{ alignSelf: 'center' }}>
+                    <strong>{`${numberOfElements.number}${numberOfElements.symbol}`}</strong>{' '}
+                    {t_i18n('entitie(s)')}
+                  </div>
+                )}
+                {(typeof handleChangeView === 'function'
+                  || typeof handleToggleExports === 'function') && (
+                  <ToggleButtonGroup
+                    size="small"
+                    value="cards"
+                    exclusive={true}
+                    onChange={(_, value) => {
+                      if (value && value === 'export') {
+                        handleToggleExports();
+                      } else if (value) {
+                        handleChangeView(value);
+                      }
+                    }}
+                  >
+                    {typeof handleChangeView === 'function' && (
+                      <Tooltip title={t_i18n('Cards view')}>
+                        <ToggleButton value="cards" aria-label="cards">
+                          <ViewModuleOutlined fontSize="small" color="primary" />
+                        </ToggleButton>
+                      </Tooltip>
+                    )}
+                    {typeof handleChangeView === 'function' && (
+                      <Tooltip title={t_i18n('Lines view')}>
+                        <ToggleButton value="lines" aria-label="lines">
+                          <ViewListOutlined fontSize="small" color="primary" />
+                        </ToggleButton>
+                      </Tooltip>
+                    )}
+                    {typeof handleToggleExports === 'function'
+                      && !exportDisabled && (
+                      <Tooltip title={t_i18n('Open export panel')}>
+                        <ToggleButton value="export" aria-label="export">
+                          <FileDownloadOutlined
+                            color="primary"
+                            fontSize="small"
+                          />
+                        </ToggleButton>
+                      </Tooltip>
+                    )}
+                    {typeof handleToggleExports === 'function'
+                      && exportDisabled && (
+                      <Tooltip
+                        title={`${
+                          t_i18n(
+                            'Export is disabled because too many entities are targeted (maximum number of entities is: ',
+                          ) + export_max_size
+                        })`}
+                      >
+                        <span>
+                          <ToggleButton
+                            size="small"
+                            value="export"
+                            aria-label="export"
+                            disabled={true}
+                          >
+                            <FileDownloadOutlined fontSize="small" />
+                          </ToggleButton>
+                        </span>
+                      </Tooltip>
+                    )}
+                  </ToggleButtonGroup>
+                )}
+
+                {
+                  additionalHeaderButtons && (
+                    <Stack
+                      direction="row"
+                      gap={1}
+                      sx={{
+                        '&:empty': {
+                          display: 'none',
+                        },
+                      }}
+                    >
+                      {[...additionalHeaderButtons]}
+                    </Stack>
+                  )
+                }
+
+                {createButton}
+              </Stack>
+            </div>
+            <FilterIconButton
+              helpers={helpers}
+              filters={filters}
+              handleRemoveFilter={handleRemoveFilter}
+              handleSwitchGlobalMode={handleSwitchGlobalMode}
+              handleSwitchLocalMode={handleSwitchLocalMode}
+              redirection
+              entityTypes={entityType ? [entityType] : undefined}
+              searchContext={{
+                entityTypes: entityType ? [entityType] : [],
+              }}
+            />
+            {typeof handleToggleExports === 'function' && (
+              <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
+                <StixDomainObjectsExports
+                  open={openExports}
+                  handleToggle={handleToggleExports.bind(this)}
+                  paginationOptions={paginationOptions}
+                  exportContext={exportContext}
+                />
+              </Security>
+            )}
+            <div className={classes.cardsContainer}>{children}</div>
+          </>
+        );
+      }}
+    </UserContext.Consumer>
+  );
+};
 
 ListCards.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
   children: PropTypes.object,
   handleSearch: PropTypes.func.isRequired,
   handleSort: PropTypes.func.isRequired,
@@ -292,4 +311,4 @@ ListCards.propTypes = {
   additionalHeaderButtons: PropTypes.arrayOf[React.ReactNode],
 };
 
-export default compose(inject18n, withStyles(styles))(ListCards);
+export default compose(withStyles(styles))(ListCards);

--- a/opencti-platform/opencti-front/src/components/list_cards/ListCards.jsx
+++ b/opencti-platform/opencti-front/src/components/list_cards/ListCards.jsx
@@ -308,7 +308,7 @@ ListCards.propTypes = {
   numberOfElements: PropTypes.object,
   helpers: PropTypes.object,
   createButton: PropTypes.object,
-  additionalHeaderButtons: PropTypes.arrayOf[React.ReactNode],
+  additionalHeaderButtons: PropTypes.arrayOf(PropTypes.node),
 };
 
 export default compose(withStyles(styles))(ListCards);

--- a/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
@@ -1,15 +1,11 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { Navigate } from 'react-router-dom';
-import { compose } from 'ramda';
+import React from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import withStyles from '@mui/styles/withStyles';
 import { graphql } from 'react-relay';
-import inject18n from '../../components/i18n';
 import { QueryRenderer } from '../../relay/environment';
 import { resolveLink } from '../../utils/Entity';
 import Loader from '../../components/Loader';
 import ErrorNotFound from '../../components/ErrorNotFound';
-import withRouter from '../../utils/compat_router/withRouter';
 
 const styles = () => ({
   container: {
@@ -96,93 +92,80 @@ export const stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery = gra
   }
 `;
 
-class StixObjectOrStixRelationship extends Component {
-  render() {
-    const {
-      classes,
-      params: { id },
-    } = this.props;
-    return (
-      <div className={classes.container}>
-        <QueryRenderer
-          query={stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery}
-          variables={{ id }}
-          render={({ props }) => {
-            if (props) {
-              if (props.stixObjectOrStixRelationship) {
-                let redirectLink;
-                const { stixObjectOrStixRelationship } = props;
-                const fromRestricted = stixObjectOrStixRelationship.from === null;
-                const toRestricted = stixObjectOrStixRelationship.to === null;
-                if (
-                  stixObjectOrStixRelationship.relationship_type
-                  === 'stix-sighting-relationship'
-                ) {
-                  if (!toRestricted) {
-                    redirectLink = `${resolveLink(
-                      stixObjectOrStixRelationship.to.entity_type,
-                    )}/${
-                      stixObjectOrStixRelationship.to.id
-                    }/knowledge/sightings/${stixObjectOrStixRelationship.id}`;
-                  } else {
-                    redirectLink = !fromRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.from.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.from.id
-                      }/knowledge/sightings/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  }
-                } else if (stixObjectOrStixRelationship.relationship_type) {
-                  if (stixObjectOrStixRelationship.from?.relationship_type) {
-                    redirectLink = !toRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.to.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.to.id
-                      }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  } else if (!fromRestricted) {
-                    redirectLink = `${resolveLink(
+const StixObjectOrStixRelationship = (props) => {
+  const { classes } = props;
+  const { id } = useParams();
+  return (
+    <div className={classes.container}>
+      <QueryRenderer
+        query={stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery}
+        variables={{ id }}
+        render={({ props }) => {
+          if (props) {
+            if (props.stixObjectOrStixRelationship) {
+              let redirectLink;
+              const { stixObjectOrStixRelationship } = props;
+              const fromRestricted = stixObjectOrStixRelationship.from === null;
+              const toRestricted = stixObjectOrStixRelationship.to === null;
+              if (
+                stixObjectOrStixRelationship.relationship_type
+                === 'stix-sighting-relationship'
+              ) {
+                if (!toRestricted) {
+                  redirectLink = `${resolveLink(
+                    stixObjectOrStixRelationship.to.entity_type,
+                  )}/${
+                    stixObjectOrStixRelationship.to.id
+                  }/knowledge/sightings/${stixObjectOrStixRelationship.id}`;
+                } else {
+                  redirectLink = !fromRestricted
+                    ? `${resolveLink(
                       stixObjectOrStixRelationship.from.entity_type,
                     )}/${
                       stixObjectOrStixRelationship.from.id
-                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`;
-                  } else {
-                    redirectLink = !toRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.to.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.to.id
-                      }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  }
-                } else {
+                    }/knowledge/sightings/${stixObjectOrStixRelationship.id}`
+                    : undefined;
+                }
+              } else if (stixObjectOrStixRelationship.relationship_type) {
+                if (stixObjectOrStixRelationship.from?.relationship_type) {
+                  redirectLink = !toRestricted
+                    ? `${resolveLink(
+                      stixObjectOrStixRelationship.to.entity_type,
+                    )}/${
+                      stixObjectOrStixRelationship.to.id
+                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
+                    : undefined;
+                } else if (!fromRestricted) {
                   redirectLink = `${resolveLink(
-                    stixObjectOrStixRelationship.entity_type,
-                  )}/${stixObjectOrStixRelationship.id}`;
+                    stixObjectOrStixRelationship.from.entity_type,
+                  )}/${
+                    stixObjectOrStixRelationship.from.id
+                  }/knowledge/relations/${stixObjectOrStixRelationship.id}`;
+                } else {
+                  redirectLink = !toRestricted
+                    ? `${resolveLink(
+                      stixObjectOrStixRelationship.to.entity_type,
+                    )}/${
+                      stixObjectOrStixRelationship.to.id
+                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
+                    : undefined;
                 }
-                if (redirectLink) {
-                  return <Navigate exact from={`/id/${id}`} to={redirectLink} replace={true} />;
-                }
+              } else {
+                redirectLink = `${resolveLink(
+                  stixObjectOrStixRelationship.entity_type,
+                )}/${stixObjectOrStixRelationship.id}`;
               }
-              return <ErrorNotFound />;
+              if (redirectLink) {
+                return <Navigate exact from={`/id/${id}`} to={redirectLink} replace={true} />;
+              }
             }
-            return <Loader />;
-          }}
-        />
-      </div>
-    );
-  }
-}
-
-StixObjectOrStixRelationship.propTypes = {
-  params: PropTypes.object,
-  navigate: PropTypes.func,
+            return <ErrorNotFound />;
+          }
+          return <Loader />;
+        }}
+      />
+    </div>
+  );
 };
 
-export default compose(
-  inject18n,
-  withRouter,
-  withStyles(styles),
-)(StixObjectOrStixRelationship);
+export default withStyles(styles)(StixObjectOrStixRelationship);

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferencesLines.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose, filter, head, map } from 'ramda';
+import { filter, head, map } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -10,7 +10,6 @@ import { CheckCircle } from '@mui/icons-material';
 import { ConnectionHandler } from 'relay-runtime';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
-import inject18n from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import ExternalReferenceCreation from './ExternalReferenceCreation';
 import { isNotEmptyField } from '../../../../utils/utils';
@@ -104,12 +103,12 @@ const sharedUpdater = (store, stixCoreObjectId, newEdge) => {
   ConnectionHandler.insertEdgeBefore(conn, newEdge);
 };
 
-class AddExternalReferencesLinesContainer extends Component {
-  toggleExternalReference(externalReference, onlyCreate = false) {
+const AddExternalReferencesLinesContainer = (props) => {
+  const toggleExternalReference = (externalReference, onlyCreate = false) => {
     const {
       stixCoreObjectOrStixCoreRelationshipId,
       stixCoreObjectOrStixCoreRelationshipReferences,
-    } = this.props;
+    } = props;
     const stixCoreObjectOrStixCoreRelationshipReferencesIds = map(
       (n) => n.node.id,
       stixCoreObjectOrStixCoreRelationshipReferences,
@@ -161,79 +160,56 @@ class AddExternalReferencesLinesContainer extends Component {
         },
       });
     }
-  }
+  };
 
-  render() {
-    const {
-      classes,
-      data,
-      stixCoreObjectOrStixCoreRelationshipReferences,
-      open,
-      search,
-      paginationOptions,
-      openContextual,
-      handleCloseContextual,
-    } = this.props;
-    const stixCoreObjectOrStixCoreRelationshipReferencesIds = map(
-      (n) => n.node.id,
-      stixCoreObjectOrStixCoreRelationshipReferences,
-    );
-    const computeTextItem = (externalReferenceNode) => {
-      const externalReference = externalReferenceNode.node;
-      const externalReferenceId = externalReference.external_id
-        ? `(${externalReference.external_id})`
-        : '';
-      return (
-        <ListItemText
-          primary={`${externalReference.source_name} ${externalReferenceId}`}
-          secondary={truncate(
-            externalReference.description !== null
-            && externalReference.description.length > 0
-              ? externalReference.description
-              : externalReference.url,
-            120,
-          )}
-        />
-      );
-    };
+  const {
+    classes,
+    data,
+    stixCoreObjectOrStixCoreRelationshipReferences,
+    open,
+    search,
+    paginationOptions,
+    openContextual,
+    handleCloseContextual,
+  } = props;
+  const stixCoreObjectOrStixCoreRelationshipReferencesIds = map(
+    (n) => n.node.id,
+    stixCoreObjectOrStixCoreRelationshipReferences,
+  );
+  const computeTextItem = (externalReferenceNode) => {
+    const externalReference = externalReferenceNode.node;
+    const externalReferenceId = externalReference.external_id
+      ? `(${externalReference.external_id})`
+      : '';
     return (
-      <div>
-        <List>
-          {data.externalReferences.edges.map((externalReferenceNode) => {
-            const externalReference = externalReferenceNode.node;
-            const alreadyAdded = stixCoreObjectOrStixCoreRelationshipReferencesIds.includes(
-              externalReference.id,
-            );
-            const isLinkedRef = isNotEmptyField(externalReference.fileId);
-            if (isLinkedRef) {
-              return (
-                <ListItemButton
-                  key={externalReference.id}
-                  classes={{ root: classes.menuItem }}
-                  divider={true}
-                  onClick={this.toggleExternalReference.bind(
-                    this,
-                    externalReference,
-                    false,
-                  )}
-                >
-                  <ListItemIcon>
-                    {alreadyAdded ? (
-                      <CheckCircle classes={{ root: classes.icon }} />
-                    ) : (
-                      <ItemIcon type="External-Reference" />
-                    )}
-                  </ListItemIcon>
-                  {computeTextItem(externalReferenceNode)}
-                </ListItemButton>
-              );
-            }
+      <ListItemText
+        primary={`${externalReference.source_name} ${externalReferenceId}`}
+        secondary={truncate(
+          externalReference.description !== null
+          && externalReference.description.length > 0
+            ? externalReference.description
+            : externalReference.url,
+          120,
+        )}
+      />
+    );
+  };
+  return (
+    <div>
+      <List>
+        {data.externalReferences.edges.map((externalReferenceNode) => {
+          const externalReference = externalReferenceNode.node;
+          const alreadyAdded = stixCoreObjectOrStixCoreRelationshipReferencesIds.includes(
+            externalReference.id,
+          );
+          const isLinkedRef = isNotEmptyField(externalReference.fileId);
+          if (isLinkedRef) {
             return (
               <ListItemButton
                 key={externalReference.id}
                 classes={{ root: classes.menuItem }}
                 divider={true}
-                onClick={this.toggleExternalReference.bind(
+                onClick={toggleExternalReference.bind(
                   this,
                   externalReference,
                   false,
@@ -249,21 +225,42 @@ class AddExternalReferencesLinesContainer extends Component {
                 {computeTextItem(externalReferenceNode)}
               </ListItemButton>
             );
-          })}
-        </List>
-        <ExternalReferenceCreation
-          display={open}
-          contextual={true}
-          openContextual={openContextual}
-          handleCloseContextual={handleCloseContextual}
-          inputValue={search}
-          paginationOptions={paginationOptions}
-          onCreate={this.toggleExternalReference.bind(this)}
-        />
-      </div>
-    );
-  }
-}
+          }
+          return (
+            <ListItemButton
+              key={externalReference.id}
+              classes={{ root: classes.menuItem }}
+              divider={true}
+              onClick={toggleExternalReference.bind(
+                this,
+                externalReference,
+                false,
+              )}
+            >
+              <ListItemIcon>
+                {alreadyAdded ? (
+                  <CheckCircle classes={{ root: classes.icon }} />
+                ) : (
+                  <ItemIcon type="External-Reference" />
+                )}
+              </ListItemIcon>
+              {computeTextItem(externalReferenceNode)}
+            </ListItemButton>
+          );
+        })}
+      </List>
+      <ExternalReferenceCreation
+        display={open}
+        contextual={true}
+        openContextual={openContextual}
+        handleCloseContextual={handleCloseContextual}
+        inputValue={search}
+        paginationOptions={paginationOptions}
+        onCreate={toggleExternalReference.bind(this)}
+      />
+    </div>
+  );
+};
 
 AddExternalReferencesLinesContainer.propTypes = {
   stixCoreObjectOrStixCoreRelationshipId: PropTypes.string,
@@ -271,8 +268,6 @@ AddExternalReferencesLinesContainer.propTypes = {
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   paginationOptions: PropTypes.object,
   open: PropTypes.bool,
   search: PropTypes.string,
@@ -359,7 +354,4 @@ const AddExternalReferencesLines = createPaginationContainer(
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(AddExternalReferencesLines);
+export default withStyles(styles)(AddExternalReferencesLines);

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferences.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -8,7 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Avatar from '@mui/material/Avatar';
 import Skeleton from '@mui/material/Skeleton';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixCoreRelationshipExternalReferencesLines, { stixCoreRelationshipExternalReferencesLinesQuery } from './StixCoreRelationshipExternalReferencesLines';
 import Card from '../../../../components/common/card/Card';
@@ -30,78 +29,72 @@ const styles = (theme) => ({
   },
 });
 
-class StixCoreRelationshipExternalReferences extends Component {
-  render() {
-    const { t, classes, stixCoreRelationshipId } = this.props;
-    return (
-      <QueryRenderer
-        query={stixCoreRelationshipExternalReferencesLinesQuery}
-        variables={{ id: stixCoreRelationshipId, count: 200 }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <StixCoreRelationshipExternalReferencesLines
-                stixCoreRelationshipId={stixCoreRelationshipId}
-                data={props}
-              />
-            );
-          }
+const StixCoreRelationshipExternalReferences = (props) => {
+  const { t_i18n } = useFormatter();
+  const { classes, stixCoreRelationshipId } = props;
+  return (
+    <QueryRenderer
+      query={stixCoreRelationshipExternalReferencesLinesQuery}
+      variables={{ id: stixCoreRelationshipId, count: 200 }}
+      render={({ props }) => {
+        if (props) {
           return (
-            <div style={{ height: '100%' }}>
-              <Card title={t('External references')}>
-                <List>
-                  {Array.from(Array(5), (e, i) => (
-                    <ListItem
-                      key={i}
-                      dense={true}
-                      divider={true}
-
-                    >
-                      <ListItemIcon>
-                        <Avatar classes={{ root: classes.avatarDisabled }}>
-                          {i}
-                        </Avatar>
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                            style={{ marginBottom: 10 }}
-                          />
-                        )}
-                        secondary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                          />
-                        )}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              </Card>
-            </div>
+            <StixCoreRelationshipExternalReferencesLines
+              stixCoreRelationshipId={stixCoreRelationshipId}
+              data={props}
+            />
           );
-        }}
-      />
-    );
-  }
-}
+        }
+        return (
+          <div style={{ height: '100%' }}>
+            <Card title={t_i18n('External references')}>
+              <List>
+                {Array.from(Array(5), (e, i) => (
+                  <ListItem
+                    key={i}
+                    dense={true}
+                    divider={true}
+
+                  >
+                    <ListItemIcon>
+                      <Avatar classes={{ root: classes.avatarDisabled }}>
+                        {i}
+                      </Avatar>
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                          style={{ marginBottom: 10 }}
+                        />
+                      )}
+                      secondary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                        />
+                      )}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Card>
+          </div>
+        );
+      }}
+    />
+  );
+};
 
 StixCoreRelationshipExternalReferences.propTypes = {
   stixCoreRelationshipId: PropTypes.string,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipExternalReferences);
+export default withStyles(styles)(StixCoreRelationshipExternalReferences);

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferences.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -8,7 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Avatar from '@mui/material/Avatar';
 import Skeleton from '@mui/material/Skeleton';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixSightingRelationshipExternalReferencesLines, { stixSightingRelationshipExternalReferencesLinesQuery } from './StixSightingRelationshipExternalReferencesLines';
 import Card from '@common/card/Card';
@@ -30,77 +29,71 @@ const styles = (theme) => ({
   },
 });
 
-class StixSightingRelationshipExternalReferences extends Component {
-  render() {
-    const { t, classes, stixSightingRelationshipId } = this.props;
-    return (
-      <QueryRenderer
-        query={stixSightingRelationshipExternalReferencesLinesQuery}
-        variables={{ id: stixSightingRelationshipId, count: 200 }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <StixSightingRelationshipExternalReferencesLines
-                stixSightingRelationshipId={stixSightingRelationshipId}
-                data={props}
-              />
-            );
-          }
+const StixSightingRelationshipExternalReferences = (props) => {
+  const { t_i18n } = useFormatter();
+  const { classes, stixSightingRelationshipId } = props;
+  return (
+    <QueryRenderer
+      query={stixSightingRelationshipExternalReferencesLinesQuery}
+      variables={{ id: stixSightingRelationshipId, count: 200 }}
+      render={({ props }) => {
+        if (props) {
           return (
-            <div style={{ height: '100%' }}>
-              <Card title={t('External references')}>
-                <List>
-                  {Array.from(Array(5), (e, i) => (
-                    <ListItem
-                      key={i}
-                      dense={true}
-                      divider={true}
-                    >
-                      <ListItemIcon>
-                        <Avatar classes={{ root: classes.avatarDisabled }}>
-                          {i}
-                        </Avatar>
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                            style={{ marginBottom: 10 }}
-                          />
-                        )}
-                        secondary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                          />
-                        )}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              </Card>
-            </div>
+            <StixSightingRelationshipExternalReferencesLines
+              stixSightingRelationshipId={stixSightingRelationshipId}
+              data={props}
+            />
           );
-        }}
-      />
-    );
-  }
-}
+        }
+        return (
+          <div style={{ height: '100%' }}>
+            <Card title={t_i18n('External references')}>
+              <List>
+                {Array.from(Array(5), (e, i) => (
+                  <ListItem
+                    key={i}
+                    dense={true}
+                    divider={true}
+                  >
+                    <ListItemIcon>
+                      <Avatar classes={{ root: classes.avatarDisabled }}>
+                        {i}
+                      </Avatar>
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                          style={{ marginBottom: 10 }}
+                        />
+                      )}
+                      secondary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                        />
+                      )}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Card>
+          </div>
+        );
+      }}
+    />
+  );
+};
 
 StixSightingRelationshipExternalReferences.propTypes = {
   stixSightingRelationshipId: PropTypes.string,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixSightingRelationshipExternalReferences);
+export default withStyles(styles)(StixSightingRelationshipExternalReferences);

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/AddNotesLines.jsx
@@ -9,9 +9,7 @@ import Typography from '@mui/material/Typography';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { Component } from 'react';
 import { createPaginationContainer, graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNode, insertNode } from '../../../../utils/store';
@@ -54,13 +52,13 @@ export const noteMutationRelationDelete = graphql`
   }
 `;
 
-class AddNotesLinesContainer extends Component {
-  toggleNote(note) {
+const AddNotesLinesContainer = (props) => {
+  const toggleNote = (note) => {
     const {
       stixCoreObjectOrStixCoreRelationshipId,
       stixCoreObjectOrStixCoreRelationshipNotes,
       paginationOptions,
-    } = this.props;
+    } = props;
     const entityNotesIds = R.map(
       (n) => n.node.id,
       stixCoreObjectOrStixCoreRelationshipNotes,
@@ -114,72 +112,70 @@ class AddNotesLinesContainer extends Component {
         },
       });
     }
-  }
+  };
 
-  render() {
-    const { classes, data, stixCoreObjectOrStixCoreRelationshipNotes } = this.props;
-    const entityNotesIds = R.map(
-      (n) => n.node.id,
-      stixCoreObjectOrStixCoreRelationshipNotes,
-    );
+  const { classes, data, stixCoreObjectOrStixCoreRelationshipNotes } = props;
+  const entityNotesIds = R.map(
+    (n) => n.node.id,
+    stixCoreObjectOrStixCoreRelationshipNotes,
+  );
 
-    return (
-      <TableContainer>
-        <Table
-          sx={{
-            '& .MuiTableRow-root:first-of-type td': {
-              borderTop: 'none',
-            },
-          }}
-        >
-          <TableBody>
-            {data.notes.edges.map((noteNode) => {
-              const note = noteNode.node;
-              const alreadyAdded = entityNotesIds.includes(note.id);
-              const noteId = note.external_id ? `(${note.external_id})` : '';
-              return (
-                <TableRow
-                  key={note.id}
-                  component={ListItemButton}
-                  classes={{ root: classes.menuItem }}
-                  onClick={this.toggleNote.bind(this, note)}
-                >
-                  <TableCell sx={{ width: 48, paddingY: 1, paddingX: 2 }}>
-                    {alreadyAdded ? (
-                      <CheckCircle
-                        color="primary"
-                        sx={{ marginTop: 0.5 }}
-                      />
-                    ) : (
-                      <WorkOutline sx={{ marginTop: 0.5 }} />
-                    )}
-                  </TableCell>
-                  <TableCell sx={{ paddingY: 1, paddingX: 2 }}>
-                    <Typography variant="body1" sx={{ fontWeight: 600 }}>
-                      {`${note.attribute_abstract} ${noteId}`}
-                    </Typography>
-                    <Typography variant="body1">
-                      {truncate(note.content, 120)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell sx={{ paddingY: 1, paddingX: 2, whiteSpace: 'nowrap' }}>
-                    {note.createdBy?.name ?? EMPTY_VALUE}
-                  </TableCell>
-                  <TableCell sx={{ paddingY: 1, paddingX: 2 }}>
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={note.objectMarking ?? []}
+  return (
+    <TableContainer>
+      <Table
+        sx={{
+          '& .MuiTableRow-root:first-of-type td': {
+            borderTop: 'none',
+          },
+        }}
+      >
+        <TableBody>
+          {data.notes.edges.map((noteNode) => {
+            const note = noteNode.node;
+            const alreadyAdded = entityNotesIds.includes(note.id);
+            const noteId = note.external_id ? `(${note.external_id})` : '';
+            return (
+              <TableRow
+                key={note.id}
+                component={ListItemButton}
+                classes={{ root: classes.menuItem }}
+                onClick={toggleNote.bind(this, note)}
+              >
+                <TableCell sx={{ width: 48, paddingY: 1, paddingX: 2 }}>
+                  {alreadyAdded ? (
+                    <CheckCircle
+                      color="primary"
+                      sx={{ marginTop: 0.5 }}
                     />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    );
-  }
-}
+                  ) : (
+                    <WorkOutline sx={{ marginTop: 0.5 }} />
+                  )}
+                </TableCell>
+                <TableCell sx={{ paddingY: 1, paddingX: 2 }}>
+                  <Typography variant="body1" sx={{ fontWeight: 600 }}>
+                    {`${note.attribute_abstract} ${noteId}`}
+                  </Typography>
+                  <Typography variant="body1">
+                    {truncate(note.content, 120)}
+                  </Typography>
+                </TableCell>
+                <TableCell sx={{ paddingY: 1, paddingX: 2, whiteSpace: 'nowrap' }}>
+                  {note.createdBy?.name ?? EMPTY_VALUE}
+                </TableCell>
+                <TableCell sx={{ paddingY: 1, paddingX: 2 }}>
+                  <ItemMarkings
+                    variant="inList"
+                    markingDefinitions={note.objectMarking ?? []}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
 
 AddNotesLinesContainer.propTypes = {
   stixCoreObjectOrStixCoreRelationshipId: PropTypes.string,
@@ -188,8 +184,6 @@ AddNotesLinesContainer.propTypes = {
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const addNotesLinesQuery = graphql`
@@ -254,4 +248,4 @@ const AddNotesLines = createPaginationContainer(
   },
 );
 
-export default R.compose(inject18n, withStyles(styles))(AddNotesLines);
+export default R.compose(withStyles(styles))(AddNotesLines);

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDetails.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemLikelihood from '../../../../components/ItemLikelihood';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
@@ -26,69 +26,66 @@ const styles = (theme) => ({
   },
 });
 
-class NoteDetailsComponent extends Component {
-  render() {
-    const { t, note } = this.props;
-    const noteImageResolver = (url) => resolveNoteEmbeddedImageUrl(url, note.id);
+const NoteDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { note } = props;
+  const noteImageResolver = (url) => resolveNoteEmbeddedImageUrl(url, note.id);
 
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Entity details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={9}>
-              <Label>
-                {t('Abstract')}
-              </Label>
-              <MarkdownDisplay
-                content={note.attribute_abstract}
-                remarkGfmPlugin={true}
-                resolveImageUrl={noteImageResolver}
-              />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Content')}
-              </Label>
-              <MarkdownDisplay
-                content={note.content}
-                remarkGfmPlugin={true}
-                commonmark={true}
-                resolveImageUrl={noteImageResolver}
-              />
-            </Grid>
-            <Grid item xs={3}>
-              <Label>
-                {t('Note types')}
-              </Label>
-              <FieldOrEmpty source={note.note_types}>
-                <Stack direction="row" flexWrap="wrap" gap={1}>
-                  {note.note_types?.map((noteType) => (
-                    <Tag
-                      key={noteType}
-                      label={noteType}
-                    />
-                  ))}
-                </Stack>
-              </FieldOrEmpty>
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Likelihood')}
-              </Label>
-              <ItemLikelihood likelihood={note.likelihood} />
-            </Grid>
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Entity details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={9}>
+            <Label>
+              {t_i18n('Abstract')}
+            </Label>
+            <MarkdownDisplay
+              content={note.attribute_abstract}
+              remarkGfmPlugin={true}
+              resolveImageUrl={noteImageResolver}
+            />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Content')}
+            </Label>
+            <MarkdownDisplay
+              content={note.content}
+              remarkGfmPlugin={true}
+              commonmark={true}
+              resolveImageUrl={noteImageResolver}
+            />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={3}>
+            <Label>
+              {t_i18n('Note types')}
+            </Label>
+            <FieldOrEmpty source={note.note_types}>
+              <Stack direction="row" flexWrap="wrap" gap={1}>
+                {note.note_types?.map((noteType) => (
+                  <Tag
+                    key={noteType}
+                    label={noteType}
+                  />
+                ))}
+              </Stack>
+            </FieldOrEmpty>
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Likelihood')}
+            </Label>
+            <ItemLikelihood likelihood={note.likelihood} />
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 NoteDetailsComponent.propTypes = {
   note: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const NoteDetails = createFragmentContainer(NoteDetailsComponent, {
@@ -103,4 +100,4 @@ const NoteDetails = createFragmentContainer(NoteDetailsComponent, {
   `,
 });
 
-export default compose(inject18n, withStyles(styles))(NoteDetails);
+export default compose(withStyles(styles))(NoteDetails);

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionDetails.jsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';
 import Card from '../../../../components/common/card/Card';
 import Label from '../../../../components/common/label/Label';
@@ -16,39 +16,36 @@ const styles = (theme) => ({
   },
 });
 
-class OpinionDetailsComponent extends Component {
-  render() {
-    const { t, opinion } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Entity details')}>
-          <Label>
-            {t('Opinion')}
-          </Label>
-          <MarkdownDisplay
-            content={opinion.opinion}
-            remarkGfmPlugin={true}
-            commonmark={true}
-          />
-          <Label sx={{ mt: 2 }}>
-            {t('Explanation')}
-          </Label>
-          <MarkdownDisplay
-            content={opinion.explanation}
-            remarkGfmPlugin={true}
-            commonmark={true}
-          />
-        </Card>
-      </div>
-    );
-  }
-}
+const OpinionDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { opinion } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Entity details')}>
+        <Label>
+          {t_i18n('Opinion')}
+        </Label>
+        <MarkdownDisplay
+          content={opinion.opinion}
+          remarkGfmPlugin={true}
+          commonmark={true}
+        />
+        <Label sx={{ mt: 2 }}>
+          {t_i18n('Explanation')}
+        </Label>
+        <MarkdownDisplay
+          content={opinion.explanation}
+          remarkGfmPlugin={true}
+          commonmark={true}
+        />
+      </Card>
+    </div>
+  );
+};
 
 OpinionDetailsComponent.propTypes = {
   opinion: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const OpinionDetails = createFragmentContainer(OpinionDetailsComponent, {
@@ -61,4 +58,4 @@ const OpinionDetails = createFragmentContainer(OpinionDetailsComponent, {
   `,
 });
 
-export default compose(inject18n, withStyles(styles))(OpinionDetails);
+export default compose(withStyles(styles))(OpinionDetails);

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEdition.jsx
@@ -1,10 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import ReportEditionContainer from './ReportEditionContainer';
 import { reportEditionOverviewFocus } from './ReportEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,48 +15,43 @@ export const reportEditionQuery = graphql`
   }
 `;
 
-class ReportEdition extends Component {
-  handleClose() {
+const ReportEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: reportEditionOverviewFocus,
       variables: {
-        id: this.props.reportId,
+        id: props.reportId,
         input: { focusOn: '' },
       },
     });
-  }
+  };
 
-  render() {
-    const { reportId } = this.props;
-    return (
-      <QueryRenderer
-        query={reportEditionQuery}
-        variables={{ id: reportId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <ReportEditionContainer
-                report={props.report}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { reportId } = props;
+  return (
+    <QueryRenderer
+      query={reportEditionQuery}
+      variables={{ id: reportId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <ReportEditionContainer
+              report={props.report}
+              handleClose={handleClose.bind(this)}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 ReportEdition.propTypes = {
   reportId: PropTypes.string,
   me: PropTypes.object,
   classes: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(ReportEdition);
+export default ReportEdition;

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/StixCoreObjectReportsHorizontalBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/StixCoreObjectReportsHorizontalBar.jsx
@@ -1,13 +1,12 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import withTheme from '@mui/styles/withTheme';
 import CircularProgress from '@mui/material/CircularProgress';
 import Card from '@common/card/Card';
 import Chart from '../../common/charts/Chart';
 import { QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { horizontalBarsChartOptions } from '../../../../utils/Charts';
 import { simpleNumberFormat } from '../../../../utils/Number';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
@@ -39,9 +38,10 @@ const stixCoreObjectReportsHorizontalBarDistributionQuery = graphql`
   }
 `;
 
-class StixCoreObjectReportsHorizontalBar extends Component {
-  renderContent() {
-    const { t, stixCoreObjectId, field, theme } = this.props;
+const StixCoreObjectReportsHorizontalBar = (props) => {
+  const { t_i18n } = useFormatter();
+  const renderContent = () => {
+    const { stixCoreObjectId, field, theme } = props;
     const reportsDistributionVariables = {
       objectId: stixCoreObjectId,
       field: field || 'report_types',
@@ -95,7 +95,7 @@ class StixCoreObjectReportsHorizontalBar extends Component {
                     textAlign: 'center',
                   }}
                 >
-                  {t(NO_DATA_WIDGET_MESSAGE)}
+                  {t_i18n(NO_DATA_WIDGET_MESSAGE)}
                 </span>
               </div>
             );
@@ -116,32 +116,26 @@ class StixCoreObjectReportsHorizontalBar extends Component {
         }}
       />
     );
-  }
+  };
 
-  render() {
-    const { t, title, height } = this.props;
-    return (
-      <div style={{ height: height || '100%', marginBottom: 24 }}>
-        <Card
-          padding="small"
-          title={title || t('Reports distribution')}
-        >
-          {this.renderContent()}
-        </Card>
-      </div>
-    );
-  }
-}
+  const { title, height } = props;
+  return (
+    <div style={{ height: height || '100%', marginBottom: 24 }}>
+      <Card
+        padding="small"
+        title={title || t_i18n('Reports distribution')}
+      >
+        {renderContent()}
+      </Card>
+    </div>
+  );
+};
 
 StixCoreObjectReportsHorizontalBar.propTypes = {
   stixCoreObjectId: PropTypes.string,
   title: PropTypes.string,
   field: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withTheme,
-)(StixCoreObjectReportsHorizontalBar);
+export default withTheme(StixCoreObjectReportsHorizontalBar);

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import StixCoreObjectKillChainPhasesView from '../../common/stix_core_objects/StixCoreObjectKillChainPhasesView';
@@ -17,102 +16,99 @@ import Tag from '../../../../components/common/tag/Tag';
 import { Stack } from '@mui/material';
 import ItemScore from '../../../../components/ItemScore';
 
-class MalwareDetailsComponent extends Component {
-  render() {
-    const { t, fldt, malware } = this.props;
+const MalwareDetailsComponent = (props) => {
+  const { t_i18n, fldt } = useFormatter();
+  const { malware } = props;
 
-    return (
-      <Card title={t('Details')}>
-        <Grid container={true} spacing={3} style={{ marginBottom: 10 }}>
-          <Grid item xs={12}>
-            <Label>
-              {t('Description')}
-            </Label>
-            <ExpandableMarkdown source={malware.description} limit={400} />
-          </Grid>
-          <Grid item xs={6}>
-            <Label>
-              {t('Is family')}
-            </Label>
-            <ItemBoolean
-              status={malware.is_family}
-              label={malware.is_family ? t('Yes') : t('No')}
-            />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Architecture execution env.')}
-            </Label>
-            <TextList
-              list={malware.architecture_execution_envs}
-            />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Implementation languages')}
-            </Label>
-            <TextList
-              list={malware.implementation_languages}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            <Label>
-              {t('Malware types')}
-            </Label>
-            <FieldOrEmpty source={malware.malware_types}>
-              <Stack direction="row" gap={1} flexWrap="wrap">
-                {malware.malware_types?.map((malwareType) => (
-                  <Tag
-                    key={malwareType}
-                    label={malwareType}
-                  />
-                ))
-                }
-              </Stack>
-            </FieldOrEmpty>
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('First seen')}
-            </Label>
-            {fldt(malware.first_seen)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Last seen')}
-            </Label>
-            {fldt(malware.last_seen)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Score')}
-            </Label>
-            <ItemScore score={malware.x_opencti_score} />
-            <StixCoreObjectKillChainPhasesView killChainPhases={malware.killChainPhases ?? []} />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Capabilities')}
-            </Label>
-            <TextList
-              list={malware.capabilities}
-            />
-          </Grid>
+  return (
+    <Card title={t_i18n('Details')}>
+      <Grid container={true} spacing={3} style={{ marginBottom: 10 }}>
+        <Grid item xs={12}>
+          <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown source={malware.description} limit={400} />
         </Grid>
-        <Divider />
-        <StixDomainObjectNestedEntities
-          entityId={malware.id}
-          entityType="Malware"
-        />
-      </Card>
-    );
-  }
-}
+        <Grid item xs={6}>
+          <Label>
+            {t_i18n('Is family')}
+          </Label>
+          <ItemBoolean
+            status={malware.is_family}
+            label={malware.is_family ? t_i18n('Yes') : t_i18n('No')}
+          />
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Architecture execution env.')}
+          </Label>
+          <TextList
+            list={malware.architecture_execution_envs}
+          />
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Implementation languages')}
+          </Label>
+          <TextList
+            list={malware.implementation_languages}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <Label>
+            {t_i18n('Malware types')}
+          </Label>
+          <FieldOrEmpty source={malware.malware_types}>
+            <Stack direction="row" gap={1} flexWrap="wrap">
+              {malware.malware_types?.map((malwareType) => (
+                <Tag
+                  key={malwareType}
+                  label={malwareType}
+                />
+              ))
+              }
+            </Stack>
+          </FieldOrEmpty>
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('First seen')}
+          </Label>
+          {fldt(malware.first_seen)}
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Last seen')}
+          </Label>
+          {fldt(malware.last_seen)}
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Score')}
+          </Label>
+          <ItemScore score={malware.x_opencti_score} />
+          <StixCoreObjectKillChainPhasesView killChainPhases={malware.killChainPhases ?? []} />
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Capabilities')}
+          </Label>
+          <TextList
+            list={malware.capabilities}
+          />
+        </Grid>
+      </Grid>
+      <Divider />
+      <StixDomainObjectNestedEntities
+        entityId={malware.id}
+        entityType="Malware"
+      />
+    </Card>
+  );
+};
 
 MalwareDetailsComponent.propTypes = {
   malware: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const MalwareDetails = createFragmentContainer(MalwareDetailsComponent, {
@@ -144,4 +140,4 @@ const MalwareDetails = createFragmentContainer(MalwareDetailsComponent, {
   `,
 });
 
-export default compose(inject18n)(MalwareDetails);
+export default MalwareDetails;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwaresLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwaresLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addSoftwaresMutationRelationDelete = graphql`
@@ -19,21 +17,19 @@ export const addSoftwaresMutationRelationDelete = graphql`
   }
 `;
 
-class AddSoftwaresLinesContainer extends Component {
-  render() {
-    const { data, vulnerabilitySoftwares, vulnerability, relationshipType } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={vulnerability}
-        relationshipType={relationshipType}
-        availableDatas={data?.stixCyberObservables}
-        existingDatas={vulnerabilitySoftwares}
-        updaterOptions={{ path: 'softwares', params: { relationshipType, first: 10 } }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const AddSoftwaresLinesContainer = (props) => {
+  const { data, vulnerabilitySoftwares, vulnerability, relationshipType } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={vulnerability}
+      relationshipType={relationshipType}
+      availableDatas={data?.stixCyberObservables}
+      existingDatas={vulnerabilitySoftwares}
+      updaterOptions={{ path: 'softwares', params: { relationshipType, first: 10 } }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 AddSoftwaresLinesContainer.propTypes = {
   vulnerability: PropTypes.object,
@@ -104,4 +100,4 @@ const AddSoftwaresLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddSoftwaresLines);
+export default AddSoftwaresLines;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Link } from 'react-router-dom';
@@ -14,7 +14,6 @@ import Tooltip from '@mui/material/Tooltip';
 import Checkbox from '@mui/material/Checkbox';
 import withTheme from '@mui/styles/withTheme';
 import { ListItemButton } from '@mui/material';
-import inject18n from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import SecurityCoverageScores from '../../analyses/security_coverages/SecurityCoverageScores';
 import ItemConfidence from '../../../../components/ItemConfidence';
@@ -24,6 +23,7 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemEntityType from '../../../../components/ItemEntityType';
 import { DraftChip, getDraftModeColor } from '../draft/DraftChip';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   item: {
@@ -62,189 +62,186 @@ const styles = (theme) => ({
   },
 });
 
-class EntityStixCoreRelationshipLineAllComponent extends Component {
-  render() {
-    const {
-      entityId,
-      fsd,
-      t,
-      theme,
-      classes,
-      dataColumns,
-      node,
-      paginationOptions,
-      entityLink,
-      onToggleEntity,
-      selectAll,
-      deSelectedElements,
-      selectedElements,
-      onToggleShiftEntity,
-      index,
-      isCoverage,
-    } = this.props;
-    const remoteNode = node.from && node.from.id === entityId ? node.to : node.from;
-    const isReversed = node.from && node.from.id === entityId;
-    const restricted = node.from === null || node.to === null;
-    const link = `${entityLink}/relations/${node.id}`;
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={node.is_inferred ? (
-          <Tooltip
-            title={
-              t('Inferred knowledge based on the rule ')
-              + R.head(node.x_opencti_inferences).rule.name
-            }
-          >
-            <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
-          </Tooltip>
-        ) : (
-          <StixCoreRelationshipPopover
-            stixCoreRelationshipId={node.id}
-            paginationOptions={paginationOptions}
-            disabled={restricted}
-            isCoverage={isCoverage}
-          />
-        )}
-      >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component={Link}
-          to={link}
-          disabled={restricted}
+const EntityStixCoreRelationshipLineAllComponent = (props) => {
+  const { fsd, t_i18n } = useFormatter();
+  const {
+    entityId,
+    theme,
+    classes,
+    dataColumns,
+    node,
+    paginationOptions,
+    entityLink,
+    onToggleEntity,
+    selectAll,
+    deSelectedElements,
+    selectedElements,
+    onToggleShiftEntity,
+    index,
+    isCoverage,
+  } = props;
+  const remoteNode = node.from && node.from.id === entityId ? node.to : node.from;
+  const isReversed = node.from && node.from.id === entityId;
+  const restricted = node.from === null || node.to === null;
+  const link = `${entityLink}/relations/${node.id}`;
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={node.is_inferred ? (
+        <Tooltip
+          title={
+            t_i18n('Inferred knowledge based on the rule ')
+            + R.head(node.x_opencti_inferences).rule.name
+          }
         >
-          <ListItemIcon
-            classes={{ root: classes.itemIcon }}
-            style={{ minWidth: 40 }}
-            onClick={(event) => (event.shiftKey
-              ? onToggleShiftEntity(index, node)
-              : onToggleEntity(node, event))
+          <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
+        </Tooltip>
+      ) : (
+        <StixCoreRelationshipPopover
+          stixCoreRelationshipId={node.id}
+          paginationOptions={paginationOptions}
+          disabled={restricted}
+          isCoverage={isCoverage}
+        />
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component={Link}
+        to={link}
+        disabled={restricted}
+      >
+        <ListItemIcon
+          classes={{ root: classes.itemIcon }}
+          style={{ minWidth: 40 }}
+          onClick={(event) => (event.shiftKey
+            ? onToggleShiftEntity(index, node)
+            : onToggleEntity(node, event))
+          }
+        >
+          <Checkbox
+            edge="start"
+            checked={
+              (selectAll && !(node.id in (deSelectedElements || {})))
+              || node.id in (selectedElements || {})
             }
-          >
-            <Checkbox
-              edge="start"
-              checked={
-                (selectAll && !(node.id in (deSelectedElements || {})))
-                || node.id in (selectedElements || {})
-              }
-              disableRipple={true}
-            />
-          </ListItemIcon>
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <ItemIcon type={node.entity_type} isReversed={isReversed} color={node.draftVersion ? getDraftModeColor(theme) : null} />
-          </ListItemIcon>
-          <ListItemText
-            classes={{ root: classes.listItemText }}
-            primary={(
-              <div className={classes.row}>
-                {dataColumns.relationship_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.relationship_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.relationship_type}
-                    />
-                  </div>
-                )}
-                {dataColumns.entity_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.entity_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={remoteNode.entity_type}
-                      isRestricted={restricted}
-                      size="large"
-                      showIcon
-                    />
-                  </div>
-                )}
+            disableRipple={true}
+          />
+        </ListItemIcon>
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <ItemIcon type={node.entity_type} isReversed={isReversed} color={node.draftVersion ? getDraftModeColor(theme) : null} />
+        </ListItemIcon>
+        <ListItemText
+          classes={{ root: classes.listItemText }}
+          primary={(
+            <div className={classes.row}>
+              {dataColumns.relationship_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.relationship_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={node.relationship_type}
+                  />
+                </div>
+              )}
+              {dataColumns.entity_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.entity_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={remoteNode.entity_type}
+                    isRestricted={restricted}
+                    size="large"
+                    showIcon
+                  />
+                </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{
+                  width: dataColumns.name
+                    ? dataColumns.name.width
+                    : dataColumns.observable_value.width,
+                }}
+              >
+                {!restricted ? getMainRepresentative(remoteNode) : t_i18n('Restricted')}
+                {remoteNode.draftVersion && (<DraftChip />)}
+              </div>
+              {isCoverage && dataColumns.coverage_information && (
                 <div
                   className={classes.bodyItem}
                   style={{
-                    width: dataColumns.name
-                      ? dataColumns.name.width
-                      : dataColumns.observable_value.width,
+                    width: dataColumns.coverage_information.width,
+                    display: 'flex',
+                    alignItems: 'center',
+                    height: 'auto',
+                    overflow: 'visible',
                   }}
                 >
-                  {!restricted ? getMainRepresentative(remoteNode) : t('Restricted')}
-                  {remoteNode.draftVersion && (<DraftChip />)}
-                </div>
-                {isCoverage && dataColumns.coverage_information && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{
-                      width: dataColumns.coverage_information.width,
-                      display: 'flex',
-                      alignItems: 'center',
-                      height: 'auto',
-                      overflow: 'visible',
-                    }}
-                  >
-                    <SecurityCoverageScores
-                      coverage_information={node.coverage_information || null}
-                      variant="header"
-                    />
-                  </div>
-                )}
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.createdBy.width }}
-                >
-                  {node.createdBy?.name ?? EMPTY_VALUE}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.creator.width }}
-                >
-                  {(node.creators ?? []).map((c) => c?.name).join(', ')}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.start_time.width }}
-                >
-                  {fsd(node.start_time)}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.stop_time.width }}
-                >
-                  {fsd(node.stop_time)}
-                </div>
-                {!isCoverage && dataColumns.created_at && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.created_at.width }}
-                  >
-                    {fsd(node.created_at)}
-                  </div>
-                )}
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.confidence.width }}
-                >
-                  <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.objectMarking.width }}
-                >
-                  <ItemMarkings
-                    variant="inList"
-                    markingDefinitions={node.objectMarking ?? []}
-                    limit={1}
+                  <SecurityCoverageScores
+                    coverage_information={node.coverage_information || null}
+                    variant="header"
                   />
                 </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.createdBy.width }}
+              >
+                {node.createdBy?.name ?? EMPTY_VALUE}
               </div>
-            )}
-          />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.creator.width }}
+              >
+                {(node.creators ?? []).map((c) => c?.name).join(', ')}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.start_time.width }}
+              >
+                {fsd(node.start_time)}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.stop_time.width }}
+              >
+                {fsd(node.stop_time)}
+              </div>
+              {!isCoverage && dataColumns.created_at && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.created_at.width }}
+                >
+                  {fsd(node.created_at)}
+                </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.confidence.width }}
+              >
+                <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.objectMarking.width }}
+              >
+                <ItemMarkings
+                  variant="inList"
+                  markingDefinitions={node.objectMarking ?? []}
+                  limit={1}
+                />
+              </div>
+            </div>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineAllComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -253,8 +250,6 @@ EntityStixCoreRelationshipLineAllComponent.propTypes = {
   paginationOptions: PropTypes.object,
   node: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fsd: PropTypes.func,
 };
 
 const EntityStixCoreRelationshipLineAllFragment = createFragmentContainer(
@@ -586,202 +581,196 @@ const EntityStixCoreRelationshipLineAllFragment = createFragmentContainer(
 );
 
 export const EntityStixCoreRelationshipLineAll = R.compose(
-  inject18n,
   withStyles(styles),
   withTheme,
 )(EntityStixCoreRelationshipLineAllFragment);
 
-class EntityStixCoreRelationshipLineAllDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={<MoreVertOutlined classes={classes.itemIconDisabled} />}
+const EntityStixCoreRelationshipLineAllDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={<MoreVertOutlined classes={classes.itemIconDisabled} />}
+    >
+      <ListItemIcon
+        classes={{ root: classes.itemIconDisabled }}
+        style={{ minWidth: 40 }}
       >
-        <ListItemIcon
-          classes={{ root: classes.itemIconDisabled }}
-          style={{ minWidth: 40 }}
-        >
-          <Checkbox edge="start" disabled={true} disableRipple={true} />
-        </ListItemIcon>
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          classes={{ root: classes.listItemText }}
-          primary={(
-            <div className={classes.row}>
-              {dataColumns.relationship_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.relationship_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.entity_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.entity_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{
-                  width: dataColumns.name
-                    ? dataColumns.name.width
-                    : dataColumns.observable_value?.width,
-                }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              {dataColumns.x_mitre_id && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.x_mitre_id.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.coverage_information && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.coverage_information.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.createdBy.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.creator.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.start_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.stop_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              {dataColumns.created_at && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.created_at.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={140}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.confidence && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.confidence.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.objectMarking && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.objectMarking.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-            </div>
-          )}
+        <Checkbox edge="start" disabled={true} disableRipple={true} />
+      </ListItemIcon>
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        classes={{ root: classes.listItemText }}
+        primary={(
+          <div className={classes.row}>
+            {dataColumns.relationship_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.relationship_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.entity_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.entity_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{
+                width: dataColumns.name
+                  ? dataColumns.name.width
+                  : dataColumns.observable_value?.width,
+              }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            {dataColumns.x_mitre_id && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.x_mitre_id.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.coverage_information && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.coverage_information.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.createdBy.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.creator.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.start_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.stop_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            {dataColumns.created_at && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.created_at.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={140}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.confidence && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.confidence.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.objectMarking && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.objectMarking.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineAllDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const EntityStixCoreRelationshipLineAllDummy = R.compose(
-  inject18n,
-  withStyles(styles),
-)(EntityStixCoreRelationshipLineAllDummyComponent);
+export const EntityStixCoreRelationshipLineAllDummy = withStyles(styles)(EntityStixCoreRelationshipLineAllDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Link } from 'react-router-dom';
@@ -14,7 +14,6 @@ import Tooltip from '@mui/material/Tooltip';
 import Checkbox from '@mui/material/Checkbox';
 import { ListItemButton } from '@mui/material';
 import withTheme from '@mui/styles/withTheme';
-import inject18n from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemConfidence from '../../../../components/ItemConfidence';
 import StixCoreRelationshipPopover from './StixCoreRelationshipPopover';
@@ -24,6 +23,7 @@ import ItemEntityType from '../../../../components/ItemEntityType';
 import { DraftChip, getDraftModeColor } from '../draft/DraftChip';
 import SecurityCoverageScores from '../../analyses/security_coverages/SecurityCoverageScores';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   item: {
@@ -66,194 +66,191 @@ const styles = (theme) => ({
   },
 });
 
-class EntityStixCoreRelationshipLineFromComponent extends Component {
-  render() {
-    const {
-      fsd,
-      t,
-      theme,
-      classes,
-      dataColumns,
-      node,
-      paginationOptions,
-      entityLink,
-      onToggleEntity,
-      selectAll,
-      deSelectedElements,
-      selectedElements,
-      onToggleShiftEntity,
-      index,
-      isCoverage,
-    } = this.props;
-    const restricted = node.to === null;
-    const link = `${entityLink}/relations/${node.id}`;
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={node.is_inferred ? (
-          <Tooltip
-            title={t('Inferred knowledge based on the rule ') + R.head(node.x_opencti_inferences).rule.name}
-          >
-            <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
-          </Tooltip>
-        ) : (
-          <StixCoreRelationshipPopover
-            stixCoreRelationshipId={node.id}
-            paginationOptions={paginationOptions}
-            disabled={restricted}
-            isCoverage={isCoverage}
-          />
-        )}
-      >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component={Link}
-          to={link}
-          disabled={restricted}
+const EntityStixCoreRelationshipLineFromComponent = (props) => {
+  const { fsd, t_i18n } = useFormatter();
+  const {
+    theme,
+    classes,
+    dataColumns,
+    node,
+    paginationOptions,
+    entityLink,
+    onToggleEntity,
+    selectAll,
+    deSelectedElements,
+    selectedElements,
+    onToggleShiftEntity,
+    index,
+    isCoverage,
+  } = props;
+  const restricted = node.to === null;
+  const link = `${entityLink}/relations/${node.id}`;
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={node.is_inferred ? (
+        <Tooltip
+          title={t_i18n('Inferred knowledge based on the rule ') + R.head(node.x_opencti_inferences).rule.name}
         >
-          <ListItemIcon
-            classes={{ root: classes.itemIcon }}
-            style={{ minWidth: 40 }}
-            onClick={(event) => (event.shiftKey
-              ? onToggleShiftEntity(index, node)
-              : onToggleEntity(node, event))
+          <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
+        </Tooltip>
+      ) : (
+        <StixCoreRelationshipPopover
+          stixCoreRelationshipId={node.id}
+          paginationOptions={paginationOptions}
+          disabled={restricted}
+          isCoverage={isCoverage}
+        />
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component={Link}
+        to={link}
+        disabled={restricted}
+      >
+        <ListItemIcon
+          classes={{ root: classes.itemIcon }}
+          style={{ minWidth: 40 }}
+          onClick={(event) => (event.shiftKey
+            ? onToggleShiftEntity(index, node)
+            : onToggleEntity(node, event))
+          }
+        >
+          <Checkbox
+            edge="start"
+            checked={
+              (selectAll && !(node.id in (deSelectedElements || {})))
+              || node.id in (selectedElements || {})
             }
-          >
-            <Checkbox
-              edge="start"
-              checked={
-                (selectAll && !(node.id in (deSelectedElements || {})))
-                || node.id in (selectedElements || {})
-              }
-              disableRipple={true}
-            />
-          </ListItemIcon>
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <ItemIcon type={node.entity_type} color={node.draftVersion ? getDraftModeColor(theme) : null} />
-          </ListItemIcon>
-          <ListItemText
-            classes={{ root: classes.listItemText }}
-            primary={(
-              <div className={classes.row}>
-                {dataColumns.relationship_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.relationship_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.relationship_type}
-                    />
-                  </div>
-                )}
-                {dataColumns.entity_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.entity_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.to?.entity_type}
-                      isRestricted={!node.to}
-                      size="large"
-                      showIcon
-                    />
-                  </div>
-                )}
+            disableRipple={true}
+          />
+        </ListItemIcon>
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <ItemIcon type={node.entity_type} color={node.draftVersion ? getDraftModeColor(theme) : null} />
+        </ListItemIcon>
+        <ListItemText
+          classes={{ root: classes.listItemText }}
+          primary={(
+            <div className={classes.row}>
+              {dataColumns.relationship_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.relationship_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={node.relationship_type}
+                  />
+                </div>
+              )}
+              {dataColumns.entity_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.entity_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={node.to?.entity_type}
+                    isRestricted={!node.to}
+                    size="large"
+                    showIcon
+                  />
+                </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{
+                  width: dataColumns.name
+                    ? dataColumns.name.width
+                    : dataColumns.observable_value.width,
+                }}
+              >
+                {!restricted ? getMainRepresentative(node.to) : t_i18n('Restricted')}
+                {node.to?.draftVersion && (<DraftChip />)}
+              </div>
+              {dataColumns.x_mitre_id && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.x_mitre_id.width }}
+                >
+                  {node.to?.x_mitre_id ?? EMPTY_VALUE}
+                </div>
+              )}
+              {dataColumns.coverage_information && (
                 <div
                   className={classes.bodyItem}
                   style={{
-                    width: dataColumns.name
-                      ? dataColumns.name.width
-                      : dataColumns.observable_value.width,
+                    width: dataColumns.coverage_information.width,
+                    display: 'flex',
+                    alignItems: 'center',
+                    overflow: 'visible',
                   }}
                 >
-                  {!restricted ? getMainRepresentative(node.to) : t('Restricted')}
-                  {node.to?.draftVersion && (<DraftChip />)}
+                  <SecurityCoverageScores
+                    coverage_information={node.coverage_information || null}
+                    variant="header"
+                  />
                 </div>
-                {dataColumns.x_mitre_id && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.x_mitre_id.width }}
-                  >
-                    {node.to?.x_mitre_id ?? EMPTY_VALUE}
-                  </div>
-                )}
-                {dataColumns.coverage_information && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{
-                      width: dataColumns.coverage_information.width,
-                      display: 'flex',
-                      alignItems: 'center',
-                      overflow: 'visible',
-                    }}
-                  >
-                    <SecurityCoverageScores
-                      coverage_information={node.coverage_information || null}
-                      variant="header"
-                    />
-                  </div>
-                )}
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.createdBy.width }}
-                >
-                  {node.createdBy?.name ?? EMPTY_VALUE}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.creator.width }}
-                >
-                  {(node.creators ?? []).map((c) => c?.name).join(', ')}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.start_time.width }}
-                >
-                  {fsd(node.start_time)}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.stop_time.width }}
-                >
-                  {fsd(node.stop_time)}
-                </div>
-                {dataColumns.created_at && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.created_at.width }}
-                  >
-                    {fsd(node.created_at)}
-                  </div>
-                )}
-                {dataColumns.confidence && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.confidence.width }}
-                  >
-                    <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
-                  </div>
-                )}
-                {dataColumns.objectMarking && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.objectMarking.width }}
-                  >
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={node.objectMarking ?? []}
-                      limit={1}
-                    />
-                  </div>
-                )}
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.createdBy.width }}
+              >
+                {node.createdBy?.name ?? EMPTY_VALUE}
               </div>
-            )}
-          />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.creator.width }}
+              >
+                {(node.creators ?? []).map((c) => c?.name).join(', ')}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.start_time.width }}
+              >
+                {fsd(node.start_time)}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.stop_time.width }}
+              >
+                {fsd(node.stop_time)}
+              </div>
+              {dataColumns.created_at && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.created_at.width }}
+                >
+                  {fsd(node.created_at)}
+                </div>
+              )}
+              {dataColumns.confidence && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.confidence.width }}
+                >
+                  <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
+                </div>
+              )}
+              {dataColumns.objectMarking && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.objectMarking.width }}
+                >
+                  <ItemMarkings
+                    variant="inList"
+                    markingDefinitions={node.objectMarking ?? []}
+                    limit={1}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineFromComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -261,8 +258,6 @@ EntityStixCoreRelationshipLineFromComponent.propTypes = {
   paginationOptions: PropTypes.object,
   node: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fsd: PropTypes.func,
 };
 
 const EntityStixCoreRelationshipLineFromFragment = createFragmentContainer(
@@ -626,202 +621,196 @@ const EntityStixCoreRelationshipLineFromFragment = createFragmentContainer(
 );
 
 export const EntityStixCoreRelationshipLineFrom = R.compose(
-  inject18n,
   withStyles(styles),
   withTheme,
 )(EntityStixCoreRelationshipLineFromFragment);
 
-class EntityStixCoreRelationshipLineFromDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={<MoreVertOutlined classes={classes.itemIconDisabled} />}
+const EntityStixCoreRelationshipLineFromDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={<MoreVertOutlined classes={classes.itemIconDisabled} />}
+    >
+      <ListItemIcon
+        classes={{ root: classes.itemIconDisabled }}
+        style={{ minWidth: 40 }}
       >
-        <ListItemIcon
-          classes={{ root: classes.itemIconDisabled }}
-          style={{ minWidth: 40 }}
-        >
-          <Checkbox edge="start" disabled={true} disableRipple={true} />
-        </ListItemIcon>
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          classes={{ root: classes.listItemText }}
-          primary={(
-            <div className={classes.row}>
-              {dataColumns.relationship_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.relationship_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.entity_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.entity_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{
-                  width: dataColumns.name
-                    ? dataColumns.name.width
-                    : dataColumns.observable_value?.width,
-                }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              {dataColumns.x_mitre_id && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.x_mitre_id.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.coverage_information && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.coverage_information.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.createdBy.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.creator.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.start_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.stop_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              {dataColumns.created_at && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.created_at.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={140}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.confidence && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.confidence.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.objectMarking && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.objectMarking.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-            </div>
-          )}
+        <Checkbox edge="start" disabled={true} disableRipple={true} />
+      </ListItemIcon>
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        classes={{ root: classes.listItemText }}
+        primary={(
+          <div className={classes.row}>
+            {dataColumns.relationship_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.relationship_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.entity_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.entity_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{
+                width: dataColumns.name
+                  ? dataColumns.name.width
+                  : dataColumns.observable_value?.width,
+              }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            {dataColumns.x_mitre_id && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.x_mitre_id.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.coverage_information && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.coverage_information.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.createdBy.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.creator.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.start_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.stop_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            {dataColumns.created_at && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.created_at.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={140}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.confidence && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.confidence.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.objectMarking && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.objectMarking.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineFromDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const EntityStixCoreRelationshipLineFromDummy = R.compose(
-  inject18n,
-  withStyles(styles),
-)(EntityStixCoreRelationshipLineFromDummyComponent);
+export const EntityStixCoreRelationshipLineFromDummy = withStyles(styles)(EntityStixCoreRelationshipLineFromDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Link } from 'react-router-dom';
@@ -15,7 +15,6 @@ import Tooltip from '@mui/material/Tooltip';
 import Checkbox from '@mui/material/Checkbox';
 import { ListItemButton } from '@mui/material';
 import withTheme from '@mui/styles/withTheme';
-import inject18n from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemConfidence from '../../../../components/ItemConfidence';
 import StixCoreRelationshipPopover from './StixCoreRelationshipPopover';
@@ -25,6 +24,7 @@ import ItemEntityType from '../../../../components/ItemEntityType';
 import { DraftChip, getDraftModeColor } from '../draft/DraftChip';
 import SecurityCoverageScores from '../../analyses/security_coverages/SecurityCoverageScores';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   item: {
@@ -63,196 +63,193 @@ const styles = (theme) => ({
   },
 });
 
-class EntityStixCoreRelationshipLineToComponent extends Component {
-  render() {
-    const {
-      fsd,
-      t,
-      theme,
-      classes,
-      dataColumns,
-      node,
-      paginationOptions,
-      entityLink,
-      onToggleEntity,
-      selectAll,
-      deSelectedElements,
-      selectedElements,
-      onToggleShiftEntity,
-      index,
-      isCoverage,
-    } = this.props;
-    const restricted = node.from === null;
-    const link = `${entityLink}/relations/${node.id}`;
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={node.is_inferred ? (
-          <Tooltip
-            title={
-              t('Inferred knowledge based on the rule ')
-              + R.head(node.x_opencti_inferences).rule.name
-            }
-          >
-            <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
-          </Tooltip>
-        ) : (
-          <StixCoreRelationshipPopover
-            stixCoreRelationshipId={node.id}
-            paginationOptions={paginationOptions}
-            isCoverage={isCoverage}
-          />
-        )}
-      >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component={Link}
-          to={link}
+const EntityStixCoreRelationshipLineToComponent = (props) => {
+  const { fsd, t_i18n } = useFormatter();
+  const {
+    theme,
+    classes,
+    dataColumns,
+    node,
+    paginationOptions,
+    entityLink,
+    onToggleEntity,
+    selectAll,
+    deSelectedElements,
+    selectedElements,
+    onToggleShiftEntity,
+    index,
+    isCoverage,
+  } = props;
+  const restricted = node.from === null;
+  const link = `${entityLink}/relations/${node.id}`;
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={node.is_inferred ? (
+        <Tooltip
+          title={
+            t_i18n('Inferred knowledge based on the rule ')
+            + R.head(node.x_opencti_inferences).rule.name
+          }
         >
-          <ListItemIcon
-            classes={{ root: classes.itemIcon }}
-            style={{ minWidth: 40 }}
-            onClick={(event) => (event.shiftKey
-              ? onToggleShiftEntity(index, node)
-              : onToggleEntity(node, event))
+          <AutoFix fontSize="small" style={{ marginLeft: -30 }} />
+        </Tooltip>
+      ) : (
+        <StixCoreRelationshipPopover
+          stixCoreRelationshipId={node.id}
+          paginationOptions={paginationOptions}
+          isCoverage={isCoverage}
+        />
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component={Link}
+        to={link}
+      >
+        <ListItemIcon
+          classes={{ root: classes.itemIcon }}
+          style={{ minWidth: 40 }}
+          onClick={(event) => (event.shiftKey
+            ? onToggleShiftEntity(index, node)
+            : onToggleEntity(node, event))
+          }
+        >
+          <Checkbox
+            edge="start"
+            checked={
+              (selectAll && !(node.id in (deSelectedElements || {})))
+              || node.id in (selectedElements || {})
             }
-          >
-            <Checkbox
-              edge="start"
-              checked={
-                (selectAll && !(node.id in (deSelectedElements || {})))
-                || node.id in (selectedElements || {})
-              }
-              disableRipple={true}
-            />
-          </ListItemIcon>
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <ItemIcon type={node.entity_type} color={node.draftVersion ? getDraftModeColor(theme) : null} />
-          </ListItemIcon>
-          <ListItemText
-            classes={{ root: classes.listItemText }}
-            primary={(
-              <div className={classes.row}>
-                {dataColumns.relationship_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.relationship_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.relationship_type}
-                    />
-                  </div>
-                )}
-                {dataColumns.entity_type && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.entity_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.from?.entity_type}
-                      isRestricted={!node.from}
-                      size="large"
-                      showIcon
-                    />
-                  </div>
-                )}
+            disableRipple={true}
+          />
+        </ListItemIcon>
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <ItemIcon type={node.entity_type} color={node.draftVersion ? getDraftModeColor(theme) : null} />
+        </ListItemIcon>
+        <ListItemText
+          classes={{ root: classes.listItemText }}
+          primary={(
+            <div className={classes.row}>
+              {dataColumns.relationship_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.relationship_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={node.relationship_type}
+                  />
+                </div>
+              )}
+              {dataColumns.entity_type && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.entity_type.width }}
+                >
+                  <ItemEntityType
+                    entityType={node.from?.entity_type}
+                    isRestricted={!node.from}
+                    size="large"
+                    showIcon
+                  />
+                </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{
+                  width: dataColumns.name
+                    ? dataColumns.name.width
+                    : dataColumns.observable_value.width,
+                }}
+              >
+                {!restricted ? getMainRepresentative(node.from) : t_i18n('Restricted')}
+                {node.from?.draftVersion && (<DraftChip />)}
+              </div>
+              {dataColumns.x_mitre_id && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.x_mitre_id.width }}
+                >
+                  {node.from?.x_mitre_id ?? EMPTY_VALUE}
+                </div>
+              )}
+              {dataColumns.coverage_information && (
                 <div
                   className={classes.bodyItem}
                   style={{
-                    width: dataColumns.name
-                      ? dataColumns.name.width
-                      : dataColumns.observable_value.width,
+                    width: dataColumns.coverage_information.width,
+                    display: 'flex',
+                    alignItems: 'center',
+                    height: 'auto',
+                    overflow: 'visible',
                   }}
                 >
-                  {!restricted ? getMainRepresentative(node.from) : t('Restricted')}
-                  {node.from?.draftVersion && (<DraftChip />)}
+                  <SecurityCoverageScores
+                    coverage_information={node.coverage_information || null}
+                    variant="header"
+                  />
                 </div>
-                {dataColumns.x_mitre_id && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.x_mitre_id.width }}
-                  >
-                    {node.from?.x_mitre_id ?? EMPTY_VALUE}
-                  </div>
-                )}
-                {dataColumns.coverage_information && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{
-                      width: dataColumns.coverage_information.width,
-                      display: 'flex',
-                      alignItems: 'center',
-                      height: 'auto',
-                      overflow: 'visible',
-                    }}
-                  >
-                    <SecurityCoverageScores
-                      coverage_information={node.coverage_information || null}
-                      variant="header"
-                    />
-                  </div>
-                )}
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.createdBy.width }}
-                >
-                  {node.createdBy?.name ?? EMPTY_VALUE}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.creator.width }}
-                >
-                  {(node.creators ?? []).map((c) => c?.name).join(', ')}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.start_time.width }}
-                >
-                  {fsd(node.start_time)}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.stop_time.width }}
-                >
-                  {fsd(node.stop_time)}
-                </div>
-                {dataColumns.created_at && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.created_at.width }}
-                  >
-                    {fsd(node.created_at)}
-                  </div>
-                )}
-                {dataColumns.confidence && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.confidence.width }}
-                  >
-                    <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
-                  </div>
-                )}
-                {dataColumns.objectMarking && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.objectMarking.width }}
-                  >
-                    <ItemMarkings
-                      variant="inList"
-                      markingDefinitions={node.objectMarking ?? []}
-                      limit={1}
-                    />
-                  </div>
-                )}
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.createdBy.width }}
+              >
+                {node.createdBy?.name ?? EMPTY_VALUE}
               </div>
-            )}
-          />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.creator.width }}
+              >
+                {(node.creators ?? []).map((c) => c?.name).join(', ')}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.start_time.width }}
+              >
+                {fsd(node.start_time)}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.stop_time.width }}
+              >
+                {fsd(node.stop_time)}
+              </div>
+              {dataColumns.created_at && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.created_at.width }}
+                >
+                  {fsd(node.created_at)}
+                </div>
+              )}
+              {dataColumns.confidence && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.confidence.width }}
+                >
+                  <ItemConfidence confidence={node.confidence} entityType={node.entity_type} variant="inList" />
+                </div>
+              )}
+              {dataColumns.objectMarking && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.objectMarking.width }}
+                >
+                  <ItemMarkings
+                    variant="inList"
+                    markingDefinitions={node.objectMarking ?? []}
+                    limit={1}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineToComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -260,8 +257,6 @@ EntityStixCoreRelationshipLineToComponent.propTypes = {
   paginationOptions: PropTypes.object,
   node: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fsd: PropTypes.func,
 };
 
 const EntityStixCoreRelationshipLineToFragment = createFragmentContainer(
@@ -629,206 +624,200 @@ const EntityStixCoreRelationshipLineToFragment = createFragmentContainer(
 );
 
 export const EntityStixCoreRelationshipLineTo = R.compose(
-  inject18n,
   withStyles(styles),
   withTheme,
 )(EntityStixCoreRelationshipLineToFragment);
 
-class EntityStixCoreRelationshipLineToDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={(
-          <Box sx={{ root: classes.itemIconDisabled }}>
-            <MoreVertOutlined />
-          </Box>
-        )}
+const EntityStixCoreRelationshipLineToDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={(
+        <Box sx={{ root: classes.itemIconDisabled }}>
+          <MoreVertOutlined />
+        </Box>
+      )}
+    >
+      <ListItemIcon
+        classes={{ root: classes.itemIconDisabled }}
+        style={{ minWidth: 40 }}
       >
-        <ListItemIcon
-          classes={{ root: classes.itemIconDisabled }}
-          style={{ minWidth: 40 }}
-        >
-          <Checkbox edge="start" disabled={true} disableRipple={true} />
-        </ListItemIcon>
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          classes={{ root: classes.listItemText }}
-          primary={(
-            <div className={classes.row}>
-              {dataColumns.relationship_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.relationship_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.entity_type && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.entity_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{
-                  width: dataColumns.name
-                    ? dataColumns.name.width
-                    : dataColumns.observable_value?.width,
-                }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              {dataColumns.x_mitre_id && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.x_mitre_id.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.coverage_information && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.coverage_information.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.createdBy.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.creator.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.start_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.stop_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={140}
-                  height="100%"
-                />
-              </div>
-              {dataColumns.created_at && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.created_at.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={140}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.confidence && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.confidence.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-              {dataColumns.objectMarking && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.objectMarking.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width={100}
-                    height="100%"
-                  />
-                </div>
-              )}
-            </div>
-          )}
+        <Checkbox edge="start" disabled={true} disableRipple={true} />
+      </ListItemIcon>
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        classes={{ root: classes.listItemText }}
+        primary={(
+          <div className={classes.row}>
+            {dataColumns.relationship_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.relationship_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.entity_type && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.entity_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{
+                width: dataColumns.name
+                  ? dataColumns.name.width
+                  : dataColumns.observable_value?.width,
+              }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            {dataColumns.x_mitre_id && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.x_mitre_id.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.coverage_information && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.coverage_information.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.createdBy.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.creator.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.start_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.stop_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={140}
+                height="100%"
+              />
+            </div>
+            {dataColumns.created_at && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.created_at.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={140}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.confidence && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.confidence.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+            {dataColumns.objectMarking && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.objectMarking.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width={100}
+                  height="100%"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 EntityStixCoreRelationshipLineToDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const EntityStixCoreRelationshipLineToDummy = R.compose(
-  inject18n,
-  withStyles(styles),
-)(EntityStixCoreRelationshipLineToDummyComponent);
+export const EntityStixCoreRelationshipLineToDummy = withStyles(styles)(EntityStixCoreRelationshipLineToDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
@@ -1,10 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
+import { useParams } from 'react-router-dom';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixCoreRelationshipOverview from './StixCoreRelationshipOverview';
 import Loader from '../../../../components/Loader';
@@ -23,47 +21,35 @@ const stixCoreRelationshipQuery = graphql`
   }
 `;
 
-class StixCoreRelationship extends Component {
-  render() {
-    const {
-      classes,
-      entityId,
-      paddingRight,
-      params: { relationId },
-    } = this.props;
-    return (
-      <div className={classes.container}>
-        <QueryRenderer
-          query={stixCoreRelationshipQuery}
-          variables={{ id: relationId }}
-          render={({ props }) => {
-            if (props && props.stixCoreRelationship) {
-              return (
-                <StixCoreRelationshipOverview
-                  entityId={entityId}
-                  stixCoreRelationship={props.stixCoreRelationship}
-                  paddingRight={paddingRight}
-                />
-              );
-            }
-            return <Loader />;
-          }}
-        />
-      </div>
-    );
-  }
-}
+const StixCoreRelationship = (props) => {
+  const { classes, entityId, paddingRight } = props;
+  const { relationId } = useParams();
+  return (
+    <div className={classes.container}>
+      <QueryRenderer
+        query={stixCoreRelationshipQuery}
+        variables={{ id: relationId }}
+        render={({ props }) => {
+          if (props && props.stixCoreRelationship) {
+            return (
+              <StixCoreRelationshipOverview
+                entityId={entityId}
+                stixCoreRelationship={props.stixCoreRelationship}
+                paddingRight={paddingRight}
+              />
+            );
+          }
+          return <Loader />;
+        }}
+      />
+    </div>
+  );
+};
 
 StixCoreRelationship.propTypes = {
   entityId: PropTypes.string,
   paddingRight: PropTypes.bool,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  match: PropTypes.object,
 };
 
-export default compose(
-  inject18n,
-  withRouter,
-  withStyles(styles),
-)(StixCoreRelationship);
+export default withStyles(styles)(StixCoreRelationship);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationships.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationships.jsx
@@ -1,93 +1,86 @@
-import { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixCoreRelationshipStixCoreRelationshipsLines, { stixCoreRelationshipStixCoreRelationshipsLinesQuery } from './StixCoreRelationshipStixCoreRelationshipsLines';
 import Card from '../../../../components/common/card/Card';
 
-class StixCoreRelationshipStixCoreRelationships extends Component {
-  render() {
-    const { t, entityId, relationshipType } = this.props;
-    const paginationOptions = {
-      fromOrToId: entityId,
-      relationship_type: relationshipType,
-      orderBy: 'created_at',
-      orderMode: 'desc',
-    };
-    return (
-      <QueryRenderer
-        query={stixCoreRelationshipStixCoreRelationshipsLinesQuery}
-        variables={{ count: 25, ...paginationOptions }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <StixCoreRelationshipStixCoreRelationshipsLines
-                entityId={entityId}
-                data={props}
-                paginationOptions={paginationOptions}
-              />
-            );
-          }
+const StixCoreRelationshipStixCoreRelationships = (props) => {
+  const { t_i18n } = useFormatter();
+  const { entityId, relationshipType } = props;
+  const paginationOptions = {
+    fromOrToId: entityId,
+    relationship_type: relationshipType,
+    orderBy: 'created_at',
+    orderMode: 'desc',
+  };
+  return (
+    <QueryRenderer
+      query={stixCoreRelationshipStixCoreRelationshipsLinesQuery}
+      variables={{ count: 25, ...paginationOptions }}
+      render={({ props }) => {
+        if (props) {
           return (
-            <div style={{ height: '100%' }}>
-              <Card title={t('Linked entities')}>
-                <List>
-                  {Array.from(Array(5), (e, i) => (
-                    <ListItem key={i} divider={true}>
-                      <ListItemIcon>
+            <StixCoreRelationshipStixCoreRelationshipsLines
+              entityId={entityId}
+              data={props}
+              paginationOptions={paginationOptions}
+            />
+          );
+        }
+        return (
+          <div style={{ height: '100%' }}>
+            <Card title={t_i18n('Linked entities')}>
+              <List>
+                {Array.from(Array(5), (e, i) => (
+                  <ListItem key={i} divider={true}>
+                    <ListItemIcon>
+                      <Skeleton
+                        animation="wave"
+                        variant="circular"
+                        width={30}
+                        height={30}
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={(
                         <Skeleton
                           animation="wave"
-                          variant="circular"
-                          width={30}
-                          height={30}
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                          style={{ marginBottom: 10 }}
                         />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                            style={{ marginBottom: 10 }}
-                          />
-                        )}
-                        secondary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                          />
-                        )}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              </Card>
-            </div>
-          );
-        }}
-      />
-    );
-  }
-}
+                      )}
+                      secondary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                        />
+                      )}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </Card>
+          </div>
+        );
+      }}
+    />
+  );
+};
 
 StixCoreRelationshipStixCoreRelationships.propTypes = {
   entityId: PropTypes.string,
   relationshipType: PropTypes.string,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(StixCoreRelationshipStixCoreRelationships);
+export default StixCoreRelationshipStixCoreRelationships;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
@@ -1,18 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { compose } from 'ramda';
 import { Link } from 'react-router-dom';
 import Tooltip from '@mui/material/Tooltip';
 import * as R from 'ramda';
 import { AutoFix } from 'mdi-material-ui';
 import { ListItemButton } from '@mui/material';
 import ListItem from '@mui/material/ListItem';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import StixCoreRelationshipPopover from './StixCoreRelationshipPopover';
 import { resolveLink } from '../../../../utils/Entity';
@@ -41,96 +40,95 @@ const styles = (theme) => ({
   },
 });
 
-class StixCoreRelationshipStixCoreRelationshipsLinesContainer extends Component {
-  render() {
-    const { t, classes, entityId, data, paginationOptions } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card
-          title={t('Linked entities')}
-          action={(
-            <Security
-              needs={[KNOWLEDGE_KNUPDATE]}
-              placeholder={<div style={{ height: 29 }} />}
-            >
-              <StixCoreRelationshipCreationFromRelation
-                entityId={entityId}
-                paddingRight={true}
-                variant="inLine"
-                paginationOptions={paginationOptions}
-              />
-            </Security>
-          )}
-        >
-          <List classes={{ root: classes.list }}>
-            {data.stixCoreRelationships.edges.map(
-              (stixCoreRelationshipEdge) => {
-                const stixCoreRelationship = stixCoreRelationshipEdge.node;
-                const remoteNode = stixCoreRelationship.from
-                  && stixCoreRelationship.from.id === entityId
-                  ? stixCoreRelationship.to
-                  : stixCoreRelationship.from;
-                const restricted = stixCoreRelationship.from === null || remoteNode === null;
-                const link = `${resolveLink(remoteNode.entity_type)}/${
-                  remoteNode.id
-                }`;
-                return (
-                  <ListItem
-                    key={stixCoreRelationship.id}
-                    dense={true}
-                    divider={true}
-                    disablePadding
-                    secondaryAction={stixCoreRelationship.is_inferred ? (
-                      <Tooltip
-                        title={
-                          t('Inferred knowledge based on the rule ')
-                          + R.head(stixCoreRelationship.x_opencti_inferences)
-                            .rule.name
-                        }
-                      >
-                        <AutoFix
-                          fontSize="small"
-                          style={{ marginLeft: -30 }}
-                          color="secondary"
-                        />
-                      </Tooltip>
-                    ) : (
-                      <StixCoreRelationshipPopover
-                        stixCoreRelationshipId={stixCoreRelationship.id}
-                        paginationOptions={paginationOptions}
-                      />
-                    )}
-                  >
-                    <ListItemButton
-                      component={Link}
-                      to={link}
+const StixCoreRelationshipStixCoreRelationshipsLinesContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const { classes, entityId, data, paginationOptions } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card
+        title={t_i18n('Linked entities')}
+        action={(
+          <Security
+            needs={[KNOWLEDGE_KNUPDATE]}
+            placeholder={<div style={{ height: 29 }} />}
+          >
+            <StixCoreRelationshipCreationFromRelation
+              entityId={entityId}
+              paddingRight={true}
+              variant="inLine"
+              paginationOptions={paginationOptions}
+            />
+          </Security>
+        )}
+      >
+        <List classes={{ root: classes.list }}>
+          {data.stixCoreRelationships.edges.map(
+            (stixCoreRelationshipEdge) => {
+              const stixCoreRelationship = stixCoreRelationshipEdge.node;
+              const remoteNode = stixCoreRelationship.from
+                && stixCoreRelationship.from.id === entityId
+                ? stixCoreRelationship.to
+                : stixCoreRelationship.from;
+              const restricted = stixCoreRelationship.from === null || remoteNode === null;
+              const link = `${resolveLink(remoteNode.entity_type)}/${
+                remoteNode.id
+              }`;
+              return (
+                <ListItem
+                  key={stixCoreRelationship.id}
+                  dense={true}
+                  divider={true}
+                  disablePadding
+                  secondaryAction={stixCoreRelationship.is_inferred ? (
+                    <Tooltip
+                      title={
+                        t_i18n('Inferred knowledge based on the rule ')
+                        + R.head(stixCoreRelationship.x_opencti_inferences)
+                          .rule.name
+                      }
                     >
-                      <ListItemIcon>
-                        <ItemIcon
-                          type={
-                            !restricted ? remoteNode.entity_type : 'restricted'
-                          }
-                        />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={
-                          remoteNode.observable_value
-                            ? remoteNode.observable_value
-                            : remoteNode.name
-                        }
-                        secondary={t(`entity_${remoteNode.entity_type}`)}
+                      <AutoFix
+                        fontSize="small"
+                        style={{ marginLeft: -30 }}
+                        color="secondary"
                       />
-                    </ListItemButton>
-                  </ListItem>
-                );
-              },
-            )}
-          </List>
-        </Card>
-      </div>
-    );
-  }
-}
+                    </Tooltip>
+                  ) : (
+                    <StixCoreRelationshipPopover
+                      stixCoreRelationshipId={stixCoreRelationship.id}
+                      paginationOptions={paginationOptions}
+                    />
+                  )}
+                >
+                  <ListItemButton
+                    component={Link}
+                    to={link}
+                  >
+                    <ListItemIcon>
+                      <ItemIcon
+                        type={
+                          !restricted ? remoteNode.entity_type : 'restricted'
+                        }
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={
+                        remoteNode.observable_value
+                          ? remoteNode.observable_value
+                          : remoteNode.name
+                      }
+                      secondary={t_i18n(`entity_${remoteNode.entity_type}`)}
+                    />
+                  </ListItemButton>
+                </ListItem>
+              );
+            },
+          )}
+        </List>
+      </Card>
+    </div>
+  );
+};
 
 StixCoreRelationshipStixCoreRelationshipsLinesContainer.propTypes = {
   entityId: PropTypes.string,
@@ -138,8 +136,6 @@ StixCoreRelationshipStixCoreRelationshipsLinesContainer.propTypes = {
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const stixCoreRelationshipStixCoreRelationshipsLinesQuery = graphql`
@@ -407,7 +403,4 @@ const StixCoreRelationshipStixCoreRelationshipsLines = createPaginationContainer
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipStixCoreRelationshipsLines);
+export default withStyles(styles)(StixCoreRelationshipStixCoreRelationshipsLines);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
@@ -70,9 +70,9 @@ const StixCoreRelationshipStixCoreRelationshipsLinesContainer = (props) => {
                 ? stixCoreRelationship.to
                 : stixCoreRelationship.from;
               const restricted = stixCoreRelationship.from === null || remoteNode === null;
-              const link = `${resolveLink(remoteNode.entity_type)}/${
-                remoteNode.id
-              }`;
+              const link = restricted
+                ? null
+                : `${resolveLink(remoteNode.entity_type)}/${remoteNode.id}`;
               return (
                 <ListItem
                   key={stixCoreRelationship.id}
@@ -101,8 +101,9 @@ const StixCoreRelationshipStixCoreRelationshipsLinesContainer = (props) => {
                   )}
                 >
                   <ListItemButton
-                    component={Link}
-                    to={link}
+                    {...(restricted
+                      ? { disabled: true }
+                      : { component: Link, to: link })}
                   >
                     <ListItemIcon>
                       <ItemIcon
@@ -113,11 +114,15 @@ const StixCoreRelationshipStixCoreRelationshipsLinesContainer = (props) => {
                     </ListItemIcon>
                     <ListItemText
                       primary={
-                        remoteNode.observable_value
-                          ? remoteNode.observable_value
-                          : remoteNode.name
+                        restricted
+                          ? t_i18n('Restricted')
+                          : remoteNode.observable_value || remoteNode.name
                       }
-                      secondary={t_i18n(`entity_${remoteNode.entity_type}`)}
+                      secondary={
+                        restricted
+                          ? t_i18n('Restricted')
+                          : t_i18n(`entity_${remoteNode.entity_type}`)
+                      }
                     />
                   </ListItemButton>
                 </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmark.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmark.jsx
@@ -1,6 +1,4 @@
-import { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import CardHeader from '@mui/material/CardHeader';
@@ -8,7 +6,7 @@ import { useTheme } from '@mui/styles';
 import CardContent from '@mui/material/CardContent';
 import Skeleton from '@mui/material/Skeleton';
 import Card from '@common/card/Card';
-import inject18n, { useFormatter } from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';
 import { renderCardTitle } from '../../../../utils/Card';
 import BookmarkToggle from '../../../../components/common/bookmark/BookmarkToggle';
@@ -244,79 +242,74 @@ export const StixDomainObjectBookmark = createFragmentContainer(
   },
 );
 
-class StixDomainObjectBookmarkDummyComponent extends Component {
-  render() {
-    const { classes } = this.props;
-    return (
-      <Card>
-        <CardHeader
-          classes={{ root: classes.header }}
-          avatar={(
-            <Skeleton
-              animation="wave"
-              variant="circular"
-              width={30}
-              height={30}
-            />
-          )}
-          title={(
-            <Skeleton
-              animation="wave"
-              variant="rectangular"
-              width="90%"
-              style={{ marginBottom: 10 }}
-            />
-          )}
-          subheader={(
-            <Skeleton
-              animation="wave"
-              variant="rectangular"
-              width="90%"
-              style={{ marginBottom: 10 }}
-            />
-          )}
-          action={(
-            <Skeleton
-              animation="wave"
-              variant="circular"
-              width={30}
-              height={30}
-            />
-          )}
-          slotProps={{
-            title: { color: 'inherit' },
-          }}
+const StixDomainObjectBookmarkDummyComponent = (props) => {
+  const { classes } = props;
+  return (
+    <Card>
+      <CardHeader
+        classes={{ root: classes.header }}
+        avatar={(
+          <Skeleton
+            animation="wave"
+            variant="circular"
+            width={30}
+            height={30}
+          />
+        )}
+        title={(
+          <Skeleton
+            animation="wave"
+            variant="rectangular"
+            width="90%"
+            style={{ marginBottom: 10 }}
+          />
+        )}
+        subheader={(
+          <Skeleton
+            animation="wave"
+            variant="rectangular"
+            width="90%"
+            style={{ marginBottom: 10 }}
+          />
+        )}
+        action={(
+          <Skeleton
+            animation="wave"
+            variant="circular"
+            width={30}
+            height={30}
+          />
+        )}
+        slotProps={{
+          title: { color: 'inherit' },
+        }}
+      />
+      <CardContent classes={{ root: classes.contentDummy }}>
+        <Skeleton
+          animation="wave"
+          variant="rectangular"
+          width="90%"
+          style={{ marginBottom: 10 }}
         />
-        <CardContent classes={{ root: classes.contentDummy }}>
-          <Skeleton
-            animation="wave"
-            variant="rectangular"
-            width="90%"
-            style={{ marginBottom: 10 }}
-          />
-          <Skeleton
-            animation="wave"
-            variant="rectangular"
-            width="95%"
-            style={{ marginBottom: 10 }}
-          />
-          <Skeleton
-            animation="wave"
-            variant="rectangular"
-            width="90%"
-            style={{ marginBottom: 10 }}
-          />
-        </CardContent>
-      </Card>
-    );
-  }
-}
+        <Skeleton
+          animation="wave"
+          variant="rectangular"
+          width="95%"
+          style={{ marginBottom: 10 }}
+        />
+        <Skeleton
+          animation="wave"
+          variant="rectangular"
+          width="90%"
+          style={{ marginBottom: 10 }}
+        />
+      </CardContent>
+    </Card>
+  );
+};
 
 StixDomainObjectBookmarkDummyComponent.propTypes = {
   classes: PropTypes.object,
 };
 
-export const StixDomainObjectBookmarkDummy = R.compose(
-  inject18n,
-  withStyles(styles),
-)(StixDomainObjectBookmarkDummyComponent);
+export const StixDomainObjectBookmarkDummy = withStyles(styles)(StixDomainObjectBookmarkDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import Drawer from '@mui/material/Drawer';
-import inject18n from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixDomainObjectEditionOverview from './StixDomainObjectEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -33,56 +32,54 @@ const stixDomainObjectEditionQuery = graphql`
   }
 `;
 
-class StixDomainObjectEdition extends Component {
-  render() {
-    const {
-      classes,
-      stixDomainObjectId,
-      open,
-      handleClose,
-      handleDelete,
-      variant,
-      noStoreUpdate,
-    } = this.props;
-    return (
-      <Drawer
-        open={open}
-        anchor="right"
-        elevation={0}
-        sx={{ zIndex: 1202 }}
-        classes={{ paper: classes.drawerPaperInGraph }}
-        onClose={handleClose.bind(this)}
-      >
-        {stixDomainObjectId ? (
-          <QueryRenderer
-            query={stixDomainObjectEditionQuery}
-            variables={{ id: stixDomainObjectId }}
-            render={({ props }) => {
-              if (props) {
-                return (
-                  <StixDomainObjectEditionOverview
-                    variant={variant}
-                    stixDomainObject={props.stixDomainObject}
-                    handleClose={handleClose.bind(this)}
-                    handleDelete={
-                      typeof handleDelete === 'function'
-                        ? handleDelete.bind(this)
-                        : null
-                    }
-                    noStoreUpdate={noStoreUpdate}
-                  />
-                );
-              }
-              return <Loader variant="inline" />;
-            }}
-          />
-        ) : (
-          <div> &nbsp; </div>
-        )}
-      </Drawer>
-    );
-  }
-}
+const StixDomainObjectEdition = (props) => {
+  const {
+    classes,
+    stixDomainObjectId,
+    open,
+    handleClose,
+    handleDelete,
+    variant,
+    noStoreUpdate,
+  } = props;
+  return (
+    <Drawer
+      open={open}
+      anchor="right"
+      elevation={0}
+      sx={{ zIndex: 1202 }}
+      classes={{ paper: classes.drawerPaperInGraph }}
+      onClose={handleClose.bind(this)}
+    >
+      {stixDomainObjectId ? (
+        <QueryRenderer
+          query={stixDomainObjectEditionQuery}
+          variables={{ id: stixDomainObjectId }}
+          render={({ props }) => {
+            if (props) {
+              return (
+                <StixDomainObjectEditionOverview
+                  variant={variant}
+                  stixDomainObject={props.stixDomainObject}
+                  handleClose={handleClose.bind(this)}
+                  handleDelete={
+                    typeof handleDelete === 'function'
+                      ? handleDelete.bind(this)
+                      : null
+                  }
+                  noStoreUpdate={noStoreUpdate}
+                />
+              );
+            }
+            return <Loader variant="inline" />;
+          }}
+        />
+      ) : (
+        <div> &nbsp; </div>
+      )}
+    </Drawer>
+  );
+};
 
 StixDomainObjectEdition.propTypes = {
   variant: PropTypes.string,
@@ -92,8 +89,7 @@ StixDomainObjectEdition.propTypes = {
   handleDelete: PropTypes.func,
   classes: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
   noStoreUpdate: PropTypes.bool,
 };
 
-export default compose(inject18n, withStyles(styles))(StixDomainObjectEdition);
+export default compose(withStyles(styles))(StixDomainObjectEdition);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectKnowledge.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { graphql } from 'react-relay';
@@ -10,7 +10,7 @@ import { HexagonMultipleOutline } from 'mdi-material-ui';
 import StixCoreObjectReportsHorizontalBar from '../../analyses/reports/StixCoreObjectReportsHorizontalBar';
 import { QueryRenderer } from '../../../../relay/environment';
 import { monthsAgo } from '../../../../utils/Time';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import EntityStixCoreRelationshipsHorizontalBars from '../stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars';
 import EntityStixSightingRelationshipsDonut from '../../events/stix_sighting_relationships/EntityStixSightingRelationshipsDonut';
 import CardNumber from '../../../../components/common/card/CardNumber';
@@ -90,173 +90,170 @@ const stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery = graphql`
   }
 `;
 
-class StixDomainObjectKnowledge extends Component {
-  render() {
-    const { t, n, stixDomainObjectId, theme } = this.props;
-    return (
-      <>
-        <Grid container={true} spacing={3} mb={3}>
-          <Grid item xs={4}>
-            <QueryRenderer
-              query={stixDomainObjectKnowledgeReportsNumberQuery}
-              variables={{
-                objectId: stixDomainObjectId,
-                endDate: monthsAgo(1),
-              }}
-              render={({ props }) => {
-                if (props && props.reportsNumber) {
-                  const { total } = props.reportsNumber;
-                  const difference = total - props.reportsNumber.count;
-                  return (
-                    <CardNumber
-                      label={t('Total reports')}
-                      value={n(total)}
-                      diffLabel={t('30 days')}
-                      diffValue={difference}
-                      icon={(
-                        <DescriptionOutlined
-                          style={{
-                            color: theme.palette.text.secondary,
-                            opacity: 0.35,
-                          }}
-                          fontSize="large"
-                        />
-                      )}
-                    />
-                  );
-                }
+const StixDomainObjectKnowledge = (props) => {
+  const { t_i18n, n } = useFormatter();
+  const { stixDomainObjectId, theme } = props;
+  return (
+    <>
+      <Grid container={true} spacing={3} mb={3}>
+        <Grid item xs={4}>
+          <QueryRenderer
+            query={stixDomainObjectKnowledgeReportsNumberQuery}
+            variables={{
+              objectId: stixDomainObjectId,
+              endDate: monthsAgo(1),
+            }}
+            render={({ props }) => {
+              if (props && props.reportsNumber) {
+                const { total } = props.reportsNumber;
+                const difference = total - props.reportsNumber.count;
                 return (
-                  <div style={{ textAlign: 'center', paddingTop: 35 }}>
-                    <CircularProgress size={40} thickness={2} />
-                  </div>
+                  <CardNumber
+                    label={t_i18n('Total reports')}
+                    value={n(total)}
+                    diffLabel={t_i18n('30 days')}
+                    diffValue={difference}
+                    icon={(
+                      <DescriptionOutlined
+                        style={{
+                          color: theme.palette.text.secondary,
+                          opacity: 0.35,
+                        }}
+                        fontSize="large"
+                      />
+                    )}
+                  />
                 );
-              }}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <QueryRenderer
-              query={
-                stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
               }
-              variables={{
-                fromOrToId: stixDomainObjectId,
-                elementWithTargetTypes: ['Stix-Cyber-Observable'],
-                endDate: monthsAgo(1),
-              }}
-              render={({ props }) => {
-                if (props && props.stixCoreRelationshipsNumber) {
-                  const { total } = props.stixCoreRelationshipsNumber;
-                  const difference = total - props.stixCoreRelationshipsNumber.count;
-                  return (
-                    <CardNumber
-                      label={t('Total observables')}
-                      value={n(total)}
-                      diffLabel={t('30 days')}
-                      diffValue={difference}
-                      icon={(
-                        <HexagonMultipleOutline
-                          style={{
-                            color: theme.palette.text.secondary,
-                            opacity: 0.35,
-                          }}
-                          fontSize="large"
-                        />
-                      )}
-                    />
-                  );
-                }
+              return (
+                <div style={{ textAlign: 'center', paddingTop: 35 }}>
+                  <CircularProgress size={40} thickness={2} />
+                </div>
+              );
+            }}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <QueryRenderer
+            query={
+              stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
+            }
+            variables={{
+              fromOrToId: stixDomainObjectId,
+              elementWithTargetTypes: ['Stix-Cyber-Observable'],
+              endDate: monthsAgo(1),
+            }}
+            render={({ props }) => {
+              if (props && props.stixCoreRelationshipsNumber) {
+                const { total } = props.stixCoreRelationshipsNumber;
+                const difference = total - props.stixCoreRelationshipsNumber.count;
                 return (
-                  <div style={{ textAlign: 'center', paddingTop: 35 }}>
-                    <CircularProgress size={40} thickness={2} />
-                  </div>
+                  <CardNumber
+                    label={t_i18n('Total observables')}
+                    value={n(total)}
+                    diffLabel={t_i18n('30 days')}
+                    diffValue={difference}
+                    icon={(
+                      <HexagonMultipleOutline
+                        style={{
+                          color: theme.palette.text.secondary,
+                          opacity: 0.35,
+                        }}
+                        fontSize="large"
+                      />
+                    )}
+                  />
                 );
-              }}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <QueryRenderer
-              query={
-                stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
               }
-              variables={{
-                fromOrToId: stixDomainObjectId,
-                endDate: monthsAgo(1),
-              }}
-              render={({ props }) => {
-                if (props && props.stixCoreRelationshipsNumber) {
-                  const { total } = props.stixCoreRelationshipsNumber;
-                  const difference = total - props.stixCoreRelationshipsNumber.count;
-                  return (
-                    <CardNumber
-                      label={t('Total relations')}
-                      value={n(total)}
-                      diffLabel={t('30 days')}
-                      diffValue={difference}
-                      icon={(
-                        <DeviceHubOutlined
-                          style={{
-                            color: theme.palette.text.secondary,
-                            opacity: 0.35,
-                          }}
-                          fontSize="large"
-                        />
-                      )}
-                    />
-                  );
-                }
+              return (
+                <div style={{ textAlign: 'center', paddingTop: 35 }}>
+                  <CircularProgress size={40} thickness={2} />
+                </div>
+              );
+            }}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <QueryRenderer
+            query={
+              stixDomainObjectKnowledgeStixCoreRelationshipsNumberQuery
+            }
+            variables={{
+              fromOrToId: stixDomainObjectId,
+              endDate: monthsAgo(1),
+            }}
+            render={({ props }) => {
+              if (props && props.stixCoreRelationshipsNumber) {
+                const { total } = props.stixCoreRelationshipsNumber;
+                const difference = total - props.stixCoreRelationshipsNumber.count;
                 return (
-                  <div style={{ textAlign: 'center', paddingTop: 35 }}>
-                    <CircularProgress size={40} thickness={2} />
-                  </div>
+                  <CardNumber
+                    label={t_i18n('Total relations')}
+                    value={n(total)}
+                    diffLabel={t_i18n('30 days')}
+                    diffValue={difference}
+                    icon={(
+                      <DeviceHubOutlined
+                        style={{
+                          color: theme.palette.text.secondary,
+                          opacity: 0.35,
+                        }}
+                        fontSize="large"
+                      />
+                    )}
+                  />
                 );
-              }}
-            />
-          </Grid>
+              }
+              return (
+                <div style={{ textAlign: 'center', paddingTop: 35 }}>
+                  <CircularProgress size={40} thickness={2} />
+                </div>
+              );
+            }}
+          />
         </Grid>
-        <StixCoreObjectReportsHorizontalBar
-          stixCoreObjectId={stixDomainObjectId}
-          field="created-by.internal_id"
-          title={t('Distribution of reports')}
-        />
-        <Grid container={true} spacing={3} style={{ marginBottom: 20 }}>
-          <Grid item xs={6} style={{ height: 350 }}>
-            <EntityStixCoreRelationshipsHorizontalBars
-              toId={stixDomainObjectId}
-              fromTypes={[
-                'Threat-Actor',
-                'Intrusion-Set',
-                'Campaign',
-                'Malware',
-              ]}
-              relationshipType="targets"
-              title={t('Top 10 threats targeting this entity')}
-              field="internal_id"
-            />
-          </Grid>
-          <Grid item xs={6} style={{ height: 350 }}>
-            <EntityStixSightingRelationshipsDonut
-              entityId={stixDomainObjectId}
-              title={t('Sightings distribution')}
-              field="entity_type"
-              variant="inKnowledge"
-            />
-          </Grid>
+      </Grid>
+      <StixCoreObjectReportsHorizontalBar
+        stixCoreObjectId={stixDomainObjectId}
+        field="created-by.internal_id"
+        title={t_i18n('Distribution of reports')}
+      />
+      <Grid container={true} spacing={3} style={{ marginBottom: 20 }}>
+        <Grid item xs={6} style={{ height: 350 }}>
+          <EntityStixCoreRelationshipsHorizontalBars
+            toId={stixDomainObjectId}
+            fromTypes={[
+              'Threat-Actor',
+              'Intrusion-Set',
+              'Campaign',
+              'Malware',
+            ]}
+            relationshipType="targets"
+            title={t_i18n('Top 10 threats targeting this entity')}
+            field="internal_id"
+          />
         </Grid>
-      </>
-    );
-  }
-}
+        <Grid item xs={6} style={{ height: 350 }}>
+          <EntityStixSightingRelationshipsDonut
+            entityId={stixDomainObjectId}
+            title={t_i18n('Sightings distribution')}
+            field="entity_type"
+            variant="inKnowledge"
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+};
 
 StixDomainObjectKnowledge.propTypes = {
   stixDomainObjectId: PropTypes.string,
   stixDomainObjectType: PropTypes.string,
   classes: PropTypes.object,
-  t: PropTypes.func,
   theme: PropTypes.object,
 };
 
 export default compose(
-  inject18n,
   withTheme,
   withStyles(styles),
 )(StixDomainObjectKnowledge);

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
@@ -1,54 +1,48 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router-dom';
 import { QueryRenderer } from '../../../../relay/environment';
 import Connector, { connectorQuery } from './Connector';
 import Loader from '../../../../components/Loader';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import inject18n from '../../../../components/i18n';
-import withRouter from '../../../../utils/compat_router/withRouter';
+import { useFormatter } from '../../../../components/i18n';
 
-class RootConnector extends Component {
-  render() {
-    const {
-      t,
-      params: { connectorId },
-    } = this.props;
-    return (
-      <QueryRenderer
-        query={connectorQuery}
-        variables={{ id: connectorId }}
-        render={({ props }) => {
-          if (props) {
-            if (props.connector) {
-              return (
-                <>
-                  <Breadcrumbs elements={[{ label: t('Integrations') }, { label: t('Deployed'), link: '/dashboard/integrations/deployed' }, { label: props.connector.title, current: true }]} />
-                  <Routes>
-                    <Route
-                      path="/"
-                      element={
-                        <Connector connector={props.connector} />
-                      }
-                    />
-                  </Routes>
-                </>
-              );
-            }
-            return <ErrorNotFound />;
+const RootConnector = () => {
+  const { t_i18n } = useFormatter();
+  const { connectorId } = useParams();
+  return (
+    <QueryRenderer
+      query={connectorQuery}
+      variables={{ id: connectorId }}
+      render={({ props }) => {
+        if (props) {
+          if (props.connector) {
+            return (
+              <>
+                <Breadcrumbs elements={[{ label: t_i18n('Integrations') }, { label: t_i18n('Deployed'), link: '/dashboard/integrations/deployed' }, { label: props.connector.title, current: true }]} />
+                <Routes>
+                  <Route
+                    path="/"
+                    element={
+                      <Connector connector={props.connector} />
+                    }
+                  />
+                </Routes>
+              </>
+            );
           }
-          return <Loader />;
-        }}
-      />
-    );
-  }
-}
+          return <ErrorNotFound />;
+        }
+        return <Loader />;
+      }}
+    />
+  );
+};
 
 RootConnector.propTypes = {
   children: PropTypes.node,
   match: PropTypes.object,
 };
 
-export default compose(inject18n, withRouter)(RootConnector);
+export default RootConnector;

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import ItemScore from '../../../../components/ItemScore';
@@ -12,60 +11,57 @@ import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import Label from '../../../../components/common/label/Label';
 import { Stack } from '@mui/material';
 
-class EventDetailsComponent extends Component {
-  render() {
-    const { fldt, t, event } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={2}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={event.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Event types')}
-              </Label>
-              <FieldOrEmpty source={event.event_types}>
-                <Stack direction="row" gap={1} flexWrap="wrap">
-                  {event.event_types?.map((eventType) => (
-                    <ItemOpenVocab key="type" small={true} type="event_type_ov" value={eventType} />
-                  ))}
-                </Stack>
-              </FieldOrEmpty>
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Start date')}
-              </Label>
-              {fldt(event.start_time)}
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('End date')}
-              </Label>
-              {fldt(event.stop_time)}
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Score')}
-              </Label>
-              <ItemScore score={event.x_opencti_score} />
-            </Grid>
+const EventDetailsComponent = (props) => {
+  const { fldt, t_i18n } = useFormatter();
+  const { event } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={2}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={event.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Event types')}
+            </Label>
+            <FieldOrEmpty source={event.event_types}>
+              <Stack direction="row" gap={1} flexWrap="wrap">
+                {event.event_types?.map((eventType) => (
+                  <ItemOpenVocab key="type" small={true} type="event_type_ov" value={eventType} />
+                ))}
+              </Stack>
+            </FieldOrEmpty>
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Start date')}
+            </Label>
+            {fldt(event.start_time)}
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('End date')}
+            </Label>
+            {fldt(event.stop_time)}
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Score')}
+            </Label>
+            <ItemScore score={event.x_opencti_score} />
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 EventDetailsComponent.propTypes = {
   event: PropTypes.object,
-  t: PropTypes.func,
-  fldt: PropTypes.func,
 };
 
 const EventDetails = createFragmentContainer(EventDetailsComponent, {
@@ -81,4 +77,4 @@ const EventDetails = createFragmentContainer(EventDetailsComponent, {
   `,
 });
 
-export default compose(inject18n)(EventDetails);
+export default EventDetails;

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDetails.jsx
@@ -1,56 +1,52 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import Label from '../../../../components/common/label/Label';
 import Tag from '../../../../components/common/tag/Tag';
 
-class IndividualDetailsComponent extends Component {
-  render() {
-    const { t, individual } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={individual.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Reliability')}
-              </Label>
-              <ItemOpenVocab
-                displayMode="chip"
-                type="reliability_ov"
-                value={individual.x_opencti_reliability}
-              />
-              <Label sx={{ marginTop: 2 }}>
-                {t('Contact information')}
-              </Label>
-              <FieldOrEmpty source={individual.contact_information}>
-                <Tag label={individual.contact_information} />
-              </FieldOrEmpty>
-            </Grid>
+const IndividualDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { individual } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={individual.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Reliability')}
+            </Label>
+            <ItemOpenVocab
+              displayMode="chip"
+              type="reliability_ov"
+              value={individual.x_opencti_reliability}
+            />
+            <Label sx={{ marginTop: 2 }}>
+              {t_i18n('Contact information')}
+            </Label>
+            <FieldOrEmpty source={individual.contact_information}>
+              <Tag label={individual.contact_information} />
+            </FieldOrEmpty>
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 IndividualDetailsComponent.propTypes = {
   individual: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const IndividualDetails = createFragmentContainer(IndividualDetailsComponent, {
@@ -64,4 +60,4 @@ const IndividualDetails = createFragmentContainer(IndividualDetailsComponent, {
   `,
 });
 
-export default R.compose(inject18n)(IndividualDetails);
+export default IndividualDetails;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSectorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSectorsLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addSubSectorsMutationRelationDelete = graphql`
@@ -19,21 +17,19 @@ export const addSubSectorsMutationRelationDelete = graphql`
   }
 `;
 
-class AddSubSectorsLinesContainer extends Component {
-  render() {
-    const { data, sectorSubSectors, sector } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={sector}
-        relationshipType="part-of"
-        availableDatas={data?.sectors}
-        existingDatas={sectorSubSectors}
-        updaterOptions={{ path: 'subSectors' }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const AddSubSectorsLinesContainer = (props) => {
+  const { data, sectorSubSectors, sector } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={sector}
+      relationshipType="part-of"
+      availableDatas={data?.sectors}
+      existingDatas={sectorSubSectors}
+      updaterOptions={{ path: 'subSectors' }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 AddSubSectorsLinesContainer.propTypes = {
   sector: PropTypes.object,
@@ -97,4 +93,4 @@ const AddSubSectorsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddSubSectorsLines);
+export default AddSubSectorsLines;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDetails.jsx
@@ -1,46 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import SectorParentSectors from './SectorParentSectors';
 import SectorSubSectors from './SectorSubSectors';
 import Label from '../../../../components/common/label/Label';
 
-class SectorDetailsComponent extends Component {
-  render() {
-    const { t, sector } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={sector.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              {sector.isSubSector ? (
-                <SectorParentSectors sector={sector} />
-              ) : (
-                <SectorSubSectors sector={sector} />
-              )}
-            </Grid>
+const SectorDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { sector } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={sector.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            {sector.isSubSector ? (
+              <SectorParentSectors sector={sector} />
+            ) : (
+              <SectorSubSectors sector={sector} />
+            )}
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 SectorDetailsComponent.propTypes = {
   sector: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const SectorDetails = createFragmentContainer(SectorDetailsComponent, {
@@ -55,4 +51,4 @@ const SectorDetails = createFragmentContainer(SectorDetailsComponent, {
   `,
 });
 
-export default compose(inject18n)(SectorDetails);
+export default SectorDetails;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorLine.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import withStyles from '@mui/styles/withStyles';
@@ -6,12 +6,12 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
-import { compose, map } from 'ramda';
+import { map } from 'ramda';
 import List from '@mui/material/List';
 import { ListItemButton } from '@mui/material';
 import Skeleton from '@mui/material/Skeleton';
 import { DraftChip } from '../../common/draft/DraftChip';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 
 const styles = (theme) => ({
@@ -54,109 +54,99 @@ const styles = (theme) => ({
   },
 });
 
-class SectorLineComponent extends Component {
-  render() {
-    const { classes, subSectors, node, isSubSector, t } = this.props;
-    return (
-      <div>
-        <ListItemButton
-          classes={{ root: isSubSector ? classes.itemNested : classes.item }}
-          divider={true}
-          component={Link}
-          to={`/dashboard/entities/sectors/${node.id}`}
-        >
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <ItemIcon type="Sector" size={isSubSector ? 'small' : 'medium'} />
-          </ListItemIcon>
-          <ListItemText
-            sx={{ margin: 0, height: '28px' }}
-            primary={(
-              <div>
-                <div className={classes.name}>
-                  {node.name}
-                  {node.draftVersion && (<DraftChip style={{ verticalAlign: 1 }} />)}
-                </div>
-                <div className={classes.description}>
-                  {node.description?.length > 0
-                    ? node.description
-                    : t('This sector does not have any description.')}
-                </div>
+const SectorLineComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { classes, subSectors, node, isSubSector } = props;
+  return (
+    <div>
+      <ListItemButton
+        classes={{ root: isSubSector ? classes.itemNested : classes.item }}
+        divider={true}
+        component={Link}
+        to={`/dashboard/entities/sectors/${node.id}`}
+      >
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <ItemIcon type="Sector" size={isSubSector ? 'small' : 'medium'} />
+        </ListItemIcon>
+        <ListItemText
+          sx={{ margin: 0, height: '28px' }}
+          primary={(
+            <div>
+              <div className={classes.name}>
+                {node.name}
+                {node.draftVersion && (<DraftChip style={{ verticalAlign: 1 }} />)}
               </div>
-            )}
-          />
-          <ListItemIcon classes={{ root: classes.goIcon }}>
-            <KeyboardArrowRightOutlined />
-          </ListItemIcon>
-        </ListItemButton>
-        {subSectors && subSectors.length > 0 && (
-          <List style={{ margin: 0, padding: 0 }}>
-            {map(
-              (subSector) => (
+              <div className={classes.description}>
+                {node.description?.length > 0
+                  ? node.description
+                  : t_i18n('This sector does not have any description.')}
+              </div>
+            </div>
+          )}
+        />
+        <ListItemIcon classes={{ root: classes.goIcon }}>
+          <KeyboardArrowRightOutlined />
+        </ListItemIcon>
+      </ListItemButton>
+      {subSectors && subSectors.length > 0 && (
+        <List style={{ margin: 0, padding: 0 }}>
+          {map(
+            (subSector) => (
 
-                <SectorLine
-                  key={subSector.id}
-                  node={subSector}
-                  isSubSector={true}
-                />
-              ),
-              subSectors,
-            )}
-          </List>
-        )}
-      </div>
-    );
-  }
-}
+              <SectorLine
+                key={subSector.id}
+                node={subSector}
+                isSubSector={true}
+              />
+            ),
+            subSectors,
+          )}
+        </List>
+      )}
+    </div>
+  );
+};
 
 SectorLineComponent.propTypes = {
   node: PropTypes.object,
   isSubSector: PropTypes.bool,
   subSectors: PropTypes.array,
   classes: PropTypes.object,
-  fd: PropTypes.func,
 };
 
-export const SectorLine = compose(
-  inject18n,
-  withStyles(styles),
-)(SectorLineComponent);
+export const SectorLine = withStyles(styles)(SectorLineComponent);
 
-class SectorLineDummyComponent extends Component {
-  render() {
-    const { classes } = this.props;
-    return (
-      <ListItem classes={{ root: classes.item }} divider={true}>
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
+const SectorLineDummyComponent = (props) => {
+  const { classes } = props;
+  return (
+    <ListItem classes={{ root: classes.item }} divider={true}>
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
+        />
+      </ListItemIcon>
+      <ListItemText
+        primary={(
           <Skeleton
             animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
+            variant="rectangular"
+            width="90%"
+            height={20}
           />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <Skeleton
-              animation="wave"
-              variant="rectangular"
-              width="90%"
-              height={20}
-            />
-          )}
-        />
-        <ListItemIcon classes={{ root: classes.goIcon }}>
-          <KeyboardArrowRightOutlined />
-        </ListItemIcon>
-      </ListItem>
-    );
-  }
-}
+        )}
+      />
+      <ListItemIcon classes={{ root: classes.goIcon }}>
+        <KeyboardArrowRightOutlined />
+      </ListItemIcon>
+    </ListItem>
+  );
+};
 
 SectorLineDummyComponent.propTypes = {
   classes: PropTypes.object,
 };
 
-export const SectorLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(SectorLineDummyComponent);
+export const SectorLineDummy = withStyles(styles)(SectorLineDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorParentSectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorParentSectors.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -9,48 +8,45 @@ import { Link } from 'react-router-dom';
 import { Domain } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { truncate } from '../../../../utils/String';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Label from '../../../../components/common/label/Label';
 
-class SectorParentSectorsComponent extends Component {
-  render() {
-    const { t, sector } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Label>
-          {t('Parent sectors')}
-        </Label>
-        <List sx={{ py: 0 }}>
-          {sector.parentSectors.edges.map((parentSectorEdge) => {
-            const parentSector = parentSectorEdge.node;
-            return (
-              <ListItemButton
-                key={parentSector.id}
-                dense={true}
-                divider={true}
-                component={Link}
-                to={`/dashboard/entities/sectors/${parentSector.id}`}
-              >
-                <ListItemIcon>
-                  <Domain color="primary" />
-                </ListItemIcon>
-                <ListItemText
-                  primary={parentSector.name}
-                  secondary={truncate(parentSector.description, 50)}
-                />
-              </ListItemButton>
-            );
-          })}
-        </List>
-      </div>
-    );
-  }
-}
+const SectorParentSectorsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { sector } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Label>
+        {t_i18n('Parent sectors')}
+      </Label>
+      <List sx={{ py: 0 }}>
+        {sector.parentSectors.edges.map((parentSectorEdge) => {
+          const parentSector = parentSectorEdge.node;
+          return (
+            <ListItemButton
+              key={parentSector.id}
+              dense={true}
+              divider={true}
+              component={Link}
+              to={`/dashboard/entities/sectors/${parentSector.id}`}
+            >
+              <ListItemIcon>
+                <Domain color="primary" />
+              </ListItemIcon>
+              <ListItemText
+                primary={parentSector.name}
+                secondary={truncate(parentSector.description, 50)}
+              />
+            </ListItemButton>
+          );
+        })}
+      </List>
+    </div>
+  );
+};
 
 SectorParentSectorsComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   attackPattern: PropTypes.object,
 };
 
@@ -74,4 +70,4 @@ const SectorParentSectors = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(SectorParentSectors);
+export default SectorParentSectors;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorsLines.jsx
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose, pipe, map, pathOr, sortBy, toLower, prop, filter, join, assoc } from 'ramda';
 import { graphql, createPaginationContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import { SectorLine, SectorLineDummy } from './SectorLine';
-import inject18n from '../../../../components/i18n';
 
 const styles = () => ({
   root: {
@@ -13,59 +12,57 @@ const styles = () => ({
   },
 });
 
-class SectorsLinesComponent extends Component {
-  render() {
-    const { data, keyword, classes } = this.props;
-    const sortByNameCaseInsensitive = sortBy(compose(toLower, prop('name')));
-    const filterSubsector = (n) => n.isSubSector === false;
-    const filterByKeyword = (n) => keyword === ''
-      || n.name.toLowerCase().indexOf(keyword.toLowerCase()) !== -1
-      || (n.description ?? '').toLowerCase().indexOf(keyword.toLowerCase())
-      !== -1
-      || (n.subsectors_text ?? '').toLowerCase().indexOf(keyword.toLowerCase())
-      !== -1;
-    const sectors = pipe(
-      pathOr([], ['sectors', 'edges']),
-      map((n) => n.node),
-      map((n) => assoc(
-        'subsectors_text',
-        pipe(
-          map((o) => `${o.node.name} ${o.node.description}`),
-          join(' | '),
-        )(pathOr([], ['subSectors', 'edges'], n)),
-        n,
-      )),
-      filter(filterSubsector),
-      filter(filterByKeyword),
-      sortByNameCaseInsensitive,
-    )(data);
-    return (
-      <List
-        component="nav"
-        aria-labelledby="nested-list-subheader"
-        className={classes.root}
-      >
-        {data
-          ? map((sector) => {
-              const subSectors = pipe(
-                pathOr([], ['subSectors', 'edges']),
-                map((n) => n.node),
-                filter(filterByKeyword),
-                sortByNameCaseInsensitive,
-              )(sector);
-              return (
-                <SectorLine
-                  key={sector.id}
-                  node={sector}
-                  subSectors={subSectors}
-                />
-              );
-            }, sectors)
-          : Array.from(Array(20), (e, i) => <SectorLineDummy key={i} />)}
-      </List>
-    );
-  }
-}
+const SectorsLinesComponent = (props) => {
+  const { data, keyword, classes } = props;
+  const sortByNameCaseInsensitive = sortBy(compose(toLower, prop('name')));
+  const filterSubsector = (n) => n.isSubSector === false;
+  const filterByKeyword = (n) => keyword === ''
+    || n.name.toLowerCase().indexOf(keyword.toLowerCase()) !== -1
+    || (n.description ?? '').toLowerCase().indexOf(keyword.toLowerCase())
+    !== -1
+    || (n.subsectors_text ?? '').toLowerCase().indexOf(keyword.toLowerCase())
+    !== -1;
+  const sectors = pipe(
+    pathOr([], ['sectors', 'edges']),
+    map((n) => n.node),
+    map((n) => assoc(
+      'subsectors_text',
+      pipe(
+        map((o) => `${o.node.name} ${o.node.description}`),
+        join(' | '),
+      )(pathOr([], ['subSectors', 'edges'], n)),
+      n,
+    )),
+    filter(filterSubsector),
+    filter(filterByKeyword),
+    sortByNameCaseInsensitive,
+  )(data);
+  return (
+    <List
+      component="nav"
+      aria-labelledby="nested-list-subheader"
+      className={classes.root}
+    >
+      {data
+        ? map((sector) => {
+            const subSectors = pipe(
+              pathOr([], ['subSectors', 'edges']),
+              map((n) => n.node),
+              filter(filterByKeyword),
+              sortByNameCaseInsensitive,
+            )(sector);
+            return (
+              <SectorLine
+                key={sector.id}
+                node={sector}
+                subSectors={subSectors}
+              />
+            );
+          }, sectors)
+        : Array.from(Array(20), (e, i) => <SectorLineDummy key={i} />)}
+    </List>
+  );
+};
 
 SectorsLinesComponent.propTypes = {
   classes: PropTypes.object,
@@ -141,4 +138,4 @@ const SectorsLinesFragment = createPaginationContainer(
   },
 );
 
-export default compose(inject18n, withStyles(styles))(SectorsLinesFragment);
+export default compose(withStyles(styles))(SectorsLinesFragment);

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemAnalysis.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemAnalysis.jsx
@@ -1,37 +1,31 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
-import withRouter from '../../../../utils/compat_router/withRouter';
-import inject18n from '../../../../components/i18n';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 
-class SystemAnalysisComponent extends Component {
-  render() {
-    const { system, viewAs } = this.props;
-    return (
-      <>
-        {viewAs === 'knowledge' ? (
-          <StixCoreObjectOrStixCoreRelationshipContainers
-            stixDomainObjectOrStixCoreRelationship={system}
-            viewAs={viewAs}
-          />
-        ) : (
-          <StixCoreObjectOrStixCoreRelationshipContainers
-            stixDomainObjectOrStixCoreRelationship={system}
-            authorId={system.id}
-            viewAs={viewAs}
-          />
-        )}
-      </>
-    );
-  }
-}
+const SystemAnalysisComponent = (props) => {
+  const { system, viewAs } = props;
+  return (
+    <>
+      {viewAs === 'knowledge' ? (
+        <StixCoreObjectOrStixCoreRelationshipContainers
+          stixDomainObjectOrStixCoreRelationship={system}
+          viewAs={viewAs}
+        />
+      ) : (
+        <StixCoreObjectOrStixCoreRelationshipContainers
+          stixDomainObjectOrStixCoreRelationship={system}
+          authorId={system.id}
+          viewAs={viewAs}
+        />
+      )}
+    </>
+  );
+};
 
 SystemAnalysisComponent.propTypes = {
   system: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   viewAs: PropTypes.string,
 };
 
@@ -46,4 +40,4 @@ const SystemAnalysis = createFragmentContainer(SystemAnalysisComponent, {
   `,
 });
 
-export default R.compose(inject18n, withRouter)(SystemAnalysis);
+export default SystemAnalysis;

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDetails.jsx
@@ -1,57 +1,53 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';
 import Label from '../../../../components/common/label/Label';
 
-class SystemDetailsComponent extends Component {
-  render() {
-    const { t, system } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={system.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Reliability')}
-              </Label>
-              <ItemOpenVocab
-                displayMode="chip"
-                type="reliability_ov"
-                value={system.x_opencti_reliability}
-              />
-              <Label sx={{ marginTop: 2 }}>
-                {t('Contact information')}
-              </Label>
-              <MarkdownDisplay
-                content={system.contact_information}
-                remarkGfmPlugin={true}
-                commonmark={true}
-              />
-            </Grid>
+const SystemDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { system } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={system.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Reliability')}
+            </Label>
+            <ItemOpenVocab
+              displayMode="chip"
+              type="reliability_ov"
+              value={system.x_opencti_reliability}
+            />
+            <Label sx={{ marginTop: 2 }}>
+              {t_i18n('Contact information')}
+            </Label>
+            <MarkdownDisplay
+              content={system.contact_information}
+              remarkGfmPlugin={true}
+              commonmark={true}
+            />
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 SystemDetailsComponent.propTypes = {
   system: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const SystemDetails = createFragmentContainer(SystemDetailsComponent, {
@@ -65,4 +61,4 @@ const SystemDetails = createFragmentContainer(SystemDetailsComponent, {
   `,
 });
 
-export default compose(inject18n)(SystemDetails);
+export default SystemDetails;

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDetails.jsx
@@ -1,85 +1,80 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
 import StixCoreObjectsDonut from '../../common/stix_core_objects/StixCoreObjectsDonut';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Label from '../../../../components/common/label/Label';
 
-class ObservedDataDetailsComponent extends Component {
-  render() {
-    const { t, fldt, observedData } = this.props;
-    const observablesDataSelection = [
-      {
-        attribute: 'entity_type',
-        filters: {
-          mode: 'and',
-          filters: [
-            {
-              key: 'entity_type',
-              values: 'Stix-Core-Object',
-            },
-            {
-              key: 'regardingOf',
-              values: [
-                { key: 'id', values: [observedData.id] },
-                { key: 'relationship_type', values: ['object'] },
-              ],
-            },
-          ],
-          filterGroups: [],
-        },
+const ObservedDataDetailsComponent = (props) => {
+  const { t_i18n, fldt } = useFormatter();
+  const { observedData } = props;
+  const observablesDataSelection = [
+    {
+      attribute: 'entity_type',
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'entity_type',
+            values: 'Stix-Core-Object',
+          },
+          {
+            key: 'regardingOf',
+            values: [
+              { key: 'id', values: [observedData.id] },
+              { key: 'relationship_type', values: ['object'] },
+            ],
+          },
+        ],
+        filterGroups: [],
       },
-    ];
+    },
+  ];
 
-    const config = {
-      startDate: undefined,
-      endDate: undefined,
-    };
+  const config = {
+    startDate: undefined,
+    endDate: undefined,
+  };
 
-    return (
-      <div style={{ height: '100%' }} data-testid="observed-data-details-page">
-        <Card title={t('Entity details')}>
-          <Grid container={true} spacing={2} sx={{ mb: 2 }}>
-            <Grid item xs={6}>
-              <Label>
-                {t('First observed')}
-              </Label>
-              {fldt(observedData.first_observed)}
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Number observed')}
-              </Label>
-              {observedData.number_observed}
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Last observed')}
-              </Label>
-              {fldt(observedData.last_observed)}
-            </Grid>
+  return (
+    <div style={{ height: '100%' }} data-testid="observed-data-details-page">
+      <Card title={t_i18n('Entity details')}>
+        <Grid container={true} spacing={2} sx={{ mb: 2 }}>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('First observed')}
+            </Label>
+            {fldt(observedData.first_observed)}
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Number observed')}
+            </Label>
+            {observedData.number_observed}
           </Grid>
-          <StixCoreObjectsDonut
-            dataSelection={observablesDataSelection}
-            parameters={{ title: t('Observables distribution') }}
-            variant="inEntity"
-            height={300}
-            config={config}
-          />
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Last observed')}
+            </Label>
+            {fldt(observedData.last_observed)}
+          </Grid>
+        </Grid>
+        <StixCoreObjectsDonut
+          dataSelection={observablesDataSelection}
+          parameters={{ title: t_i18n('Observables distribution') }}
+          variant="inEntity"
+          height={300}
+          config={config}
+        />
+      </Card>
+    </div>
+  );
+};
 
 ObservedDataDetailsComponent.propTypes = {
   observedData: PropTypes.object,
-  t: PropTypes.func,
-  fldt: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const ObservedDataDetails = createFragmentContainer(
@@ -96,4 +91,4 @@ const ObservedDataDetails = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(ObservedDataDetails);
+export default ObservedDataDetails;

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipsDonut.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipsDonut.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { graphql } from 'react-relay';
@@ -8,7 +8,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import * as R from 'ramda';
 import Chart from '../../common/charts/Chart';
 import { QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { donutChartOptions } from '../../../../utils/Charts';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import { NO_DATA_WIDGET_MESSAGE } from '../../../../components/dashboard/WidgetNoData';
@@ -134,65 +134,11 @@ const entityStixSightingRelationshipsDonutStixSightingRelationshipsDistributionQ
   }
 `;
 
-class EntityStixSightingRelationshipsDonut extends Component {
-  constructor(props) {
-    super(props);
-    this.renderLabel = this.renderLabel.bind(this);
-    this.renderSimpleLabel = this.renderSimpleLabel.bind(this);
-  }
+const EntityStixSightingRelationshipsDonut = (props) => {
+  const { t_i18n } = useFormatter();
 
-  renderSimpleLabel(props) {
-    return props.value;
-  }
-
-  renderLabel(props) {
-    const { theme } = this.props;
-    const RADIAN = Math.PI / 180;
-    const { cx, cy, midAngle, outerRadius, fill, payload, percent, value } = props;
-    const sin = Math.sin(-RADIAN * midAngle);
-    const cos = Math.cos(-RADIAN * midAngle);
-    const sx = cx + (outerRadius + 10) * cos;
-    const sy = cy + (outerRadius + 10) * sin;
-    const mx = cx + (outerRadius + 30) * cos;
-    const my = cy + (outerRadius + 30) * sin;
-    const ex = mx + (cos >= 0 ? 1 : -1) * 22;
-    const ey = my;
-    const textAnchor = cos >= 0 ? 'start' : 'end';
-
-    return (
-      <g>
-        <path
-          d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`}
-          stroke={fill}
-          fill="none"
-        />
-        <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
-        <text
-          x={ex + (cos >= 0 ? 1 : -1) * 12}
-          y={ey}
-          textAnchor={textAnchor}
-          fill={theme.palette.text.primary}
-          style={{ fontSize: 12 }}
-        >
-          {' '}
-          {payload.label} ({value})
-        </text>
-        <text
-          x={ex + (cos >= 0 ? 1 : -1) * 12}
-          y={ey}
-          dy={18}
-          textAnchor={textAnchor}
-          fill="#999999"
-          style={{ fontSize: 12 }}
-        >
-          {` ${(percent * 100).toFixed(2)}%`}
-        </text>
-      </g>
-    );
-  }
-
-  renderContent() {
-    const { t, entityId, variant, field, startDate, endDate, theme, toTypes } = this.props;
+  const renderContent = () => {
+    const { entityId, variant, field, startDate, endDate, theme, toTypes } = props;
     const stixSightingRelationshipsDistributionVariables = {
       fromId: entityId,
       startDate: startDate || null,
@@ -220,7 +166,7 @@ class EntityStixSightingRelationshipsDonut extends Component {
                   'label',
                   `${
                     toTypes.length > 1 && n.entity
-                      ? `[${t(`entity_${n.entity.entity_type}`)}] ${n.entity.name}`
+                      ? `[${t_i18n(`entity_${n.entity.entity_type}`)}] ${n.entity.name}`
                       : `${getMainRepresentative(n.entity) || n.label}`
                   }`,
                   n,
@@ -229,7 +175,7 @@ class EntityStixSightingRelationshipsDonut extends Component {
               );
             }
             const chartData = data.map((n) => n.value);
-            const labels = data.map((n) => (field === 'entity_type' ? t(`entity_${n.label}`) : n.label));
+            const labels = data.map((n) => (field === 'entity_type' ? t_i18n(`entity_${n.label}`) : n.label));
             return (
               <Chart
                 options={donutChartOptions(
@@ -254,7 +200,7 @@ class EntityStixSightingRelationshipsDonut extends Component {
                     textAlign: 'center',
                   }}
                 >
-                  {t(NO_DATA_WIDGET_MESSAGE)}
+                  {t_i18n(NO_DATA_WIDGET_MESSAGE)}
                 </span>
               </div>
             );
@@ -275,17 +221,15 @@ class EntityStixSightingRelationshipsDonut extends Component {
         }}
       />
     );
-  }
+  };
 
-  render() {
-    const { t, title } = this.props;
-    return (
-      <Card title={title || t('Distribution of entities')}>
-        {this.renderContent()}
-      </Card>
-    );
-  }
-}
+  const { title } = props;
+  return (
+    <Card title={title || t_i18n('Distribution of entities')}>
+      {renderContent()}
+    </Card>
+  );
+};
 
 EntityStixSightingRelationshipsDonut.propTypes = {
   title: PropTypes.string,
@@ -296,13 +240,10 @@ EntityStixSightingRelationshipsDonut.propTypes = {
   field: PropTypes.string,
   classes: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   toTypes: PropTypes.array,
 };
 
 export default compose(
-  inject18n,
   withTheme,
   withStyles(styles),
 )(EntityStixSightingRelationshipsDonut);

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { Link } from 'react-router-dom';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
@@ -11,7 +10,6 @@ import { MoreVert } from '@mui/icons-material';
 import Skeleton from '@mui/material/Skeleton';
 import { ListItemButton } from '@mui/material';
 import Box from '@mui/material/Box';
-import inject18n from '../../../../components/i18n';
 import ItemConfidence from '../../../../components/ItemConfidence';
 import StixCoreRelationshipPopover from '../../common/stix_core_relationships/StixCoreRelationshipPopover';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -20,6 +18,7 @@ import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import ItemEntityType from '../../../../components/ItemEntityType';
 import { isEmptyField } from '../../../../utils/utils';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   item: {
@@ -48,136 +47,131 @@ const styles = (theme) => ({
   },
 });
 
-class IndicatorEntityLineComponent extends Component {
-  render() {
-    const {
-      fsd,
-      t,
-      classes,
-      dataColumns,
-      node,
-      paginationOptions,
-      displayRelation,
-      entityId,
-      entityLink,
-    } = this.props;
-    const element = node.to?.id === entityId ? node.from : node.to;
-    const restricted = isEmptyField(element);
-    const link = `${entityLink}/relations/${node.id}`;
+const IndicatorEntityLineComponent = (props) => {
+  const { fsd, t_i18n } = useFormatter();
+  const {
+    classes,
+    dataColumns,
+    node,
+    paginationOptions,
+    displayRelation,
+    entityId,
+    entityLink,
+  } = props;
+  const element = node.to?.id === entityId ? node.from : node.to;
+  const restricted = isEmptyField(element);
+  const link = `${entityLink}/relations/${node.id}`;
 
-    const isRelationship = t(`relationship_${element.entity_type}`) !== `relationship_${element.entity_type}`;
+  const isRelationship = t_i18n(`relationship_${element.entity_type}`) !== `relationship_${element.entity_type}`;
 
-    const displayName = !restricted
-      ? isRelationship
-        ? element.representative?.main
-        ?? `${element.from?.name ?? element.from?.observable_value ?? EMPTY_VALUE}
-         ${String.fromCharCode(8594)}
-         ${element.to?.name ?? element.to?.observable_value ?? EMPTY_VALUE}`
-        : element.name || element.observable_value
-      : t('Restricted');
+  const displayName = !restricted
+    ? isRelationship
+      ? element.representative?.main
+      ?? `${element.from?.name ?? element.from?.observable_value ?? EMPTY_VALUE}
+       ${String.fromCharCode(8594)}
+       ${element.to?.name ?? element.to?.observable_value ?? EMPTY_VALUE}`
+      : element.name || element.observable_value
+    : t_i18n('Restricted');
 
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={(
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <StixCoreRelationshipPopover
-              stixCoreRelationshipId={node.id}
-              paginationOptions={paginationOptions}
-              disabled={restricted}
-            />
-          </Security>
-        )}
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={(
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <StixCoreRelationshipPopover
+            stixCoreRelationshipId={node.id}
+            paginationOptions={paginationOptions}
+            disabled={restricted}
+          />
+        </Security>
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component={Link}
+        to={link}
+        disabled={restricted}
       >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component={Link}
-          to={link}
-          disabled={restricted}
-        >
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <ItemIcon type={node.entity_type} />
-          </ListItemIcon>
-          <ListItemText
-            primary={(
-              <div>
-                {displayRelation && (
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.relationship_type.width }}
-                  >
-                    <ItemEntityType
-                      entityType={node.relationship_type}
-                    />
-                  </div>
-                )}
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <ItemIcon type={node.entity_type} />
+        </ListItemIcon>
+        <ListItemText
+          primary={(
+            <div>
+              {displayRelation && (
                 <div
                   className={classes.bodyItem}
-                  style={{ width: dataColumns.entity_type.width }}
+                  style={{ width: dataColumns.relationship_type.width }}
                 >
                   <ItemEntityType
-                    entityType={element.entity_type === 'stix_relation'
-                      || element.entity_type === 'stix-relation'
-                      ? element.parent_types[0]
-                      : element.entity_type}
-                    isRestricted={restricted}
-                    size="large"
-                    showIcon
+                    entityType={node.relationship_type}
                   />
                 </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.name.width }}
-                >
-                  {displayName}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.createdBy.width }}
-                >
-                  {node.createdBy?.name ?? EMPTY_VALUE}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.creator.width }}
-                >
-                  {(node.creators ?? []).map((c) => c?.name).join(', ')}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.start_time.width }}
-                >
-                  {fsd(node.start_time)}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.stop_time.width }}
-                >
-                  {fsd(node.stop_time)}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.confidence.width }}
-                >
-                  <ItemConfidence confidence={node.confidence} entityType="stix-core-relationship" variant="inList" />
-                </div>
+              )}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.entity_type.width }}
+              >
+                <ItemEntityType
+                  entityType={element.entity_type === 'stix_relation'
+                    || element.entity_type === 'stix-relation'
+                    ? element.parent_types[0]
+                    : element.entity_type}
+                  isRestricted={restricted}
+                  size="large"
+                  showIcon
+                />
               </div>
-            )}
-          />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.name.width }}
+              >
+                {displayName}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.createdBy.width }}
+              >
+                {node.createdBy?.name ?? EMPTY_VALUE}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.creator.width }}
+              >
+                {(node.creators ?? []).map((c) => c?.name).join(', ')}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.start_time.width }}
+              >
+                {fsd(node.start_time)}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.stop_time.width }}
+              >
+                {fsd(node.stop_time)}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.confidence.width }}
+              >
+                <ItemConfidence confidence={node.confidence} entityType="stix-core-relationship" variant="inList" />
+              </div>
+            </div>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 IndicatorEntityLineComponent.propTypes = {
   paginationOptions: PropTypes.object,
   dataColumns: PropTypes.object,
   node: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fsd: PropTypes.func,
   displayRelation: PropTypes.bool,
   entityId: PropTypes.string,
 };
@@ -698,110 +692,105 @@ const IndicatorEntityLineFragment = createFragmentContainer(
   },
 );
 
-export const IndicatorEntityLine = compose(
-  inject18n,
-  withStyles(styles),
-)(IndicatorEntityLineFragment);
+export const IndicatorEntityLine = withStyles(styles)(IndicatorEntityLineFragment);
 
-class IndicatorEntityLineDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns, displayRelation } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={(
-          <Box sx={{ root: classes.itemIconDisabled }}>
-            <MoreVert />
-          </Box>
-        )}
-      >
-        <ListItemIcon classes={{ root: classes.itemIconDisabled }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <div>
-              {displayRelation && (
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.relationship_type.width }}
-                >
-                  <Skeleton
-                    animation="wave"
-                    variant="rectangular"
-                    width="90%"
-                    height="100%"
-                  />
-                </div>
-              )}
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.entity_type.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.name.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.start_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.stop_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.confidence.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={100}
-                  height="100%"
-                />
-              </div>
-            </div>
-          )}
+const IndicatorEntityLineDummyComponent = (props) => {
+  const { classes, dataColumns, displayRelation } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={(
+        <Box sx={{ root: classes.itemIconDisabled }}>
+          <MoreVert />
+        </Box>
+      )}
+    >
+      <ListItemIcon classes={{ root: classes.itemIconDisabled }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        primary={(
+          <div>
+            {displayRelation && (
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.relationship_type.width }}
+              >
+                <Skeleton
+                  animation="wave"
+                  variant="rectangular"
+                  width="90%"
+                  height="100%"
+                />
+              </div>
+            )}
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.entity_type.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.name.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.start_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.stop_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.confidence.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={100}
+                height="100%"
+              />
+            </div>
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 IndicatorEntityLineDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -809,7 +798,4 @@ IndicatorEntityLineDummyComponent.propTypes = {
   displayRelation: PropTypes.bool,
 };
 
-export const IndicatorEntityLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(IndicatorEntityLineDummyComponent);
+export const IndicatorEntityLineDummy = withStyles(styles)(IndicatorEntityLineDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicatorsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicatorsLines.jsx
@@ -1,25 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
-class StixCyberObservableAddIndicatorsLinesContainer extends Component {
-  render() {
-    const { data, stixCyberObservableIndicators, stixCyberObservable } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={stixCyberObservable}
-        relationshipType="based-on"
-        availableDatas={data?.indicators}
-        existingDatas={stixCyberObservableIndicators}
-        updaterOptions={{ path: '__Pagination_stixCyberObservables_indicators_connection' }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const StixCyberObservableAddIndicatorsLinesContainer = (props) => {
+  const { data, stixCyberObservableIndicators, stixCyberObservable } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={stixCyberObservable}
+      relationshipType="based-on"
+      availableDatas={data?.indicators}
+      existingDatas={stixCyberObservableIndicators}
+      updaterOptions={{ path: '__Pagination_stixCyberObservables_indicators_connection' }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 StixCyberObservableAddIndicatorsLinesContainer.propTypes = {
   stixCyberObservable: PropTypes.object,
@@ -102,4 +98,4 @@ const StixCyberObservableAddIndicatorsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(StixCyberObservableAddIndicatorsLines);
+export default StixCyberObservableAddIndicatorsLines;

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
@@ -6,12 +6,10 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
-import { compose } from 'ramda';
 import Skeleton from '@mui/material/Skeleton';
 import { Link } from 'react-router-dom';
 import { ListItemButton } from '@mui/material';
 import Box from '@mui/material/Box';
-import inject18n from '../../../../components/i18n';
 import { groupsSearchQuery } from '../Groups';
 import { QueryRenderer } from '../../../../relay/environment';
 import useSensitiveModifications from '../../../../utils/hooks/useSensitiveModifications';
@@ -131,7 +129,6 @@ RoleLineComponent.propTypes = {
   paginationOptions: PropTypes.object,
   me: PropTypes.object,
   classes: PropTypes.object,
-  fd: PropTypes.func,
 };
 
 const RoleLineFragment = createFragmentContainer(RoleLineComponent, {
@@ -146,93 +143,85 @@ const RoleLineFragment = createFragmentContainer(RoleLineComponent, {
   `,
 });
 
-export const RoleLine = compose(
-  inject18n,
-  withStyles(styles),
-)(RoleLineFragment);
+export const RoleLine = withStyles(styles)(RoleLineFragment);
 
-class RoleLineDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={(
-          <Box sx={{ root: classes.itemIconDisabled }}>
-            <KeyboardArrowRightOutlined />
-          </Box>
-        )}
-      >
-        <ListItemIcon classes={{ root: classes.itemIconDisabled }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.name.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.groups.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.created_at.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.updated_at.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-            </div>
-          )}
+const RoleLineDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={(
+        <Box sx={{ root: classes.itemIconDisabled }}>
+          <KeyboardArrowRightOutlined />
+        </Box>
+      )}
+    >
+      <ListItemIcon classes={{ root: classes.itemIconDisabled }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        primary={(
+          <div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.name.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.groups.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.created_at.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.updated_at.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 RoleLineDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const RoleLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(RoleLineDummyComponent);
+export const RoleLineDummy = withStyles(styles)(RoleLineDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
@@ -10,6 +10,7 @@ import Skeleton from '@mui/material/Skeleton';
 import { Link } from 'react-router-dom';
 import { ListItemButton } from '@mui/material';
 import Box from '@mui/material/Box';
+import { useFormatter } from '../../../../components/i18n';
 import { groupsSearchQuery } from '../Groups';
 import { QueryRenderer } from '../../../../relay/environment';
 import useSensitiveModifications from '../../../../utils/hooks/useSensitiveModifications';
@@ -43,7 +44,8 @@ const styles = (theme) => ({
   },
 });
 
-const RoleLineComponent = ({ fd, classes, dataColumns, node }) => {
+const RoleLineComponent = ({ classes, dataColumns, node }) => {
+  const { fd } = useFormatter();
   const { isSensitive } = useSensitiveModifications('roles', node.standard_id);
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfActionLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfActionLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addCoursesOfActionMutationRelationDelete = graphql`
@@ -19,21 +17,19 @@ export const addCoursesOfActionMutationRelationDelete = graphql`
   }
 `;
 
-class AddCoursesOfActionLinesContainer extends Component {
-  render() {
-    const { data, attackPatternCoursesOfAction, attackPattern } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={attackPattern}
-        relationshipType="mitigates"
-        availableDatas={data?.coursesOfAction}
-        existingDatas={attackPatternCoursesOfAction}
-        updaterOptions={{ path: 'coursesOfAction' }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const AddCoursesOfActionLinesContainer = (props) => {
+  const { data, attackPatternCoursesOfAction, attackPattern } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={attackPattern}
+      relationshipType="mitigates"
+      availableDatas={data?.coursesOfAction}
+      existingDatas={attackPatternCoursesOfAction}
+      updaterOptions={{ path: 'coursesOfAction' }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 AddCoursesOfActionLinesContainer.propTypes = {
   attackPattern: PropTypes.object,
@@ -100,4 +96,4 @@ const AddCoursesOfActionLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddCoursesOfActionLines);
+export default AddCoursesOfActionLines;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPatternsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPatternsLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addSubAttackPatternsMutationRelationDelete = graphql`
@@ -19,21 +17,19 @@ export const addSubAttackPatternsMutationRelationDelete = graphql`
   }
 `;
 
-class AddSubAttackPatternsLinesContainer extends Component {
-  render() {
-    const { data, attackPatternSubAttackPatterns, attackPattern } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={attackPattern}
-        relationshipType="subtechnique-of"
-        availableDatas={data?.attackPatterns}
-        existingDatas={attackPatternSubAttackPatterns}
-        updaterOptions={{ path: 'subAttackPatterns' }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const AddSubAttackPatternsLinesContainer = (props) => {
+  const { data, attackPatternSubAttackPatterns, attackPattern } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={attackPattern}
+      relationshipType="subtechnique-of"
+      availableDatas={data?.attackPatterns}
+      existingDatas={attackPatternSubAttackPatterns}
+      updaterOptions={{ path: 'subAttackPatterns' }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 AddSubAttackPatternsLinesContainer.propTypes = {
   attackPattern: PropTypes.object,
@@ -101,4 +97,4 @@ const AddSubAttackPatternsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddSubAttackPatternsLines);
+export default AddSubAttackPatternsLines;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDetails.jsx
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import List from '@mui/material/List';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import AttackPatternParentAttackPatterns from './AttackPatternParentAttackPatterns';
 import AttackPatternSubAttackPatterns from './AttackPatternSubAttackPatterns';
@@ -17,85 +16,82 @@ import Label from '../../../../components/common/label/Label';
 import Tag from '@common/tag/Tag';
 import TextList from '@common/text/TextList';
 
-class AttackPatternDetailsComponent extends Component {
-  render() {
-    const { t, attackPattern } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={2}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown
-                source={attackPattern.description}
-                limit={300}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              {attackPattern.isSubAttackPattern && (
-                <AttackPatternParentAttackPatterns
-                  attackPattern={attackPattern}
-                />
-              )}
-              <Label
-                sx={{ marginTop: attackPattern.isSubAttackPattern ? 2 : 0 }}
-              >
-                {t('External ID')}
-              </Label>
-              <FieldOrEmpty source={attackPattern.x_mitre_id}>
-                <Tag
-                  label={attackPattern.x_mitre_id}
-                />
-              </FieldOrEmpty>
-              <div>
-                <Label
-                  sx={{ marginTop: 2 }}
-                >
-                  {t('Platforms')}
-                </Label>
-                <List style={{ paddingTop: 0 }}>
-                  <TextList list={attackPattern.x_mitre_platforms} />
-                </List>
-              </div>
-              <AttackPatternSubAttackPatterns attackPattern={attackPattern} />
-            </Grid>
-            <Grid item xs={6}>
-              <StixCoreObjectKillChainPhasesView
-                killChainPhases={attackPattern.killChainPhases}
-                firstLine={true}
-              />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Detection')}
-              </Label>
-              <ExpandableMarkdown
-                source={attackPattern.x_mitre_detection}
-                limit={400}
-              />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Required permissions')}
-              </Label>
-              <TextList list={attackPattern.x_mitre_permissions_required} />
-              <AttackPatternCoursesOfAction attackPattern={attackPattern} />
-              <AttackPatternDataComponents attackPattern={attackPattern} />
-            </Grid>
+const AttackPatternDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { attackPattern } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={2}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={attackPattern.description}
+              limit={300}
+            />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            {attackPattern.isSubAttackPattern && (
+              <AttackPatternParentAttackPatterns
+                attackPattern={attackPattern}
+              />
+            )}
+            <Label
+              sx={{ marginTop: attackPattern.isSubAttackPattern ? 2 : 0 }}
+            >
+              {t_i18n('External ID')}
+            </Label>
+            <FieldOrEmpty source={attackPattern.x_mitre_id}>
+              <Tag
+                label={attackPattern.x_mitre_id}
+              />
+            </FieldOrEmpty>
+            <div>
+              <Label
+                sx={{ marginTop: 2 }}
+              >
+                {t_i18n('Platforms')}
+              </Label>
+              <List style={{ paddingTop: 0 }}>
+                <TextList list={attackPattern.x_mitre_platforms} />
+              </List>
+            </div>
+            <AttackPatternSubAttackPatterns attackPattern={attackPattern} />
+          </Grid>
+          <Grid item xs={6}>
+            <StixCoreObjectKillChainPhasesView
+              killChainPhases={attackPattern.killChainPhases}
+              firstLine={true}
+            />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Detection')}
+            </Label>
+            <ExpandableMarkdown
+              source={attackPattern.x_mitre_detection}
+              limit={400}
+            />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Required permissions')}
+            </Label>
+            <TextList list={attackPattern.x_mitre_permissions_required} />
+            <AttackPatternCoursesOfAction attackPattern={attackPattern} />
+            <AttackPatternDataComponents attackPattern={attackPattern} />
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 AttackPatternDetailsComponent.propTypes = {
   attackPattern: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const AttackPatternDetails = createFragmentContainer(
@@ -131,4 +127,4 @@ const AttackPatternDetails = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(AttackPatternDetails);
+export default AttackPatternDetails;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternParentAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternParentAttackPatterns.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -8,49 +7,46 @@ import { Link } from 'react-router-dom';
 import { LockPattern } from 'mdi-material-ui';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { ListItemButton } from '@mui/material';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Label from '../../../../components/common/label/Label';
 
-class AttackPatternParentAttackPatternsComponent extends Component {
-  render() {
-    const { t, attackPattern } = this.props;
-    return (
-      <div>
-        <Label>
-          {t('Parent attack patterns')}
-        </Label>
-        <List>
-          {attackPattern.parentAttackPatterns.edges.map(
-            (parentAttackPatternEdge) => {
-              const parentAttackPattern = parentAttackPatternEdge.node;
-              return (
-                <ListItemButton
-                  key={parentAttackPattern.id}
-                  dense={true}
-                  divider={true}
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${parentAttackPattern.id}`}
-                >
-                  <ListItemIcon>
-                    <LockPattern color="primary" />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={`[${parentAttackPattern.x_mitre_id}] ${parentAttackPattern.name}`}
-                  />
-                </ListItemButton>
-              );
-            },
-          )}
-        </List>
-      </div>
-    );
-  }
-}
+const AttackPatternParentAttackPatternsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { attackPattern } = props;
+  return (
+    <div>
+      <Label>
+        {t_i18n('Parent attack patterns')}
+      </Label>
+      <List>
+        {attackPattern.parentAttackPatterns.edges.map(
+          (parentAttackPatternEdge) => {
+            const parentAttackPattern = parentAttackPatternEdge.node;
+            return (
+              <ListItemButton
+                key={parentAttackPattern.id}
+                dense={true}
+                divider={true}
+                component={Link}
+                to={`/dashboard/techniques/attack_patterns/${parentAttackPattern.id}`}
+              >
+                <ListItemIcon>
+                  <LockPattern color="primary" />
+                </ListItemIcon>
+                <ListItemText
+                  primary={`[${parentAttackPattern.x_mitre_id}] ${parentAttackPattern.name}`}
+                />
+              </ListItemButton>
+            );
+          },
+        )}
+      </List>
+    </div>
+  );
+};
 
 AttackPatternParentAttackPatternsComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   attackPattern: PropTypes.object,
 };
 
@@ -75,4 +71,4 @@ const AttackPatternParentAttackPatterns = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(AttackPatternParentAttackPatterns);
+export default AttackPatternParentAttackPatterns;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatternsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatternsLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addAttackPatternsLinesMutationRelationDelete = graphql`
@@ -19,20 +17,18 @@ export const addAttackPatternsLinesMutationRelationDelete = graphql`
   }
 `;
 
-class AddAttackPatternsLinesContainer extends Component {
-  render() {
-    const { data, courseOfActionAttackPatterns, courseOfAction } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={courseOfAction}
-        relationshipType="mitigates"
-        availableDatas={data?.attackPatterns}
-        existingDatas={courseOfActionAttackPatterns}
-        updaterOptions={{ path: 'attackPatterns' }}
-      />
-    );
-  }
-}
+const AddAttackPatternsLinesContainer = (props) => {
+  const { data, courseOfActionAttackPatterns, courseOfAction } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={courseOfAction}
+      relationshipType="mitigates"
+      availableDatas={data?.attackPatterns}
+      existingDatas={courseOfActionAttackPatterns}
+      updaterOptions={{ path: 'attackPatterns' }}
+    />
+  );
+};
 
 AddAttackPatternsLinesContainer.propTypes = {
   courseOfAction: PropTypes.object,
@@ -99,4 +95,4 @@ const AddAttackPatternsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddAttackPatternsLines);
+export default AddAttackPatternsLines;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionDetails.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
@@ -11,80 +10,77 @@ import { PostOutline } from 'mdi-material-ui';
 import ListItemText from '@mui/material/ListItemText';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import CoursesOfActionAttackPatterns from './CourseOfActionAttackPatterns';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import Card from '@common/card/Card';
 import Label from '../../../../components/common/label/Label';
 
-class CourseOfActionDetailsComponent extends Component {
-  render() {
-    const { t, courseOfAction } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={2}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown
-                source={courseOfAction.description}
-                limit={300}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Log sources')}
-              </Label>
-              <FieldOrEmpty source={courseOfAction.x_opencti_log_sources}>
-                <List>
-                  {(courseOfAction.x_opencti_log_sources ?? []).map((logSource, index) => (
-                    <ListItem key={`${index}:${logSource}`} dense={true} divider={true}>
-                      <ListItemIcon>
-                        <PostOutline />
-                      </ListItemIcon>
-                      <ListItemText primary={logSource} />
-                    </ListItem>
-                  ))}
-                </List>
-              </FieldOrEmpty>
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('External ID')}
-              </Label>
-              <FieldOrEmpty
-                source={courseOfAction.x_mitre_id}
-              >
-                <Chip
-                  size="small"
-                  label={courseOfAction.x_mitre_id}
-                  color="primary"
-                  style={{ borderRadius: 4 }}
-                />
-              </FieldOrEmpty>
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Threat hunting techniques')}
-              </Label>
-              <ExpandableMarkdown
-                source={courseOfAction.x_opencti_threat_hunting}
-                limit={300}
-              />
-            </Grid>
+const CourseOfActionDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { courseOfAction } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={2}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={courseOfAction.description}
+              limit={300}
+            />
           </Grid>
-          <CoursesOfActionAttackPatterns courseOfAction={courseOfAction} />
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Log sources')}
+            </Label>
+            <FieldOrEmpty source={courseOfAction.x_opencti_log_sources}>
+              <List>
+                {(courseOfAction.x_opencti_log_sources ?? []).map((logSource, index) => (
+                  <ListItem key={`${index}:${logSource}`} dense={true} divider={true}>
+                    <ListItemIcon>
+                      <PostOutline />
+                    </ListItemIcon>
+                    <ListItemText primary={logSource} />
+                  </ListItem>
+                ))}
+              </List>
+            </FieldOrEmpty>
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('External ID')}
+            </Label>
+            <FieldOrEmpty
+              source={courseOfAction.x_mitre_id}
+            >
+              <Chip
+                size="small"
+                label={courseOfAction.x_mitre_id}
+                color="primary"
+                style={{ borderRadius: 4 }}
+              />
+            </FieldOrEmpty>
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Threat hunting techniques')}
+            </Label>
+            <ExpandableMarkdown
+              source={courseOfAction.x_opencti_threat_hunting}
+              limit={300}
+            />
+          </Grid>
+        </Grid>
+        <CoursesOfActionAttackPatterns courseOfAction={courseOfAction} />
+      </Card>
+    </div>
+  );
+};
 
 CourseOfActionDetailsComponent.propTypes = {
   courseOfAction: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const CourseOfActionDetails = createFragmentContainer(
@@ -108,4 +104,4 @@ const CourseOfActionDetails = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(CourseOfActionDetails);
+export default CourseOfActionDetails;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import CourseOfActionEditionContainer from './CourseOfActionEditionContainer';
 import { courseOfActionEditionOverviewFocus } from './CourseOfActionEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,46 +15,41 @@ export const courseOfActionEditionQuery = graphql`
   }
 `;
 
-class CourseOfActionEdition extends Component {
-  handleClose() {
+const CourseOfActionEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: courseOfActionEditionOverviewFocus,
       variables: {
-        id: this.props.courseOfActionId,
+        id: props.courseOfActionId,
         input: { focusOn: '' },
       },
     });
-  }
+  };
 
-  render() {
-    const { courseOfActionId } = this.props;
-    return (
-      <QueryRenderer
-        query={courseOfActionEditionQuery}
-        variables={{ id: courseOfActionId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <CourseOfActionEditionContainer
-                courseOfAction={props.courseOfAction}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { courseOfActionId } = props;
+  return (
+    <QueryRenderer
+      query={courseOfActionEditionQuery}
+      variables={{ id: courseOfActionId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <CourseOfActionEditionContainer
+              courseOfAction={props.courseOfAction}
+              handleClose={handleClose.bind(this)}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 CourseOfActionEdition.propTypes = {
   courseOfActionId: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(CourseOfActionEdition);
+export default CourseOfActionEdition;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrativesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrativesLines.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
-import inject18n from '../../../../components/i18n';
 
 export const addSubNarrativesMutationRelationDelete = graphql`
   mutation AddSubNarrativesLinesRelationDeleteMutation(
@@ -19,21 +17,19 @@ export const addSubNarrativesMutationRelationDelete = graphql`
   }
 `;
 
-class AddSubNarrativesLinesContainer extends Component {
-  render() {
-    const { data, narrativeSubNarratives, narrative } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={narrative}
-        relationshipType="subnarrative-of"
-        availableDatas={data?.narratives}
-        existingDatas={narrativeSubNarratives}
-        updaterOptions={{ path: 'subNarratives' }}
-        isRelationReversed={true}
-      />
-    );
-  }
-}
+const AddSubNarrativesLinesContainer = (props) => {
+  const { data, narrativeSubNarratives, narrative } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={narrative}
+      relationshipType="subnarrative-of"
+      availableDatas={data?.narratives}
+      existingDatas={narrativeSubNarratives}
+      updaterOptions={{ path: 'subNarratives' }}
+      isRelationReversed={true}
+    />
+  );
+};
 
 AddSubNarrativesLinesContainer.propTypes = {
   narrative: PropTypes.object,
@@ -96,4 +92,4 @@ const AddSubNarrativesLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddSubNarrativesLines);
+export default AddSubNarrativesLines;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDetails.jsx
@@ -1,46 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Card from '@common/card/Card';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import NarrativeParentNarratives from './NarrativeParentNarratives';
 import NarrativeSubNarratives from './NarrativeSubNarratives';
 import Label from '../../../../components/common/label/Label';
 
-class NarrativeDetailsComponent extends Component {
-  render() {
-    const { t, narrative } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={narrative.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              {narrative.isSubNarrative ? (
-                <NarrativeParentNarratives narrative={narrative} />
-              ) : (
-                <NarrativeSubNarratives narrative={narrative} />
-              )}
-            </Grid>
+const NarrativeDetailsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { narrative } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={narrative.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            {narrative.isSubNarrative ? (
+              <NarrativeParentNarratives narrative={narrative} />
+            ) : (
+              <NarrativeSubNarratives narrative={narrative} />
+            )}
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 NarrativeDetailsComponent.propTypes = {
   narrative: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 const NarrativeDetails = createFragmentContainer(NarrativeDetailsComponent, {
@@ -55,4 +51,4 @@ const NarrativeDetails = createFragmentContainer(NarrativeDetailsComponent, {
   `,
 });
 
-export default R.compose(inject18n)(NarrativeDetails);
+export default NarrativeDetails;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import NarrativeEditionContainer from './NarrativeEditionContainer';
 import { narrativeEditionOverviewFocus } from './NarrativeEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,47 +15,42 @@ export const narrativeEditionQuery = graphql`
   }
 `;
 
-class NarrativeEdition extends Component {
-  handleClose() {
+const NarrativeEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: narrativeEditionOverviewFocus,
       variables: {
-        id: this.props.narrativeId,
+        id: props.narrativeId,
         input: { focusOn: '' },
       },
     });
-  }
+  };
 
-  render() {
-    const { narrativeId } = this.props;
-    return (
-      <QueryRenderer
-        query={narrativeEditionQuery}
-        variables={{ id: narrativeId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <NarrativeEditionContainer
-                narrative={props.narrative}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { narrativeId } = props;
+  return (
+    <QueryRenderer
+      query={narrativeEditionQuery}
+      variables={{ id: narrativeId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <NarrativeEditionContainer
+              narrative={props.narrative}
+              handleClose={handleClose.bind(this)}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 NarrativeEdition.propTypes = {
   narrativeId: PropTypes.string,
   me: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(NarrativeEdition);
+export default NarrativeEdition;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeParentNarratives.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeParentNarratives.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -9,48 +8,45 @@ import { SpeakerNotesOutlined } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Label from '../../../../components/common/label/Label';
 
-class NarrativeParentNarrativesComponent extends Component {
-  render() {
-    const { t, narrative } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Label>
-          {t('Parent narratives')}
-        </Label>
-        <List sx={{ py: 0 }}>
-          {narrative.parentNarratives.edges.map((parentNarrativeEdge) => {
-            const parentNarrative = parentNarrativeEdge.node;
-            return (
-              <ListItemButton
-                key={parentNarrative.id}
-                dense={true}
-                divider={true}
-                component={Link}
-                to={`/dashboard/techniques/narratives/${parentNarrative.id}`}
-              >
-                <ListItemIcon>
-                  <SpeakerNotesOutlined color="primary" />
-                </ListItemIcon>
-                <ListItemText
-                  primary={parentNarrative.name}
-                  secondary={truncate(parentNarrative.description, 50)}
-                />
-              </ListItemButton>
-            );
-          })}
-        </List>
-      </div>
-    );
-  }
-}
+const NarrativeParentNarrativesComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { narrative } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Label>
+        {t_i18n('Parent narratives')}
+      </Label>
+      <List sx={{ py: 0 }}>
+        {narrative.parentNarratives.edges.map((parentNarrativeEdge) => {
+          const parentNarrative = parentNarrativeEdge.node;
+          return (
+            <ListItemButton
+              key={parentNarrative.id}
+              dense={true}
+              divider={true}
+              component={Link}
+              to={`/dashboard/techniques/narratives/${parentNarrative.id}`}
+            >
+              <ListItemIcon>
+                <SpeakerNotesOutlined color="primary" />
+              </ListItemIcon>
+              <ListItemText
+                primary={parentNarrative.name}
+                secondary={truncate(parentNarrative.description, 50)}
+              />
+            </ListItemButton>
+          );
+        })}
+      </List>
+    </div>
+  );
+};
 
 NarrativeParentNarrativesComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   attackPattern: PropTypes.object,
 };
 
@@ -74,4 +70,4 @@ const NarrativeParentNarratives = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(NarrativeParentNarratives);
+export default NarrativeParentNarratives;

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeSubNarratives.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeSubNarratives.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose, filter } from 'ramda';
+import { filter } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -13,22 +13,23 @@ import ListItem from '@mui/material/ListItem';
 import AddSubNarrative from './AddSubNarrative';
 import { addSubNarrativesMutationRelationDelete } from './AddSubNarrativesLines';
 import { commitMutation } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import Label from '../../../../components/common/label/Label';
 
-class NarrativeSubNarrativesComponent extends Component {
-  removeSubNarrative(subNarrativeEdge) {
+const NarrativeSubNarrativesComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const removeSubNarrative = (subNarrativeEdge) => {
     commitMutation({
       mutation: addSubNarrativesMutationRelationDelete,
       variables: {
         fromId: subNarrativeEdge.node.id,
-        toId: this.props.narrative.id,
+        toId: props.narrative.id,
         relationship_type: 'subnarrative-of',
       },
       updater: (store) => {
-        const node = store.get(this.props.narrative.id);
+        const node = store.get(props.narrative.id);
         const subNarratives = node.getLinkedRecord('subNarratives');
         const edges = subNarratives.getLinkedRecords('edges');
         const newEdges = filter(
@@ -39,65 +40,61 @@ class NarrativeSubNarrativesComponent extends Component {
         subNarratives.setLinkedRecords(newEdges, 'edges');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, narrative } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Label action={(
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <AddSubNarrative
-              narrative={narrative}
-              narrativeSubNarratives={narrative.subNarratives.edges}
-            />
-          </Security>
-        )}
-        >
-          {t('Subnarratives')}
-        </Label>
-        <List sx={{ py: 0 }}>
-          {narrative.subNarratives.edges.map((subNarrativeEdge) => {
-            const subNarrative = subNarrativeEdge.node;
-            return (
-              <ListItem
-                key={subNarrative.id}
-                dense={true}
-                divider={true}
-                secondaryAction={(
-                  <IconButton
-                    aria-label="Remove"
-                    onClick={this.removeSubNarrative.bind(
-                      this,
-                      subNarrativeEdge,
-                    )}
-                  >
-                    <LinkOff />
-                  </IconButton>
-                )}
-              >
-                <ListItemButton
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${subNarrative.id}`}
+  const { narrative } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Label action={(
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <AddSubNarrative
+            narrative={narrative}
+            narrativeSubNarratives={narrative.subNarratives.edges}
+          />
+        </Security>
+      )}
+      >
+        {t_i18n('Subnarratives')}
+      </Label>
+      <List sx={{ py: 0 }}>
+        {narrative.subNarratives.edges.map((subNarrativeEdge) => {
+          const subNarrative = subNarrativeEdge.node;
+          return (
+            <ListItem
+              key={subNarrative.id}
+              dense={true}
+              divider={true}
+              secondaryAction={(
+                <IconButton
+                  aria-label="Remove"
+                  onClick={removeSubNarrative.bind(
+                    this,
+                    subNarrativeEdge,
+                  )}
                 >
-                  <ListItemIcon>
-                    <SpeakerNotesOutlined color="primary" />
-                  </ListItemIcon>
-                  <ListItemText primary={subNarrative.name} />
-                </ListItemButton>
-              </ListItem>
-            );
-          })}
-        </List>
-      </div>
-    );
-  }
-}
+                  <LinkOff />
+                </IconButton>
+              )}
+            >
+              <ListItemButton
+                component={Link}
+                to={`/dashboard/techniques/narratives/${subNarrative.id}`}
+              >
+                <ListItemIcon>
+                  <SpeakerNotesOutlined color="primary" />
+                </ListItemIcon>
+                <ListItemText primary={subNarrative.name} />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
+      </List>
+    </div>
+  );
+};
 
 NarrativeSubNarrativesComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   narrative: PropTypes.object,
 };
 
@@ -125,4 +122,4 @@ const NarrativeSubNarratives = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(NarrativeSubNarratives);
+export default NarrativeSubNarratives;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDetails.jsx
@@ -1,60 +1,56 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
 import Grid from '@mui/material/Grid';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';
 import Card from '@common/card/Card';
 import Label from '../../../../components/common/label/Label';
 
-class CampaignDetailsComponent extends Component {
-  render() {
-    const { fldt, t, campaign } = this.props;
-    return (
-      <div style={{ height: '100%' }}>
-        <Card title={t('Details')}>
-          <Grid container={true} spacing={3}>
-            <Grid item xs={12}>
-              <Label>
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown source={campaign.description} limit={400} />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Objective')}
-              </Label>
-              <MarkdownDisplay
-                content={campaign.objective}
-                remarkGfmPlugin={true}
-                commonmark={true}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('First seen')}
-              </Label>
-              {fldt(campaign.first_seen)}
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Last seen')}
-              </Label>
-              {fldt(campaign.last_seen)}
-            </Grid>
+const CampaignDetailsComponent = (props) => {
+  const { fldt, t_i18n } = useFormatter();
+  const { campaign } = props;
+  return (
+    <div style={{ height: '100%' }}>
+      <Card title={t_i18n('Details')}>
+        <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={campaign.description} limit={400} />
           </Grid>
-        </Card>
-      </div>
-    );
-  }
-}
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Objective')}
+            </Label>
+            <MarkdownDisplay
+              content={campaign.objective}
+              remarkGfmPlugin={true}
+              commonmark={true}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('First seen')}
+            </Label>
+            {fldt(campaign.first_seen)}
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Last seen')}
+            </Label>
+            {fldt(campaign.last_seen)}
+          </Grid>
+        </Grid>
+      </Card>
+    </div>
+  );
+};
 
 CampaignDetailsComponent.propTypes = {
   campaign: PropTypes.object,
-  t: PropTypes.func,
-  fldt: PropTypes.func,
 };
 
 const CampaignDetails = createFragmentContainer(CampaignDetailsComponent, {
@@ -69,4 +65,4 @@ const CampaignDetails = createFragmentContainer(CampaignDetailsComponent, {
   `,
 });
 
-export default compose(inject18n)(CampaignDetails);
+export default CampaignDetails;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocationsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocationsLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addLocationsMutationRelationDelete = graphql`
@@ -19,20 +17,18 @@ export const addLocationsMutationRelationDelete = graphql`
   }
 `;
 
-class AddLocationsLinesContainer extends Component {
-  render() {
-    const { data, intrusionSetLocations, intrusionSet } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={intrusionSet}
-        relationshipType="originates-from"
-        availableDatas={data?.locations}
-        existingDatas={intrusionSetLocations}
-        updaterOptions={{ path: 'locations' }}
-      />
-    );
-  }
-}
+const AddLocationsLinesContainer = (props) => {
+  const { data, intrusionSetLocations, intrusionSet } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={intrusionSet}
+      relationshipType="originates-from"
+      availableDatas={data?.locations}
+      existingDatas={intrusionSetLocations}
+      updaterOptions={{ path: 'locations' }}
+    />
+  );
+};
 
 AddLocationsLinesContainer.propTypes = {
   intrusionSet: PropTypes.object,
@@ -96,4 +92,4 @@ const AddLocationsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddLocationsLines);
+export default AddLocationsLines;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import IntrusionSetEditionContainer from './IntrusionSetEditionContainer';
 import { intrusionSetEditionOverviewFocus } from './IntrusionSetEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,44 +15,41 @@ export const intrusionSetEditionQuery = graphql`
   }
 `;
 
-class IntrusionSetEdition extends Component {
-  handleClose() {
+const IntrusionSetEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: intrusionSetEditionOverviewFocus,
       variables: {
-        id: this.props.intrusionSetId,
+        id: props.intrusionSetId,
         input: { focusOn: '' },
       },
     });
-  }
+  };
 
-  render() {
-    const { intrusionSetId } = this.props;
-    return (
-      <QueryRenderer
-        query={intrusionSetEditionQuery}
-        variables={{ id: intrusionSetId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <IntrusionSetEditionContainer
-                intrusionSet={props.intrusionSet}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { intrusionSetId } = props;
+  return (
+    <QueryRenderer
+      query={intrusionSetEditionQuery}
+      variables={{ id: intrusionSetId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <IntrusionSetEditionContainer
+              intrusionSet={props.intrusionSet}
+              handleClose={handleClose.bind(this)}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 IntrusionSetEdition.propTypes = {
   intrusionSetId: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(IntrusionSetEdition);
+export default IntrusionSetEdition;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetLocations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetLocations.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
@@ -15,7 +15,7 @@ import AddLocations from './AddLocations';
 import { addLocationsMutationRelationDelete } from './AddLocationsLines';
 import { commitMutation } from '../../../../relay/environment';
 import { findFlagUrl } from '../../../../utils/flags';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';
 import ItemIcon from '../../../../components/ItemIcon';
 import Security from '../../../../utils/Security';
@@ -40,17 +40,18 @@ const styles = (theme) => ({
   },
 });
 
-class IntrusionSetLocationsComponent extends Component {
-  removeLocation(locationEdge) {
+const IntrusionSetLocationsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const removeLocation = (locationEdge) => {
     commitMutation({
       mutation: addLocationsMutationRelationDelete,
       variables: {
-        fromId: this.props.intrusionSet.id,
+        fromId: props.intrusionSet.id,
         toId: locationEdge.node.id,
         relationship_type: 'originates-from',
       },
       updater: (store) => {
-        const node = store.get(this.props.intrusionSet.id);
+        const node = store.get(props.intrusionSet.id);
         const locations = node.getLinkedRecord('locations');
         const edges = locations.getLinkedRecords('edges');
         const newEdges = edges.filter(
@@ -59,80 +60,76 @@ class IntrusionSetLocationsComponent extends Component {
         locations.setLinkedRecords(newEdges, 'edges');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, intrusionSet } = this.props;
-    return (
-      <>
-        <Label action={(
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <AddLocations
-              intrusionSet={intrusionSet}
-              intrusionSetLocations={intrusionSet.locations.edges}
-            />
-          </Security>
-        )}
-        >
-          {t('Originates from')}
-        </Label>
-        <FieldOrEmpty source={intrusionSet.locations.edges}>
-          <List style={{ marginTop: -10 }}>
-            {intrusionSet.locations.edges.map((locationEdge) => {
-              const location = locationEdge.node;
-              const link = resolveLink(location.entity_type);
-              const flagUrl = location.entity_type === 'Country'
-                && findFlagUrl(location.x_opencti_aliases);
-              return (
-                <ListItem
-                  key={location.id}
-                  dense={true}
-                  divider={true}
-                  disablePadding
-                  secondaryAction={(
-                    <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <Tooltip title={t('Delete relationship')}>
-                        <IconButton
-                          aria-label="Remove"
-                          onClick={this.removeLocation.bind(this, locationEdge)}
-                        >
-                          <Delete />
-                        </IconButton>
-                      </Tooltip>
-                    </Security>
-                  )}
+  const { intrusionSet } = props;
+  return (
+    <>
+      <Label action={(
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <AddLocations
+            intrusionSet={intrusionSet}
+            intrusionSetLocations={intrusionSet.locations.edges}
+          />
+        </Security>
+      )}
+      >
+        {t_i18n('Originates from')}
+      </Label>
+      <FieldOrEmpty source={intrusionSet.locations.edges}>
+        <List style={{ marginTop: -10 }}>
+          {intrusionSet.locations.edges.map((locationEdge) => {
+            const location = locationEdge.node;
+            const link = resolveLink(location.entity_type);
+            const flagUrl = location.entity_type === 'Country'
+              && findFlagUrl(location.x_opencti_aliases);
+            return (
+              <ListItem
+                key={location.id}
+                dense={true}
+                divider={true}
+                disablePadding
+                secondaryAction={(
+                  <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                    <Tooltip title={t_i18n('Delete relationship')}>
+                      <IconButton
+                        aria-label="Remove"
+                        onClick={removeLocation.bind(this, locationEdge)}
+                      >
+                        <Delete />
+                      </IconButton>
+                    </Tooltip>
+                  </Security>
+                )}
+              >
+                <ListItemButton
+                  component={Link}
+                  to={`${link}/${location.id}`}
                 >
-                  <ListItemButton
-                    component={Link}
-                    to={`${link}/${location.id}`}
-                  >
-                    <ListItemIcon sx={{ minWidth: 32 }}>
-                      {flagUrl ? (
-                        <img
-                          style={{ width: 20 }}
-                          src={flagUrl}
-                          alt={location.name}
-                        />
-                      ) : (
-                        <ItemIcon type={location.entity_type} />
-                      )}
-                    </ListItemIcon>
-                    <ListItemText primary={location.name} />
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
-        </FieldOrEmpty>
-      </>
-    );
-  }
-}
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    {flagUrl ? (
+                      <img
+                        style={{ width: 20 }}
+                        src={flagUrl}
+                        alt={location.name}
+                      />
+                    ) : (
+                      <ItemIcon type={location.entity_type} />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText primary={location.name} />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+      </FieldOrEmpty>
+    </>
+  );
+};
 
 IntrusionSetLocationsComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   intrusionSet: PropTypes.object,
 };
 
@@ -162,4 +159,4 @@ const IntrusionSetLocations = createFragmentContainer(
   },
 );
 
-export default compose(inject18n, withStyles(styles))(IntrusionSetLocations);
+export default compose(withStyles(styles))(IntrusionSetLocations);

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroupLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroupLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addLocationsThreatActorGroupMutationRelationDelete = graphql`
@@ -19,20 +17,18 @@ export const addLocationsThreatActorGroupMutationRelationDelete = graphql`
   }
 `;
 
-class AddLocationsThreatActorGroupLinesContainer extends Component {
-  render() {
-    const { data, threatActorGroupLocations, threatActorGroup } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={threatActorGroup}
-        relationshipType="located-at"
-        availableDatas={data?.locations}
-        existingDatas={threatActorGroupLocations}
-        updaterOptions={{ path: 'locations' }}
-      />
-    );
-  }
-}
+const AddLocationsThreatActorGroupLinesContainer = (props) => {
+  const { data, threatActorGroupLocations, threatActorGroup } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={threatActorGroup}
+      relationshipType="located-at"
+      availableDatas={data?.locations}
+      existingDatas={threatActorGroupLocations}
+      updaterOptions={{ path: 'locations' }}
+    />
+  );
+};
 
 AddLocationsThreatActorGroupLinesContainer.propTypes = {
   threatActorGroup: PropTypes.object,
@@ -101,4 +97,4 @@ const AddLocationsThreatActorGroupLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddLocationsThreatActorGroupLines);
+export default AddLocationsThreatActorGroupLines;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDetails.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import ImageCarousel from '../../../../components/ImageCarousel';
@@ -16,148 +15,145 @@ import Tag from '../../../../components/common/tag/Tag';
 import TextList from '../../../../components/common/text/TextList';
 import { Stack } from '@mui/material';
 
-class ThreatActorGroupDetailsComponent extends Component {
-  render() {
-    const { t, threatActorGroup, fldt } = this.props;
-    const hasImages = (threatActorGroup.images?.edges ?? []).filter(
-      (n) => n?.node?.metaData?.inCarousel,
-    ).length > 0;
+const ThreatActorGroupDetailsComponent = (props) => {
+  const { t_i18n, fldt } = useFormatter();
+  const { threatActorGroup } = props;
+  const hasImages = (threatActorGroup.images?.edges ?? []).filter(
+    (n) => n?.node?.metaData?.inCarousel,
+  ).length > 0;
 
-    return (
-      <Card title={t('Details')}>
-        <Grid container={true} spacing={2}>
-          <Grid item xs={12}>
-            <Label>
-              {t('Description')}
-            </Label>
-            <ExpandableMarkdown
-              source={threatActorGroup.description}
-              limit={hasImages ? 400 : 600}
-            />
-          </Grid>
-          <Grid item xs={hasImages ? 7 : 6}>
-            <Grid container={true} spacing={2}>
-              {hasImages && (
-                <Grid item xs={4}>
-                  <ImageCarousel data={threatActorGroup} />
-                </Grid>
-              )}
-              <Grid item xs={hasImages ? 8 : 12}>
-                <Label>
-                  {t('Threat actor types')}
-                </Label>
-                <FieldOrEmpty source={threatActorGroup.threat_actor_types}>
-                  <Stack direction="row" flexWrap="wrap" gap={1}>
-                    {threatActorGroup.threat_actor_types
-                      && threatActorGroup.threat_actor_types.map(
-                        (threatActorGroupType) => (
-                          <Tag
-                            key={threatActorGroupType}
-                            label={threatActorGroupType}
-                          />
-                        ),
-                      )}
-                  </Stack>
-                </FieldOrEmpty>
+  return (
+    <Card title={t_i18n('Details')}>
+      <Grid container={true} spacing={2}>
+        <Grid item xs={12}>
+          <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown
+            source={threatActorGroup.description}
+            limit={hasImages ? 400 : 600}
+          />
+        </Grid>
+        <Grid item xs={hasImages ? 7 : 6}>
+          <Grid container={true} spacing={2}>
+            {hasImages && (
+              <Grid item xs={4}>
+                <ImageCarousel data={threatActorGroup} />
               </Grid>
+            )}
+            <Grid item xs={hasImages ? 8 : 12}>
+              <Label>
+                {t_i18n('Threat actor types')}
+              </Label>
+              <FieldOrEmpty source={threatActorGroup.threat_actor_types}>
+                <Stack direction="row" flexWrap="wrap" gap={1}>
+                  {threatActorGroup.threat_actor_types
+                    && threatActorGroup.threat_actor_types.map(
+                      (threatActorGroupType) => (
+                        <Tag
+                          key={threatActorGroupType}
+                          label={threatActorGroupType}
+                        />
+                      ),
+                    )}
+                </Stack>
+              </FieldOrEmpty>
             </Grid>
           </Grid>
-          <Grid item xs={hasImages ? 5 : 6}>
-            <ThreatActorGroupLocation threatActorGroup={threatActorGroup} />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('First seen')}
-            </Label>
-            {fldt(threatActorGroup.first_seen)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Last seen')}
-            </Label>
-            {fldt(threatActorGroup.last_seen)}
-          </Grid>
         </Grid>
-        <Grid container={true} spacing={2}>
-          <Grid item xs={4}>
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Sophistication')}
-            </Label>
-            <FieldOrEmpty source={threatActorGroup.sophistication}>
-              <ItemOpenVocab
-                type="threat-actor-group-sophistication-ov"
-                value={threatActorGroup.sophistication}
-              />
-            </FieldOrEmpty>
-          </Grid>
-          <Grid item xs={4}>
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Resource level')}
-            </Label>
-            <FieldOrEmpty source={threatActorGroup.resource_level}>
-              <ItemOpenVocab
-                type="attack-resource-level-ov"
-                value={threatActorGroup.resource_level}
-              />
-            </FieldOrEmpty>
-          </Grid>
-          <Grid item xs={4}>
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Primary motivation')}
-            </Label>
-            <FieldOrEmpty source={threatActorGroup.primary_motivation}>
-              <ItemOpenVocab
-                type="attack-motivation-ov"
-                value={threatActorGroup.primary_motivation}
-              />
-            </FieldOrEmpty>
-          </Grid>
-          <Grid item xs={4}>
-            <Label>
-              {t('Roles')}
-            </Label>
-            <TextList
-              list={threatActorGroup.roles}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <Label>
-              {t('Score')}
-            </Label>
-            <ItemScore score={threatActorGroup.x_opencti_score} />
-          </Grid>
-          <Grid item xs={4}>
-            <Label>
-              {t('Goals')}
-            </Label>
-            <TextList
-              list={threatActorGroup.goals}
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <Label>
-              {t('Secondary motivations')}
-            </Label>
-            <TextList
-              list={threatActorGroup.secondary_motivations}
-            />
-          </Grid>
+        <Grid item xs={hasImages ? 5 : 6}>
+          <ThreatActorGroupLocation threatActorGroup={threatActorGroup} />
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('First seen')}
+          </Label>
+          {fldt(threatActorGroup.first_seen)}
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Last seen')}
+          </Label>
+          {fldt(threatActorGroup.last_seen)}
         </Grid>
-      </Card>
-    );
-  }
-}
+      </Grid>
+      <Grid container={true} spacing={2}>
+        <Grid item xs={4}>
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Sophistication')}
+          </Label>
+          <FieldOrEmpty source={threatActorGroup.sophistication}>
+            <ItemOpenVocab
+              type="threat-actor-group-sophistication-ov"
+              value={threatActorGroup.sophistication}
+            />
+          </FieldOrEmpty>
+        </Grid>
+        <Grid item xs={4}>
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Resource level')}
+          </Label>
+          <FieldOrEmpty source={threatActorGroup.resource_level}>
+            <ItemOpenVocab
+              type="attack-resource-level-ov"
+              value={threatActorGroup.resource_level}
+            />
+          </FieldOrEmpty>
+        </Grid>
+        <Grid item xs={4}>
+          <Label
+            sx={{ marginTop: 2 }}
+          >
+            {t_i18n('Primary motivation')}
+          </Label>
+          <FieldOrEmpty source={threatActorGroup.primary_motivation}>
+            <ItemOpenVocab
+              type="attack-motivation-ov"
+              value={threatActorGroup.primary_motivation}
+            />
+          </FieldOrEmpty>
+        </Grid>
+        <Grid item xs={4}>
+          <Label>
+            {t_i18n('Roles')}
+          </Label>
+          <TextList
+            list={threatActorGroup.roles}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <Label>
+            {t_i18n('Score')}
+          </Label>
+          <ItemScore score={threatActorGroup.x_opencti_score} />
+        </Grid>
+        <Grid item xs={4}>
+          <Label>
+            {t_i18n('Goals')}
+          </Label>
+          <TextList
+            list={threatActorGroup.goals}
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <Label>
+            {t_i18n('Secondary motivations')}
+          </Label>
+          <TextList
+            list={threatActorGroup.secondary_motivations}
+          />
+        </Grid>
+      </Grid>
+    </Card>
+  );
+};
 
 ThreatActorGroupDetailsComponent.propTypes = {
   threatActorGroup: PropTypes.object,
-  t: PropTypes.func,
-  fd: PropTypes.func,
 };
 
 const ThreatActorGroupDetails = createFragmentContainer(
@@ -197,4 +193,4 @@ const ThreatActorGroupDetails = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(ThreatActorGroupDetails);
+export default ThreatActorGroupDetails;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEdition.jsx
@@ -1,10 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import ThreatActorGroupEditionContainer from './ThreatActorGroupEditionContainer';
 import { ThreatActorGroupEditionOverviewFocus } from './ThreatActorGroupEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -26,47 +24,41 @@ export const ThreatActorGroupEditionQuery = graphql`
   }
 `;
 
-class ThreatActorGroupEdition extends Component {
-  handleClose() {
+const ThreatActorGroupEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: ThreatActorGroupEditionOverviewFocus,
       variables: {
-        id: this.props.threatActorGroupId,
+        id: props.threatActorGroupId,
         input: { focusOn: '' },
       },
     });
-  }
+  };
 
-  render() {
-    const { threatActorGroupId } = this.props;
-    return (
-      <QueryRenderer
-        query={ThreatActorGroupEditionQuery}
-        variables={{ id: threatActorGroupId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <ThreatActorGroupEditionContainer
-                threatActorGroup={props.threatActorGroup}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { threatActorGroupId } = props;
+  return (
+    <QueryRenderer
+      query={ThreatActorGroupEditionQuery}
+      variables={{ id: threatActorGroupId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <ThreatActorGroupEditionContainer
+              threatActorGroup={props.threatActorGroup}
+              handleClose={handleClose.bind(this)}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 ThreatActorGroupEdition.propTypes = {
   threatActorGroupId: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles, { withTheme: true }),
-)(ThreatActorGroupEdition);
+export default withStyles(styles, { withTheme: true })(ThreatActorGroupEdition);

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupLocation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupLocation.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -13,7 +12,7 @@ import { ListItemButton } from '@mui/material';
 import ListItem from '@mui/material/ListItem';
 import { commitMutation } from '../../../../relay/environment';
 import { findFlagUrl } from '../../../../utils/flags';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';
 import ItemIcon from '../../../../components/ItemIcon';
 import Security from '../../../../utils/Security';
@@ -23,17 +22,18 @@ import { addLocationsThreatActorGroupMutationRelationDelete } from './AddLocatio
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import Label from '../../../../components/common/label/Label';
 
-class ThreatActorGroupLocationsComponent extends Component {
-  removeLocation(locationEdge) {
+const ThreatActorGroupLocationsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const removeLocation = (locationEdge) => {
     commitMutation({
       mutation: addLocationsThreatActorGroupMutationRelationDelete,
       variables: {
-        fromId: this.props.threatActorGroup.id,
+        fromId: props.threatActorGroup.id,
         toId: locationEdge.node.id,
         relationship_type: 'located-at',
       },
       updater: (store) => {
-        const node = store.get(this.props.threatActorGroup.id);
+        const node = store.get(props.threatActorGroup.id);
         const locations = node.getLinkedRecord('locations');
         const edges = locations.getLinkedRecords('edges');
         const newEdges = edges.filter(
@@ -42,81 +42,77 @@ class ThreatActorGroupLocationsComponent extends Component {
         locations.setLinkedRecords(newEdges, 'edges');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, threatActorGroup } = this.props;
-    return (
-      <>
-        <Label action={(
-          <Security needs={[KNOWLEDGE_KNUPDATE]}>
-            <AddLocationsThreatActorGroup
-              threatActorGroup={threatActorGroup}
-              threatActorGroupLocations={threatActorGroup.locations.edges}
-            />
-          </Security>
-        )}
-        >
-          {t('Located at')}
-        </Label>
+  const { threatActorGroup } = props;
+  return (
+    <>
+      <Label action={(
+        <Security needs={[KNOWLEDGE_KNUPDATE]}>
+          <AddLocationsThreatActorGroup
+            threatActorGroup={threatActorGroup}
+            threatActorGroupLocations={threatActorGroup.locations.edges}
+          />
+        </Security>
+      )}
+      >
+        {t_i18n('Located at')}
+      </Label>
 
-        <FieldOrEmpty source={threatActorGroup.locations.edges}>
-          <List>
-            {threatActorGroup.locations.edges.map((locationEdge) => {
-              const { types } = locationEdge;
-              const location = locationEdge.node;
-              const link = resolveLink(location.entity_type);
-              const flagUrl = location.entity_type === 'Country'
-                && findFlagUrl(location.x_opencti_aliases);
-              return (
-                <ListItem
-                  key={location.id}
-                  dense={true}
-                  divider={true}
-                  disablePadding
-                  secondaryAction={types.includes('manual') && (
-                    <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <IconButton
-                        aria-label="Remove"
-                        onClick={() => this.removeLocation(locationEdge)}
-                      >
-                        <LinkOff />
-                      </IconButton>
-                    </Security>
-                  )}
+      <FieldOrEmpty source={threatActorGroup.locations.edges}>
+        <List>
+          {threatActorGroup.locations.edges.map((locationEdge) => {
+            const { types } = locationEdge;
+            const location = locationEdge.node;
+            const link = resolveLink(location.entity_type);
+            const flagUrl = location.entity_type === 'Country'
+              && findFlagUrl(location.x_opencti_aliases);
+            return (
+              <ListItem
+                key={location.id}
+                dense={true}
+                divider={true}
+                disablePadding
+                secondaryAction={types.includes('manual') && (
+                  <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                    <IconButton
+                      aria-label="Remove"
+                      onClick={() => removeLocation(locationEdge)}
+                    >
+                      <LinkOff />
+                    </IconButton>
+                  </Security>
+                )}
+              >
+                <ListItemButton
+                  component={Link}
+                  to={`${link}/${location.id}`}
                 >
-                  <ListItemButton
-                    component={Link}
-                    to={`${link}/${location.id}`}
-                  >
-                    <ListItemIcon sx={{ minWidth: 32 }}>
-                      {flagUrl ? (
-                        <img
-                          style={{ width: 20 }}
-                          src={flagUrl}
-                          alt={location.name}
-                        />
-                      ) : (
-                        <ItemIcon type={location.entity_type} />
-                      )}
-                    </ListItemIcon>
-                    <ListItemText primary={location.name} />
-                    {!types.includes('manual') && <AutoFix fontSize="small" style={{ marginRight: 13 }} />}
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
-        </FieldOrEmpty>
-      </>
-    );
-  }
-}
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    {flagUrl ? (
+                      <img
+                        style={{ width: 20 }}
+                        src={flagUrl}
+                        alt={location.name}
+                      />
+                    ) : (
+                      <ItemIcon type={location.entity_type} />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText primary={location.name} />
+                  {!types.includes('manual') && <AutoFix fontSize="small" style={{ marginRight: 13 }} />}
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+      </FieldOrEmpty>
+    </>
+  );
+};
 
 ThreatActorGroupLocationsComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   threatActorGroup: PropTypes.object,
 };
 
@@ -147,4 +143,4 @@ const ThreatActorGroupLocations = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(ThreatActorGroupLocations);
+export default ThreatActorGroupLocations;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividualLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/AddLocationsThreatActorIndividualLines.jsx
@@ -1,8 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../../components/i18n';
 import StixCoreRelationshipCreationFromEntityList from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntityList';
 
 export const addLocationsThreatActorMutationRelationDelete = graphql`
@@ -19,20 +17,18 @@ export const addLocationsThreatActorMutationRelationDelete = graphql`
   }
 `;
 
-class AddLocationsThreatActorIndividualLinesContainer extends Component {
-  render() {
-    const { data, threatActorIndividualLocations, threatActorIndividual } = this.props;
-    return (
-      <StixCoreRelationshipCreationFromEntityList
-        entity={threatActorIndividual}
-        relationshipType="located-at"
-        availableDatas={data?.locations}
-        existingDatas={threatActorIndividualLocations}
-        updaterOptions={{ path: 'locations' }}
-      />
-    );
-  }
-}
+const AddLocationsThreatActorIndividualLinesContainer = (props) => {
+  const { data, threatActorIndividualLocations, threatActorIndividual } = props;
+  return (
+    <StixCoreRelationshipCreationFromEntityList
+      entity={threatActorIndividual}
+      relationshipType="located-at"
+      availableDatas={data?.locations}
+      existingDatas={threatActorIndividualLocations}
+      updaterOptions={{ path: 'locations' }}
+    />
+  );
+};
 
 AddLocationsThreatActorIndividualLinesContainer.propTypes = {
   threatActorIndividual: PropTypes.object,
@@ -101,4 +97,4 @@ const AddLocationsThreatActorIndividualLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n)(AddLocationsThreatActorIndividualLines);
+export default AddLocationsThreatActorIndividualLines;

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLocation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLocation.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -13,7 +12,7 @@ import { ListItemButton } from '@mui/material';
 import ListItem from '@mui/material/ListItem';
 import { commitMutation } from '../../../../relay/environment';
 import { findFlagUrl } from '../../../../utils/flags';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';
 import ItemIcon from '../../../../components/ItemIcon';
 import Security from '../../../../utils/Security';
@@ -23,17 +22,18 @@ import AddLocationsThreatActorIndividual from './AddLocationsThreatActorIndividu
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import Label from '../../../../components/common/label/Label';
 
-class ThreatActorIndividualLocationsComponent extends Component {
-  removeLocation(locationEdge) {
+const ThreatActorIndividualLocationsComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const removeLocation = (locationEdge) => {
     commitMutation({
       mutation: addLocationsThreatActorMutationRelationDelete,
       variables: {
-        fromId: this.props.threatActorIndividual.id,
+        fromId: props.threatActorIndividual.id,
         toId: locationEdge.node.id,
         relationship_type: 'located-at',
       },
       updater: (store) => {
-        const node = store.get(this.props.threatActorIndividual.id);
+        const node = store.get(props.threatActorIndividual.id);
         const locations = node.getLinkedRecord('locations');
         const edges = locations.getLinkedRecords('edges');
         const newEdges = edges.filter(
@@ -42,85 +42,81 @@ class ThreatActorIndividualLocationsComponent extends Component {
         locations.setLinkedRecords(newEdges, 'edges');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, threatActorIndividual } = this.props;
-    return (
-      <>
-        <Label
-          sx={{ marginTop: '20px' }}
-          action={(
-            <Security needs={[KNOWLEDGE_KNUPDATE]}>
-              <AddLocationsThreatActorIndividual
-                threatActorIndividual={threatActorIndividual}
-              />
-            </Security>
-          )}
-        >
-          {t('Located at')}
-        </Label>
-        <FieldOrEmpty source={threatActorIndividual.locations.edges}>
-          <List style={{ marginTop: -10 }}>
-            {threatActorIndividual.locations.edges.map((locationEdge) => {
-              const { types } = locationEdge;
-              const location = locationEdge.node;
-              const link = resolveLink(location.entity_type);
-              const flagUrl = location.entity_type === 'Country'
-                && findFlagUrl(location.x_opencti_aliases);
-              return (
-                <ListItem
-                  key={location.id}
-                  dense={true}
-                  divider={true}
-                  disablePadding
-                  secondaryAction={
-                    types.includes('manual') && (
-                      <div style={{ right: 0 }}>
-                        <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                          <IconButton
-                            aria-label="Remove"
-                            onClick={() => this.removeLocation(locationEdge)}
-                          >
-                            <LinkOff />
-                          </IconButton>
-                        </Security>
-                      </div>
-                    )
-                  }
+  const { threatActorIndividual } = props;
+  return (
+    <>
+      <Label
+        sx={{ marginTop: '20px' }}
+        action={(
+          <Security needs={[KNOWLEDGE_KNUPDATE]}>
+            <AddLocationsThreatActorIndividual
+              threatActorIndividual={threatActorIndividual}
+            />
+          </Security>
+        )}
+      >
+        {t_i18n('Located at')}
+      </Label>
+      <FieldOrEmpty source={threatActorIndividual.locations.edges}>
+        <List style={{ marginTop: -10 }}>
+          {threatActorIndividual.locations.edges.map((locationEdge) => {
+            const { types } = locationEdge;
+            const location = locationEdge.node;
+            const link = resolveLink(location.entity_type);
+            const flagUrl = location.entity_type === 'Country'
+              && findFlagUrl(location.x_opencti_aliases);
+            return (
+              <ListItem
+                key={location.id}
+                dense={true}
+                divider={true}
+                disablePadding
+                secondaryAction={
+                  types.includes('manual') && (
+                    <div style={{ right: 0 }}>
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <IconButton
+                          aria-label="Remove"
+                          onClick={() => removeLocation(locationEdge)}
+                        >
+                          <LinkOff />
+                        </IconButton>
+                      </Security>
+                    </div>
+                  )
+                }
+              >
+                <ListItemButton
+                  component={Link}
+                  to={`${link}/${location.id}`}
                 >
-                  <ListItemButton
-                    component={Link}
-                    to={`${link}/${location.id}`}
-                  >
-                    <ListItemIcon sx={{ minWidth: 32 }}>
-                      {flagUrl ? (
-                        <img
-                          style={{ width: 20 }}
-                          src={flagUrl}
-                          alt={location.name}
-                        />
-                      ) : (
-                        <ItemIcon type={location.entity_type} />
-                      )}
-                    </ListItemIcon>
-                    <ListItemText primary={location.name} />
-                    {!types.includes('manual') && <AutoFix fontSize="small" style={{ marginRight: 13 }} />}
-                  </ListItemButton>
-                </ListItem>
-              );
-            })}
-          </List>
-        </FieldOrEmpty>
-      </>
-    );
-  }
-}
+                  <ListItemIcon sx={{ minWidth: 32 }}>
+                    {flagUrl ? (
+                      <img
+                        style={{ width: 20 }}
+                        src={flagUrl}
+                        alt={location.name}
+                      />
+                    ) : (
+                      <ItemIcon type={location.entity_type} />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText primary={location.name} />
+                  {!types.includes('manual') && <AutoFix fontSize="small" style={{ marginRight: 13 }} />}
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+      </FieldOrEmpty>
+    </>
+  );
+};
 
 ThreatActorIndividualLocationsComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   threatActorIndividual: PropTypes.object,
 };
 
@@ -151,4 +147,4 @@ const ThreatActorIndividualLocations = createFragmentContainer(
   },
 );
 
-export default compose(inject18n)(ThreatActorIndividualLocations);
+export default ThreatActorIndividualLocations;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceEditionContainer.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceEditionContainer.jsx
@@ -1,36 +1,33 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { compose } from 'ramda';
-import inject18n from '../../../components/i18n';
+import { useFormatter } from '../../../components/i18n';
 import WorkspaceEditionOverview from './WorkspaceEditionOverview';
 import Drawer from '../common/drawer/Drawer';
 
-class WorkspaceEditionContainer extends Component {
-  render() {
-    const { t, handleClose, workspace, open, type } = this.props;
-    const { editContext } = workspace;
-    return (
-      <Drawer
-        title={t(`Update ${type}`)}
-        open={open}
-        onClose={handleClose}
+const WorkspaceEditionContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const { handleClose, workspace, open, type } = props;
+  const { editContext } = workspace;
+  return (
+    <Drawer
+      title={t_i18n(`Update ${type}`)}
+      open={open}
+      onClose={handleClose}
+      context={editContext}
+    >
+      <WorkspaceEditionOverview
+        workspace={props.workspace}
         context={editContext}
-      >
-        <WorkspaceEditionOverview
-          workspace={this.props.workspace}
-          context={editContext}
-        />
-      </Drawer>
-    );
-  }
-}
+      />
+    </Drawer>
+  );
+};
 
 WorkspaceEditionContainer.propTypes = {
   handleClose: PropTypes.func,
   workspace: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
   type: PropTypes.oneOf(['dashboard', 'investigation']),
 };
 
@@ -50,6 +47,4 @@ const WorkspaceEditionFragment = createFragmentContainer(
   },
 );
 
-export default compose(
-  inject18n,
-)(WorkspaceEditionFragment);
+export default WorkspaceEditionFragment;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/Investigation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/Investigation.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import { QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import InvestigationGraph, { investigationGraphQuery } from './InvestigationGraph';
 import Loader from '../../../../components/Loader';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -18,38 +17,35 @@ const styles = (theme) => ({
   },
 });
 
-class InvestigationComponent extends Component {
-  render() {
-    const { classes, workspace } = this.props;
-    return (
-      <div className={classes.container} id="container">
-        <QueryRenderer
-          query={investigationGraphQuery}
-          variables={{ id: workspace.id }}
-          render={({ props }) => {
-            if (props) {
-              if (props.workspace) {
-                return (
-                  <InvestigationGraph
-                    id={workspace.id}
-                    data={props.workspace}
-                  />
-                );
-              }
-              return <ErrorNotFound />;
+const InvestigationComponent = (props) => {
+  const { classes, workspace } = props;
+  return (
+    <div className={classes.container} id="container">
+      <QueryRenderer
+        query={investigationGraphQuery}
+        variables={{ id: workspace.id }}
+        render={({ props }) => {
+          if (props) {
+            if (props.workspace) {
+              return (
+                <InvestigationGraph
+                  id={workspace.id}
+                  data={props.workspace}
+                />
+              );
             }
-            return <Loader />;
-          }}
-        />
-      </div>
-    );
-  }
-}
+            return <ErrorNotFound />;
+          }
+          return <Loader />;
+        }}
+      />
+    </div>
+  );
+};
 
 InvestigationComponent.propTypes = {
   workspace: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
 const Investigation = createFragmentContainer(InvestigationComponent, {
@@ -69,4 +65,4 @@ const Investigation = createFragmentContainer(InvestigationComponent, {
   `,
 });
 
-export default compose(inject18n, withStyles(styles))(Investigation);
+export default compose(withStyles(styles))(Investigation);


### PR DESCRIPTION
Closes #17967

> **Stacked on #17966.** The base branch is `issue/17965-inject18n-useformatter`, so this diff only shows this tranche. Merge #17966 first; GitHub then retargets this PR to `master` on its own.

## Proposed changes

First tranche of #17967: the 60 `inject18n` consumers whose class carries **no state, no lifecycle method and no ref**. `render()` becomes the function body, the injected props come from `useFormatter`, and the HOC wrapper goes away.

`inject18n` still stands for the 74 remaining class components, which need state, lifecycle and ref conversions and will come in later tranches — the largest ones (`StixCoreRelationshipOverview`, 4877 lines; `DataTableToolBar`, 3518) last.

## What the conversion surfaced

Three latent problems that a class hid, each worth a look on its own:

**`ListCards` declared both a `sortBy` method and a `sortBy` prop.** Distinct as `this.sortBy` and `sortBy` inside a class, a duplicate declaration once both become consts. The method is renamed `handleSortBy`.

**`EntityStixSightingRelationshipsDonut` carried 50 lines of dead code.** Its constructor bound `renderLabel` and `renderSimpleLabel`, neither of which was ever called. `no-unused-vars` does not look at class methods, so nothing flagged it. Both are removed along with the constructor, which existed only for those bindings.

**Four components only needed `withRouter`**, whose own JSDoc says *"Use React Router hooks instead"*. As function components they call `useParams` directly. `SystemAnalysis` turned out never to read a router prop at all, so it is simply unwrapped.

That last point also fixed a typing problem: with `inject18n` gone from the `compose()` chain, `withRouter` typed the wrapped component as accepting no props at all, which made 19 call sites fail `check-ts`. Calling the hook removes the wrapper and the errors with it.

## How it was done

Scripted transformation plus review, not 60 hand edits. The script refused anything it could not prove safe — a class with a constructor, a name clash between a member and a prop — and those cases were done by hand. Two rounds of verification caught real defects in its output, including multi-line `this.props` destructurings whose injected props would have silently become `undefined` at runtime.

## Verification

Measured against the base branch, which is clean on all four:

| | base | this branch |
|---|---|---|
| `yarn check-ts` | 0 errors | 0 errors |
| `yarn lint` on touched files | clean | clean |
| `yarn build` | passes | passes |
| `TZ=UTC yarn test` | 150 files / 1326 tests | 150 files / 1326 tests |
| `verify-translation` | passes | passes |

Also checked across the 60 files: no `extends Component`, no `this.`, no `inject18n` reference left, and no injected prop still destructured from `props`.

## Related issues

Closes #17967

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/updated the relevant documentation (not applicable, internal refactor)
