### PR TITLE
refactor(frontend): convert the stateful inject18n classes to function components (#17971)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Button from '@common/button/Button';
 import { ArrowDropDown, ArrowDropUp, FileDownloadOutlined, LibraryBooksOutlined, SettingsOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import Alert from '@mui/material/Alert';
@@ -21,7 +22,6 @@ import { ListViewIcon, SublistViewIcon } from 'filigran-icon';
 import { FileDelimitedOutline, FormatListGroup, Group, RelationManyToMany, VectorPolygon } from 'mdi-material-ui';
 import * as PropTypes from 'prop-types';
 import { compose, toPairs, uniq } from 'ramda';
-import { Component } from 'react';
 import { ErrorBoundary } from '../../private/components/Error';
 import FiligranIcon from '../../private/components/common/FiligranIcon';
 import Filters from '../../private/components/common/lists/Filters';
@@ -36,7 +36,7 @@ import { KNOWLEDGE_KNGETEXPORT } from '../../utils/hooks/useGranted';
 import { export_max_size } from '../../utils/utils';
 import FilterIconButton from '../FilterIconButton';
 import SearchInput from '../SearchInput';
-import inject18n from '../i18n';
+import { useFormatter } from '../i18n';
 
 const styles = (theme) => ({
   container: {
@@ -114,26 +114,23 @@ const styles = (theme) => ({
   },
 });
 
-class ListLines extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { openSettings: false };
-  }
+const ListLines = (props) => {
+  const { t_i18n } = useFormatter();
+  const [openSettings, setOpenSettings] = useState(false);
+  const handleOpenSettings = () => {
+    setOpenSettings(true);
+  };
 
-  handleOpenSettings() {
-    this.setState({ openSettings: true });
-  }
+  const handleCloseSettings = () => {
+    setOpenSettings(false);
+  };
 
-  handleCloseSettings() {
-    this.setState({ openSettings: false });
-  }
+  const reverseBy = (field) => {
+    props.handleSort(field, !props.orderAsc);
+  };
 
-  reverseBy(field) {
-    this.props.handleSort(field, !this.props.orderAsc);
-  }
-
-  renderHeaderElement(field, label, width, isSortable) {
-    const { classes, t, sortBy, orderAsc } = this.props;
+  const renderHeaderElement = (field, label, width, isSortable) => {
+    const { classes, sortBy, orderAsc } = props;
     if (isSortable) {
       const orderComponent = orderAsc ? (<ArrowDropDown />) : (<ArrowDropUp />);
       return (
@@ -141,9 +138,9 @@ class ListLines extends Component {
           key={field}
           className={classes.sortableHeaderItem}
           style={{ width }}
-          onClick={this.reverseBy.bind(this, field)}
+          onClick={reverseBy.bind(null, field)}
         >
-          <div className={classes.headerItemText}>{t(label)}</div>
+          <div className={classes.headerItemText}>{t_i18n(label)}</div>
           {sortBy === field ? orderComponent : ''}
         </div>
       );
@@ -154,14 +151,13 @@ class ListLines extends Component {
         style={{ width }}
         key={field}
       >
-        <div className={classes.headerItemText}>{t(label)}</div>
+        <div className={classes.headerItemText}>{t_i18n(label)}</div>
       </div>
     );
-  }
+  };
 
-  renderContent(availableFilterKeys, entityTypes, selectedIds = []) {
+  const renderContent = (availableFilterKeys, entityTypes, selectedIds = []) => {
     const {
-      t,
       classes,
       handleSearch,
       handleChangeView,
@@ -209,7 +205,7 @@ class ListLines extends Component {
       inline,
       additionalFilterKeys,
       createButton,
-    } = this.props;
+    } = props;
     const exportDisabled = numberOfElements
       && ((selectedIds.length > export_max_size
         && numberOfElements.number > export_max_size)
@@ -233,7 +229,7 @@ class ListLines extends Component {
             {typeof handleSearch === 'function' && (
               <SearchInput
                 variant={searchVariant || 'small'}
-                onSubmit={handleSearch.bind(this)}
+                onSubmit={handleSearch}
                 keyword={keyword}
               />
             )}
@@ -267,7 +263,7 @@ class ListLines extends Component {
                   }
                 >
                   <strong>{`${numberOfElements.number}${numberOfElements.symbol}`}</strong>{' '}
-                  {t('entitie(s)')}
+                  {t_i18n('entitie(s)')}
                 </div>
               )}
               {(typeof handleChangeView === 'function'
@@ -282,7 +278,7 @@ class ListLines extends Component {
                     if (value && value === 'export') {
                       handleToggleExports();
                     } else if (value && value === 'settings') {
-                      this.handleOpenSettings();
+                      handleOpenSettings();
                     } else if (value && value !== 'export-csv') {
                       handleChangeView(value);
                     }
@@ -290,7 +286,7 @@ class ListLines extends Component {
                 >
                   {typeof handleChangeView === 'function' && !disableCards && (
                     <ToggleButton value="cards" aria-label="cards">
-                      <Tooltip title={t('Cards view')}>
+                      <Tooltip title={t_i18n('Cards view')}>
                         <ViewModuleOutlined fontSize="small" color="primary" />
                       </Tooltip>
                     </ToggleButton>
@@ -298,7 +294,7 @@ class ListLines extends Component {
                   {typeof handleChangeView === 'function'
                     && enableEntitiesView && (
                     <ToggleButton value="entities" aria-label="entities">
-                      <Tooltip title={t('Entities view')}>
+                      <Tooltip title={t_i18n('Entities view')}>
                         <LibraryBooksOutlined
                           fontSize="small"
                         />
@@ -306,7 +302,7 @@ class ListLines extends Component {
                     </ToggleButton>
                   )}
                   {(enableEntitiesView || (!enableEntitiesView && currentView === 'entities') || currentView === 'relationships') && (
-                    <Tooltip title={t('Relationships view')}>
+                    <Tooltip title={t_i18n('Relationships view')}>
                       <ToggleButton
                         value="relationships"
                         aria-label="relationships"
@@ -319,14 +315,14 @@ class ListLines extends Component {
                   )}
 
                   {typeof handleChangeView === 'function' && !enableEntitiesView && currentView !== 'relationships' && currentView !== 'entities' && (
-                    <Tooltip title={t('Lines view')}>
+                    <Tooltip title={t_i18n('Lines view')}>
                       <ToggleButton value="lines" aria-label="lines">
                         <FiligranIcon icon={ListViewIcon} size="small" />
                       </ToggleButton>
                     </Tooltip>
                   )}
                   {typeof handleChangeView === 'function' && enableGraph && (
-                    <Tooltip title={t('Graph view')}>
+                    <Tooltip title={t_i18n('Graph view')}>
                       <ToggleButton value="graph" aria-label="graph">
                         <VectorPolygon fontSize="small" />
                       </ToggleButton>
@@ -334,7 +330,7 @@ class ListLines extends Component {
                   )}
                   {typeof handleChangeView === 'function'
                     && enableNestedView && (
-                    <Tooltip title={t('Nested view')}>
+                    <Tooltip title={t_i18n('Nested view')}>
                       <ToggleButton value="nested" aria-label="nested">
                         <FormatListGroup fontSize="small" />
                       </ToggleButton>
@@ -344,7 +340,7 @@ class ListLines extends Component {
                     && enableContextualView && (
                     <ToggleButton value="contextual" aria-label="contextual">
                       <Tooltip
-                        title={t('Knowledge from related containers view')}
+                        title={t_i18n('Knowledge from related containers view')}
                       >
                         <Group
                           fontSize="small"
@@ -353,14 +349,14 @@ class ListLines extends Component {
                     </ToggleButton>
                   )}
                   {typeof handleChangeView === 'function' && enableSubEntityLines && (
-                    <Tooltip title={t('Sub entity lines view')}>
+                    <Tooltip title={t_i18n('Sub entity lines view')}>
                       <ToggleButton value="subEntityLines" aria-label="subEntityLines">
                         <FiligranIcon icon={SublistViewIcon} size="small" />
                       </ToggleButton>
                     </Tooltip>
                   )}
                   {handleSwitchRedirectionMode && (
-                    <Tooltip title={t('List settings')}>
+                    <Tooltip title={t_i18n('List settings')}>
                       <ToggleButton
                         size="small"
                         value="settings"
@@ -372,7 +368,7 @@ class ListLines extends Component {
                   )}
                   {typeof handleToggleExports === 'function'
                     && !exportDisabled && (
-                    <Tooltip title={t('Open export panel')}>
+                    <Tooltip title={t_i18n('Open export panel')}>
                       <ToggleButton value="export" aria-label="export">
                         <FileDownloadOutlined
                           fontSize="small"
@@ -381,7 +377,7 @@ class ListLines extends Component {
                     </Tooltip>
                   )}
                   {typeof handleExportCsv === 'function' && !exportDisabled && (
-                    <Tooltip title={t('Export first 5000 rows in CSV')}>
+                    <Tooltip title={t_i18n('Export first 5000 rows in CSV')}>
                       <ToggleButton
                         value="export-csv"
                         onClick={() => handleExportCsv()}
@@ -397,7 +393,7 @@ class ListLines extends Component {
                     && exportDisabled && (
                     <Tooltip
                       title={`${
-                        t(
+                        t_i18n(
                           'Export is disabled because too many entities are targeted (maximum number of entities is: ',
                         ) + export_max_size
                       })`}
@@ -473,7 +469,7 @@ class ListLines extends Component {
                       disableRipple={true}
                       onChange={
                         typeof handleToggleSelectAll === 'function'
-                        && handleToggleSelectAll.bind(this)
+                        && handleToggleSelectAll
                       }
                       disabled={typeof handleToggleSelectAll !== 'function'}
                     />
@@ -490,7 +486,7 @@ class ListLines extends Component {
                 <ListItemText
                   primary={(
                     <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                      {toPairs(dataColumns).map((dataColumn) => this.renderHeaderElement(
+                      {toPairs(dataColumns).map((dataColumn) => renderHeaderElement(
                         dataColumn[0],
                         dataColumn[1].label,
                         dataColumn[1].width,
@@ -510,7 +506,7 @@ class ListLines extends Component {
             <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
               <StixDomainObjectsExports
                 open={openExports}
-                handleToggle={handleToggleExports.bind(this)}
+                handleToggle={handleToggleExports}
                 paginationOptions={paginationOptions}
                 exportContext={exportContext}
               />
@@ -521,7 +517,7 @@ class ListLines extends Component {
             <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
               <StixCoreRelationshipsExports
                 open={openExports}
-                handleToggle={handleToggleExports.bind(this)}
+                handleToggle={handleToggleExports}
                 paginationOptions={paginationOptions}
                 exportContext={exportContext}
               />
@@ -532,7 +528,7 @@ class ListLines extends Component {
             <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
               <StixCoreObjectsExports
                 open={openExports}
-                handleToggle={handleToggleExports.bind(this)}
+                handleToggle={handleToggleExports}
                 paginationOptions={paginationOptions}
                 exportContext={exportContext}
               />
@@ -543,7 +539,7 @@ class ListLines extends Component {
             <Security needs={[KNOWLEDGE_KNGETEXPORT]}>
               <StixCyberObservablesExports
                 open={openExports}
-                handleToggle={handleToggleExports.bind(this)}
+                handleToggle={handleToggleExports}
                 paginationOptions={paginationOptions}
                 exportContext={exportContext}
               />
@@ -551,14 +547,14 @@ class ListLines extends Component {
           )}
           {handleSwitchRedirectionMode && (
             <Dialog
-              open={this.state.openSettings}
-              onClose={this.handleCloseSettings.bind(this)}
+              open={openSettings}
+              onClose={handleCloseSettings}
               size="small"
-              title={t('List settings')}
+              title={t_i18n('List settings')}
             >
               <FormControl style={{ width: '100%' }}>
                 <InputLabel id="redirectionMode">
-                  {t('Redirection mode')}
+                  {t_i18n('Redirection mode')}
                 </InputLabel>
                 <Select
                   value={redirectionMode}
@@ -567,20 +563,20 @@ class ListLines extends Component {
                   fullWidth={true}
                 >
                   <MenuItem value="overview">
-                    {t('Redirecting to the Overview section')}
+                    {t_i18n('Redirecting to the Overview section')}
                   </MenuItem>
                   <MenuItem value="knowledge">
-                    {t('Redirecting to the Knowledge section')}
+                    {t_i18n('Redirecting to the Knowledge section')}
                   </MenuItem>
                   <MenuItem value="content">
-                    {t('Redirecting to the Content section')}
+                    {t_i18n('Redirecting to the Content section')}
                   </MenuItem>
                 </Select>
               </FormControl>
 
               <DialogActions>
-                <Button onClick={this.handleCloseSettings.bind(this)}>
-                  {t('Close')}
+                <Button onClick={handleCloseSettings}>
+                  {t_i18n('Close')}
                 </Button>
               </DialogActions>
             </Dialog>
@@ -588,43 +584,40 @@ class ListLines extends Component {
         </ErrorBoundary>
       </div>
     );
-  }
+  };
 
-  render() {
-    const { disableExport, exportContext, additionalFilterKeys } = this.props;
-    const entityTypes = this.props.entityTypes ?? (exportContext?.entity_type ? [exportContext?.entity_type] : undefined);
-    return (
-      <UserContext.Consumer>
-        {({ schema }) => {
-          let availableFilterKeys = this.props.availableFilterKeys ?? [];
-          if (availableFilterKeys.length === 0 && entityTypes) {
-            const filterKeysMap = new Map();
-            entityTypes.forEach((entityType) => {
-              const currentMap = schema.filterKeysSchema.get(entityType);
-              currentMap?.forEach((value, key) => filterKeysMap.set(key, value));
-            });
-            availableFilterKeys = uniq(Array.from(filterKeysMap.keys())); // keys of the entity type if availableFilterKeys is not specified
-          }
-          if (additionalFilterKeys && additionalFilterKeys.filterKeys) availableFilterKeys = uniq(availableFilterKeys.concat(additionalFilterKeys.filterKeys));
-          if (disableExport) {
-            return this.renderContent(availableFilterKeys, entityTypes);
-          }
-          return (
-            <ExportContext.Consumer>
-              {({ selectedIds }) => {
-                return this.renderContent(availableFilterKeys, entityTypes, selectedIds);
-              }}
-            </ExportContext.Consumer>
-          );
-        }}
-      </UserContext.Consumer>
-    );
-  }
-}
+  const { disableExport, exportContext, additionalFilterKeys } = props;
+  const entityTypes = props.entityTypes ?? (exportContext?.entity_type ? [exportContext?.entity_type] : undefined);
+  return (
+    <UserContext.Consumer>
+      {({ schema }) => {
+        let availableFilterKeys = props.availableFilterKeys ?? [];
+        if (availableFilterKeys.length === 0 && entityTypes) {
+          const filterKeysMap = new Map();
+          entityTypes.forEach((entityType) => {
+            const currentMap = schema.filterKeysSchema.get(entityType);
+            currentMap?.forEach((value, key) => filterKeysMap.set(key, value));
+          });
+          availableFilterKeys = uniq(Array.from(filterKeysMap.keys())); // keys of the entity type if availableFilterKeys is not specified
+        }
+        if (additionalFilterKeys && additionalFilterKeys.filterKeys) availableFilterKeys = uniq(availableFilterKeys.concat(additionalFilterKeys.filterKeys));
+        if (disableExport) {
+          return renderContent(availableFilterKeys, entityTypes);
+        }
+        return (
+          <ExportContext.Consumer>
+            {({ selectedIds }) => {
+              return renderContent(availableFilterKeys, entityTypes, selectedIds);
+            }}
+          </ExportContext.Consumer>
+        );
+      }}
+    </UserContext.Consumer>
+  );
+};
 
 ListLines.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
   children: PropTypes.object,
   handleSearch: PropTypes.func,
   handleSort: PropTypes.func,
@@ -678,4 +671,4 @@ ListLines.propTypes = {
   createButton: PropTypes.object,
 };
 
-export default compose(inject18n, withStyles(styles))(ListLines);
+export default compose(withStyles(styles))(ListLines);

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import ChannelEditionContainer from './ChannelEditionContainer';
 import { channelEditionOverviewFocus } from './ChannelEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,58 +15,43 @@ export const channelEditionQuery = graphql`
   }
 `;
 
-class ChannelEdition extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-  }
-
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
+const ChannelEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: channelEditionOverviewFocus,
       variables: {
-        id: this.props.channelId,
+        id: props.channelId,
         input: { focusOn: '' },
       },
     });
-    this.setState({ open: false });
-  }
+  };
 
-  render() {
-    const { channelId } = this.props;
-    return (
-      <QueryRenderer
-        query={channelEditionQuery}
-        variables={{ id: channelId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <ChannelEditionContainer
-                channel={props.channel}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { channelId } = props;
+  return (
+    <QueryRenderer
+      query={channelEditionQuery}
+      variables={{ id: channelId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <ChannelEditionContainer
+              channel={props.channel}
+              handleClose={handleClose}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 ChannelEdition.propTypes = {
   channelId: PropTypes.string,
   me: PropTypes.object,
   classes: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(ChannelEdition);
+export default ChannelEdition;

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwares.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/AddSoftwares.jsx
@@ -1,95 +1,90 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddSoftwaresLines, { addSoftwaresLinesQuery } from './AddSoftwaresLines';
 import StixCyberObservableCreation from '../../observations/stix_cyber_observables/StixCyberObservableCreation';
 import Drawer from '../../common/drawer/Drawer';
 
-class AddSoftwares extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddSoftwares = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, vulnerability, vulnerabilitySoftwares, relationshipType } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    return (
-      <div>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add software')}
-          subHeader={{
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
+  const { vulnerability, vulnerabilitySoftwares, relationshipType } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  return (
+    <div>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add software')}
+        subHeader={{
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addSoftwaresLinesQuery}
+          variables={{ ...paginationOptions, count: 25 }}
+          render={({ props }) => {
+            return (
+              <AddSoftwaresLines
+                vulnerability={vulnerability}
+                vulnerabilitySoftwares={vulnerabilitySoftwares}
+                relationshipType={relationshipType}
+                data={props}
               />
-            )],
+            );
           }}
-        >
-          <QueryRenderer
-            query={addSoftwaresLinesQuery}
-            variables={{ ...paginationOptions, count: 25 }}
-            render={({ props }) => {
-              return (
-                <AddSoftwaresLines
-                  vulnerability={vulnerability}
-                  vulnerabilitySoftwares={vulnerabilitySoftwares}
-                  relationshipType={relationshipType}
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-        <StixCyberObservableCreation
-          display={this.state.open}
-          contextual={true}
-          inputValue={this.state.search}
-          paginationOptions={{ ...paginationOptions, types: ['Software'] }}
-          paginationKey="Pagination_stixCyberObservables"
-          type="Software"
         />
-      </div>
-    );
-  }
-}
+      </Drawer>
+      <StixCyberObservableCreation
+        display={open}
+        contextual={true}
+        inputValue={search}
+        paginationOptions={{ ...paginationOptions, types: ['Software'] }}
+        paginationKey="Pagination_stixCyberObservables"
+        type="Software"
+      />
+    </div>
+  );
+};
 
 AddSoftwares.propTypes = {
   vulnerability: PropTypes.object,
   vulnerabilitySoftwares: PropTypes.array,
   relationshipType: PropTypes.string,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddSoftwares);
+export default AddSoftwares;

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectPopover.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import Dialog from '@common/dialog/Dialog';
@@ -13,10 +14,9 @@ import { Form, Formik } from 'formik';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { compose } from 'ramda';
-import { Component } from 'react';
 import { graphql } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import { serializeObjectB64 } from '../../../../utils/object';
@@ -89,78 +89,76 @@ export const containerStixCoreObjectPopoverDeleteMutation = graphql`
   }
 `;
 
-class ContainerStixCoreObjectPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDeleteMapping: false,
-      displayRemove: false,
-      displayDelete: false,
-      removing: false,
-      deleting: false,
-      deletingMapping: false,
-      referenceDialogOpened: false,
-    };
-  }
-
-  handleOpen(event) {
+const ContainerStixCoreObjectPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDeleteMapping, setDisplayDeleteMapping] = useState(false);
+  const [displayRemove, setDisplayRemove] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deletingMapping, setDeletingMapping] = useState(false);
+  const [referenceDialogOpened, setReferenceDialogOpened] = useState(false);
+  const handleOpen = (event) => {
     stopEvent(event);
-    this.setState({ anchorEl: event.currentTarget });
-  }
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleOpenRemove() {
-    this.setState({ displayRemove: true });
-    this.handleClose();
-  }
+  const handleOpenRemove = () => {
+    setDisplayRemove(true);
+    handleClose();
+  };
 
-  handleCloseRemove() {
-    this.setState({ removing: false, displayRemove: false });
-  }
+  const handleCloseRemove = () => {
+    setRemoving(false);
+    setDisplayRemove(false);
+  };
 
-  handleSubmitRemove() {
-    const { enableReferences } = this.props;
+  const handleSubmitRemove = () => {
+    const { enableReferences } = props;
     if (enableReferences) {
-      this.setState({ referenceDialogOpened: true });
+      setReferenceDialogOpened(true);
     } else {
-      this.submitRemove();
+      submitRemove();
     }
-  }
+  };
 
-  handleOpenDeleteMapping() {
-    this.setState({ displayDeleteMapping: true });
-    this.handleClose();
-  }
+  const handleOpenDeleteMapping = () => {
+    setDisplayDeleteMapping(true);
+    handleClose();
+  };
 
-  handleCloseDeleteMapping() {
-    this.setState({ deletingMapping: false, displayDeleteMapping: false });
-  }
+  const handleCloseDeleteMapping = () => {
+    setDeletingMapping(false);
+    setDisplayDeleteMapping(false);
+  };
 
-  handleSubmitDeleteMapping() {
-    const { enableReferences } = this.props;
+  const handleSubmitDeleteMapping = () => {
+    const { enableReferences } = props;
     if (enableReferences) {
-      this.setState({ referenceDialogOpened: true });
+      setReferenceDialogOpened(true);
     } else {
-      this.submitDeleteMapping();
+      submitDeleteMapping();
     }
-  }
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleCloseDelete() {
-    this.setState({ deleting: false, displayDelete: false });
-  }
+  const handleCloseDelete = () => {
+    setDeleting(false);
+    setDisplayDelete(false);
+  };
 
-  submitDeleteMapping(commitMessage = '', references = [], setSubmitting = null, resetForm = null) {
-    const { containerId, toStandardId, contentMappingData } = this.props;
-    this.setState({ deletingMapping: true });
+  const submitDeleteMapping = (commitMessage = '', references = [], setSubmitting = null, resetForm = null) => {
+    const { containerId, toStandardId, contentMappingData } = props;
+    setDeletingMapping(true);
     const newMappingData = deleteElementByValue(contentMappingData, toStandardId);
     commitMutation({
       mutation: containerStixCoreObjectPopoverFieldPatchMutation,
@@ -174,14 +172,14 @@ class ContainerStixCoreObjectPopover extends Component {
         references,
       },
       onCompleted: () => {
-        this.handleCloseDeleteMapping();
+        handleCloseDeleteMapping();
         if (setSubmitting) setSubmitting(false);
         if (resetForm) resetForm(true);
       },
     });
-  }
+  };
 
-  submitRemove(commitMessage = '', references = [], setSubmitting = null, resetForm = null) {
+  const submitRemove = (commitMessage = '', references = [], setSubmitting = null, resetForm = null) => {
     const {
       containerId,
       toId,
@@ -190,8 +188,8 @@ class ContainerStixCoreObjectPopover extends Component {
       paginationOptions,
       selectedElements,
       setSelectedElements,
-    } = this.props;
-    this.setState({ removing: true });
+    } = props;
+    setRemoving(true);
     commitMutation({
       mutation: containerStixCoreObjectPopoverRemoveMutation,
       variables: {
@@ -216,16 +214,16 @@ class ContainerStixCoreObjectPopover extends Component {
         }
       },
       onCompleted: () => {
-        this.submitDeleteMapping(commitMessage, references, setSubmitting, resetForm);
-        this.handleCloseRemove();
+        submitDeleteMapping(commitMessage, references, setSubmitting, resetForm);
+        handleCloseRemove();
         const newSelectedElements = R.omit([toId], selectedElements);
         setSelectedElements?.(newSelectedElements);
       },
       setSubmitting,
     });
-  }
+  };
 
-  submitDelete() {
+  const submitDelete = () => {
     const {
       containerId,
       toId,
@@ -233,8 +231,8 @@ class ContainerStixCoreObjectPopover extends Component {
       paginationOptions,
       selectedElements,
       setSelectedElements,
-    } = this.props;
-    this.setState({ deleting: true });
+    } = props;
+    setDeleting(true);
     commitMutation({
       mutation: containerStixCoreObjectPopoverDeleteMutation,
       variables: {
@@ -255,170 +253,166 @@ class ContainerStixCoreObjectPopover extends Component {
         }
       },
       onCompleted: () => {
-        this.handleCloseDelete();
+        handleCloseDelete();
         const newSelectedElements = R.omit([toId], selectedElements);
         setSelectedElements?.(newSelectedElements);
       },
     });
-  }
+  };
 
-  closeReferencesPopup() {
-    this.setState({ referenceDialogOpened: false });
-  }
+  const closeReferencesPopup = () => {
+    setReferenceDialogOpened(false);
+  };
 
-  submitReference(values, { setSubmitting, resetForm }) {
-    const { displayRemove, displayDeleteMapping } = this.state;
+  const submitReference = (values, { setSubmitting, resetForm }) => {
     const references = (values.references || []).map((ref) => ref.value);
-    if (displayRemove) this.submitRemove(values.message, references, setSubmitting, resetForm);
-    else if (displayDeleteMapping) this.submitDeleteMapping(values.message, references, setSubmitting, resetForm);
-  }
+    if (displayRemove) submitRemove(values.message, references, setSubmitting, resetForm);
+    else if (displayDeleteMapping) submitDeleteMapping(values.message, references, setSubmitting, resetForm);
+  };
 
-  render() {
-    const { classes, t, theme, contentMappingData, mapping, containerId, enableReferences } = this.props;
-    const { referenceDialogOpened } = this.state;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          color="primary"
-          onClick={this.handleOpen.bind(this)}
-          disabled={this.props.menuDisable ?? false}
-          aria-haspopup="true"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          {contentMappingData && mapping && mapping > 0 && (
-            <MenuItem onClick={this.handleOpenDeleteMapping.bind(this)}>
-              {t('Delete mapping')}
-            </MenuItem>
-          )}
-          <MenuItem onClick={this.handleOpenRemove.bind(this)}>
-            {t('Remove')}
+  const { classes, theme, contentMappingData, mapping, containerId, enableReferences } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        color="primary"
+        onClick={handleOpen}
+        disabled={props.menuDisable ?? false}
+        aria-haspopup="true"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        {contentMappingData && mapping && mapping > 0 && (
+          <MenuItem onClick={handleOpenDeleteMapping}>
+            {t_i18n('Delete mapping')}
           </MenuItem>
-          <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-            <MenuItem
-              onClick={this.handleOpenDelete.bind(this)}
-              style={{ color: theme.palette.warning.main }}
-            >
-              {t('Delete')}
-            </MenuItem>
-          </Security>
-        </Menu>
-        <Dialog
-          open={this.state.displayDeleteMapping}
-          onClose={this.handleCloseDeleteMapping.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to delete the mapping for this entity?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDeleteMapping.bind(this)}
-              disabled={this.state.deletingMapping}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.handleSubmitDeleteMapping.bind(this)}
-              disabled={this.state.deletingMapping}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          open={this.state.displayRemove}
-          onClose={this.handleCloseRemove.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to remove the entity from this container?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseRemove.bind(this)}
-              disabled={this.state.removing}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.handleSubmitRemove.bind(this)}
-              disabled={this.state.removing}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        {enableReferences && (
-          <Formik
-            initialValues={{ message: '', references: [] }}
-            onSubmit={this.submitReference.bind(this)}
-          >
-            {({
-              submitForm,
-              isSubmitting,
-              setFieldValue,
-              values,
-            }) => (
-              <Form>
-                <CommitMessage
-                  handleClose={this.closeReferencesPopup.bind(this)}
-                  open={referenceDialogOpened}
-                  submitForm={submitForm}
-                  disabled={isSubmitting}
-                  setFieldValue={setFieldValue}
-                  values={values.references}
-                  id={containerId}
-                  noStoreUpdate={true}
-                />
-              </Form>
-            )}
-          </Formik>
         )}
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
+        <MenuItem onClick={handleOpenRemove}>
+          {t_i18n('Remove')}
+        </MenuItem>
+        <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+          <MenuItem
+            onClick={handleOpenDelete}
+            style={{ color: theme.palette.warning.main }}
+          >
+            {t_i18n('Delete')}
+          </MenuItem>
+        </Security>
+      </Menu>
+      <Dialog
+        open={displayDeleteMapping}
+        onClose={handleCloseDeleteMapping}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete the mapping for this entity?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDeleteMapping}
+            disabled={deletingMapping}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmitDeleteMapping}
+            disabled={deletingMapping}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={displayRemove}
+        onClose={handleCloseRemove}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to remove the entity from this container?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseRemove}
+            disabled={removing}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmitRemove}
+            disabled={removing}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      {enableReferences && (
+        <Formik
+          initialValues={{ message: '', references: [] }}
+          onSubmit={submitReference}
         >
-          <DialogContentText>
-            {t('Do you want to delete this entity?')}
-            <Alert severity="warning" variant="outlined" style={{ marginTop: 20 }}>
-              {t(
-                'You are about to completely delete the entity from the platform (not only from the container), be sure of what you are doing.',
-              )}
-            </Alert>
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+          {({
+            submitForm,
+            isSubmitting,
+            setFieldValue,
+            values,
+          }) => (
+            <Form>
+              <CommitMessage
+                handleClose={closeReferencesPopup}
+                open={referenceDialogOpened}
+                submitForm={submitForm}
+                disabled={isSubmitting}
+                setFieldValue={setFieldValue}
+                values={values.references}
+                id={containerId}
+                noStoreUpdate={true}
+              />
+            </Form>
+          )}
+        </Formik>
+      )}
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this entity?')}
+          <Alert severity="warning" variant="outlined" style={{ marginTop: 20 }}>
+            {t_i18n(
+              'You are about to completely delete the entity from the platform (not only from the container), be sure of what you are doing.',
+            )}
+          </Alert>
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 ContainerStixCoreObjectPopover.propTypes = {
   containerId: PropTypes.string,
@@ -428,7 +422,6 @@ ContainerStixCoreObjectPopover.propTypes = {
   paginationKey: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   selectedElements: PropTypes.object,
   setSelectedElements: PropTypes.func,
   contentMappingData: PropTypes.object,
@@ -437,7 +430,6 @@ ContainerStixCoreObjectPopover.propTypes = {
 };
 
 export default compose(
-  inject18n,
   withTheme,
   withStyles(styles),
 )(ContainerStixCoreObjectPopover);

--- a/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
@@ -6,15 +6,13 @@ import withStyles from '@mui/styles/withStyles';
 import { Field, Form, Formik } from 'formik';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { compose } from 'ramda';
-import { Component } from 'react';
 import { graphql } from 'react-relay';
 import { v4 as uuid } from 'uuid';
 import * as Yup from 'yup';
 import TextField from '../../../../components/TextField';
 import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { ExternalReferencesField } from '../form/ExternalReferencesField';
@@ -80,29 +78,17 @@ const identityValidation = (t) => Yup.object().shape({
   type: Yup.string().trim().required(t('This field is required')),
 });
 
-class IdentityCreation extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-  }
-
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
-    this.setState({ open: false });
-  }
-
-  onSubmit(values, { setSubmitting, resetForm }) {
-    if (this.props.dryrun && this.props.contextual) {
-      this.props.creationCallback({
+const IdentityCreation = (props) => {
+  const { t_i18n } = useFormatter();
+  const onSubmit = (values, { setSubmitting, resetForm }) => {
+    if (props.dryrun && props.contextual) {
+      props.creationCallback({
         identityAdd: {
           ...values,
           id: `identity--${uuid()}`,
         },
       });
-      return this.props.handleClose();
+      return props.handleClose();
     }
     const finalValues = R.pipe(
       R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
@@ -118,129 +104,124 @@ class IdentityCreation extends Component {
       onCompleted: (response) => {
         setSubmitting(false);
         resetForm();
-        if (this.props.contextual) {
-          this.props.creationCallback(response);
-          this.props.handleClose();
-        } else {
-          this.handleClose();
+        if (props.contextual) {
+          props.creationCallback(response);
+          props.handleClose();
         }
       },
     });
-  }
+  };
 
-  onResetContextual() {
-    this.props.handleClose();
-  }
+  const onResetContextual = () => {
+    props.handleClose();
+  };
 
-  render() {
-    const { t, inputValue, open, onlyAuthors, handleClose, dryrun } = this.props;
-    return (
-      <>
-        <Formik
-          enableReinitialize={true}
-          initialValues={{
-            name: inputValue,
-            description: '',
-            type: '',
-            objectMarking: [],
-            objectLabel: [],
-            externalReferences: [],
-          }}
-          validationSchema={identityValidation(t)}
-          onSubmit={this.onSubmit.bind(this)}
-          onReset={this.onResetContextual.bind(this)}
-        >
-          {({
-            submitForm,
-            handleReset,
-            isSubmitting,
-            setFieldValue,
-            values,
-          }) => (
-            <Form>
-              <Dialog
-                open={open}
-                onClose={handleClose.bind(this)}
-                title={t('Create an entity')}
+  const { inputValue, open, onlyAuthors, handleClose, dryrun } = props;
+  return (
+    <>
+      <Formik
+        enableReinitialize={true}
+        initialValues={{
+          name: inputValue,
+          description: '',
+          type: '',
+          objectMarking: [],
+          objectLabel: [],
+          externalReferences: [],
+        }}
+        validationSchema={identityValidation(t_i18n)}
+        onSubmit={onSubmit}
+        onReset={onResetContextual}
+      >
+        {({
+          submitForm,
+          handleReset,
+          isSubmitting,
+          setFieldValue,
+          values,
+        }) => (
+          <Form>
+            <Dialog
+              open={open}
+              onClose={handleClose}
+              title={t_i18n('Create an entity')}
+            >
+              <Field
+                component={TextField}
+                variant="standard"
+                name="name"
+                label={t_i18n('Name')}
+                fullWidth={true}
+                detectDuplicate={['Organization', 'Individual']}
+              />
+              <Field
+                component={MarkdownField}
+                name="description"
+                label={t_i18n('Description')}
+                fullWidth={true}
+                multiline={true}
+                rows="4"
+                style={{ marginTop: 20 }}
+              />
+              <Field
+                component={SelectField}
+                variant="standard"
+                name="type"
+                label={t_i18n('Entity type')}
+                fullWidth={true}
+                containerstyle={fieldSpacingContainerStyle}
               >
-                <Field
-                  component={TextField}
-                  variant="standard"
-                  name="name"
-                  label={t('Name')}
-                  fullWidth={true}
-                  detectDuplicate={['Organization', 'Individual']}
+                {!onlyAuthors && (<MenuItem value="Sector">{t_i18n('Sector')}</MenuItem>)}
+                <MenuItem value="Organization">{t_i18n('Organization')}</MenuItem>
+                <MenuItem value="System">{t_i18n('System')}</MenuItem>
+                <MenuItem value="Individual">{t_i18n('Individual')}</MenuItem>
+              </Field>
+              {!dryrun && (
+                <ObjectLabelField
+                  name="objectLabel"
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                  values={values.objectLabel}
                 />
-                <Field
-                  component={MarkdownField}
-                  name="description"
-                  label={t('Description')}
-                  fullWidth={true}
-                  multiline={true}
-                  rows="4"
-                  style={{ marginTop: 20 }}
+              )}
+              {!dryrun && (
+                <ObjectMarkingField
+                  name="objectMarking"
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
                 />
-                <Field
-                  component={SelectField}
-                  variant="standard"
-                  name="type"
-                  label={t('Entity type')}
-                  fullWidth={true}
-                  containerstyle={fieldSpacingContainerStyle}
+              )}
+              {!dryrun && (
+                <ExternalReferencesField
+                  name="externalReferences"
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                  values={values.externalReferences}
+                />
+              )}
+              <DialogActions>
+                <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
+                  {t_i18n('Cancel')}
+                </Button>
+                <Button
+                  onClick={submitForm}
+                  disabled={isSubmitting}
                 >
-                  {!onlyAuthors && (<MenuItem value="Sector">{t('Sector')}</MenuItem>)}
-                  <MenuItem value="Organization">{t('Organization')}</MenuItem>
-                  <MenuItem value="System">{t('System')}</MenuItem>
-                  <MenuItem value="Individual">{t('Individual')}</MenuItem>
-                </Field>
-                {!dryrun && (
-                  <ObjectLabelField
-                    name="objectLabel"
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                    values={values.objectLabel}
-                  />
-                )}
-                {!dryrun && (
-                  <ObjectMarkingField
-                    name="objectMarking"
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                  />
-                )}
-                {!dryrun && (
-                  <ExternalReferencesField
-                    name="externalReferences"
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                    values={values.externalReferences}
-                  />
-                )}
-                <DialogActions>
-                  <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
-                    {t('Cancel')}
-                  </Button>
-                  <Button
-                    onClick={submitForm}
-                    disabled={isSubmitting}
-                  >
-                    {t('Create')}
-                  </Button>
-                </DialogActions>
-              </Dialog>
-            </Form>
-          )}
-        </Formik>
-      </>
-    );
-  }
-}
+                  {t_i18n('Create')}
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </Form>
+        )}
+      </Formik>
+    </>
+  );
+};
 
 IdentityCreation.propTypes = {
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
   theme: PropTypes.object,
-  t: PropTypes.func,
   contextual: PropTypes.bool,
   onlyAuthors: PropTypes.bool,
   open: PropTypes.bool,
@@ -249,7 +230,4 @@ IdentityCreation.propTypes = {
   creationCallback: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles, { withTheme: true }),
-)(IdentityCreation);
+export default withStyles(styles, { withTheme: true })(IdentityCreation);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelation.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql } from 'react-relay';
 import * as R from 'ramda';
@@ -15,7 +15,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { ConnectionHandler } from 'relay-runtime';
 import Skeleton from '@mui/material/Skeleton';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { formatDate } from '../../../../utils/Time';
 import { resolveRelationsTypes } from '../../../../utils/Relation';
 import StixCoreRelationshipCreationFromRelationStixDomainObjectsLines, {
@@ -278,28 +278,24 @@ const sharedUpdater = (store, userId, paginationOptions, newEdge) => {
   ConnectionHandler.insertEdgeBefore(conn, newEdge);
 };
 
-class StixCoreRelationshipCreationFromRelation extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      open: false,
-      step: 0,
-      targetEntity: null,
-      search: '',
-    };
-  }
+const StixCoreRelationshipCreationFromRelation = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+  const [targetEntity, setTargetEntity] = useState(null);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setStep(0);
+    setTargetEntity(null);
+    setOpen(false);
+  };
 
-  handleClose() {
-    this.setState({ step: 0, targetEntity: null, open: false });
-  }
-
-  onSubmit(values, { setSubmitting, resetForm }) {
-    const { isRelationReversed, entityId } = this.props;
-    const { targetEntity } = this.state;
+  const onSubmit = (values, { setSubmitting, resetForm }) => {
+    const { isRelationReversed, entityId } = props;
     const fromEntityId = isRelationReversed ? targetEntity.id : entityId;
     const toEntityId = isRelationReversed ? entityId : targetEntity.id;
     const finalValues = R.pipe(
@@ -323,14 +319,14 @@ class StixCoreRelationshipCreationFromRelation extends Component {
         : stixCoreRelationshipCreationFromRelationFromMutation,
       variables: { input: finalValues },
       updater: (store) => {
-        if (typeof this.props.onCreate !== 'function') {
+        if (typeof props.onCreate !== 'function') {
           const payload = store.getRootField('stixCoreRelationshipAdd');
           const newEdge = payload.setLinkedRecord(payload, 'node');
           const container = store.getRoot();
           sharedUpdater(
             store,
             container.getDataID(),
-            this.props.paginationOptions,
+            props.paginationOptions,
             newEdge,
           );
         }
@@ -339,24 +335,26 @@ class StixCoreRelationshipCreationFromRelation extends Component {
       onCompleted: () => {
         setSubmitting(false);
         resetForm();
-        this.handleClose();
+        handleClose();
       },
     });
-  }
+  };
 
-  handleResetSelection() {
-    this.setState({ step: 0, targetEntity: null });
-  }
+  const handleResetSelection = () => {
+    setStep(0);
+    setTargetEntity(null);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSelectEntity(stixDomainObject) {
-    this.setState({ step: 1, targetEntity: stixDomainObject });
-  }
+  const handleSelectEntity = (stixDomainObject) => {
+    setStep(1);
+    setTargetEntity(stixDomainObject);
+  };
 
-  renderFakeList() {
+  const renderFakeList = () => {
     return (
       <List>
         {Array.from(Array(20), (e, i) => (
@@ -392,11 +390,10 @@ class StixCoreRelationshipCreationFromRelation extends Component {
         ))}
       </List>
     );
-  }
+  };
 
-  renderSelectEntity() {
-    const { search } = this.state;
-    const { stixCoreObjectTypes, onlyObservables } = this.props;
+  const renderSelectEntity = () => {
+    const { stixCoreObjectTypes, onlyObservables } = props;
     const stixDomainObjectsPaginationOptions = {
       search,
       types: stixCoreObjectTypes
@@ -417,12 +414,12 @@ class StixCoreRelationshipCreationFromRelation extends Component {
               if (props) {
                 return (
                   <StixCoreRelationshipCreationFromRelationStixDomainObjectsLines
-                    handleSelect={this.handleSelectEntity.bind(this)}
+                    handleSelect={handleSelectEntity}
                     data={props}
                   />
                 );
               }
-              return this.renderFakeList();
+              return renderFakeList();
             }}
           />
         ) : (
@@ -433,7 +430,7 @@ class StixCoreRelationshipCreationFromRelation extends Component {
             stixCoreRelationshipCreationFromRelationStixCyberObservablesLinesQuery
           }
           variables={{
-            search: this.state.search,
+            search: search,
             types: stixCoreObjectTypes,
             count: 50,
             orderBy: 'created_at',
@@ -443,14 +440,14 @@ class StixCoreRelationshipCreationFromRelation extends Component {
             if (props) {
               return (
                 <StixCoreRelationshipCreationFromRelationStixCyberObservablesLines
-                  handleSelect={this.handleSelectEntity.bind(this)}
+                  handleSelect={handleSelectEntity}
                   data={props}
                 />
               );
             }
             return !stixCoreObjectTypes
               || stixCoreObjectTypes.length === 0 ? (
-                  this.renderFakeList()
+                  renderFakeList()
                 ) : (
                   <div> &nbsp; </div>
                 );
@@ -458,19 +455,18 @@ class StixCoreRelationshipCreationFromRelation extends Component {
         />
         <Stack direction="row" alignSelf="flex-end">
           <StixDomainObjectCreation
-            display={this.state.open}
-            inputValue={this.state.search}
+            display={open}
+            inputValue={search}
             paginationOptions={stixDomainObjectsPaginationOptions}
             stixDomainObjectTypes={stixCoreObjectTypes}
           />
         </Stack>
       </Stack>
     );
-  }
+  };
 
-  renderForm(sourceEntity) {
-    const { t, classes, isRelationReversed, allowedRelationshipTypes } = this.props;
-    const { targetEntity } = this.state;
+  const renderForm = (sourceEntity) => {
+    const { classes, isRelationReversed, allowedRelationshipTypes } = props;
     let fromEntity = sourceEntity;
     let toEntity = targetEntity;
     if (isRelationReversed) {
@@ -498,28 +494,28 @@ class StixCoreRelationshipCreationFromRelation extends Component {
                 <IconButton
                   aria-label="Close"
                   className={classes.closeButton}
-                  onClick={this.handleClose.bind(this)}
+                  onClick={handleClose}
                 >
                   <Close fontSize="small" color="primary" />
                 </IconButton>
-                <Typography variant="h6">{t('Create a relationship')}</Typography>
+                <Typography variant="h6">{t_i18n('Create a relationship')}</Typography>
               </div>
               <StixCoreRelationshipCreationForm
                 fromEntities={[fromEntity]}
                 toEntities={[toEntity]}
                 relationshipTypes={relationshipTypes}
-                handleResetSelection={this.handleResetSelection.bind(this)}
-                onSubmit={this.onSubmit.bind(this)}
-                handleClose={this.handleClose.bind(this)}
+                handleResetSelection={handleResetSelection}
+                onSubmit={onSubmit}
+                handleClose={handleClose}
               />
             </>
           );
         }}
       </UserContext.Consumer>
     );
-  }
+  };
 
-  renderLoader() {
+  const renderLoader = () => {
     return (
       <div style={{ display: 'table', height: '100%', width: '100%' }}>
         <span
@@ -533,72 +529,69 @@ class StixCoreRelationshipCreationFromRelation extends Component {
         </span>
       </div>
     );
-  }
+  };
 
-  render() {
-    const { classes, entityId, variant, paddingRight, t } = this.props;
-    const { open, step } = this.state;
-    return (
-      <div>
-        {variant === 'inLine' ? (
-          <IconButton
-            aria-label="Label"
-            onClick={this.handleOpen.bind(this)}
-            size="small"
-            variant="tertiary"
-          >
-            <Add />
-          </IconButton>
-        ) : (
-          <Fab
-            onClick={this.handleOpen.bind(this)}
-            color="primary"
-            aria-label="Add"
-            className={
-              paddingRight
-                ? classes.createButtonWithPadding
-                : classes.createButton
-            }
-          >
-            <Add />
-          </Fab>
-        )}
-        <Drawer
-          open={open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Create a relationship')}
-          subHeader={{
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
-          }}
+  const { classes, entityId, variant, paddingRight } = props;
+  return (
+    <div>
+      {variant === 'inLine' ? (
+        <IconButton
+          aria-label="Label"
+          onClick={handleOpen}
+          size="small"
+          variant="tertiary"
         >
-          <QueryRenderer
-            query={stixCoreRelationshipCreationFromRelationQuery}
-            variables={{ id: entityId }}
-            render={({ props }) => {
-              if (props && props.stixCoreRelationship) {
-                return (
-                  <div>
-                    {step === 0 ? this.renderSelectEntity() : ''}
-                    {step === 1
-                      ? this.renderForm(props.stixCoreRelationship)
-                      : ''}
-                  </div>
-                );
-              }
-              return this.renderLoader();
-            }}
-          />
-        </Drawer>
-      </div>
-    );
-  }
-}
+          <Add />
+        </IconButton>
+      ) : (
+        <Fab
+          onClick={handleOpen}
+          color="primary"
+          aria-label="Add"
+          className={
+            paddingRight
+              ? classes.createButtonWithPadding
+              : classes.createButton
+          }
+        >
+          <Add />
+        </Fab>
+      )}
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Create a relationship')}
+        subHeader={{
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={stixCoreRelationshipCreationFromRelationQuery}
+          variables={{ id: entityId }}
+          render={({ props }) => {
+            if (props && props.stixCoreRelationship) {
+              return (
+                <div>
+                  {step === 0 ? renderSelectEntity() : ''}
+                  {step === 1
+                    ? renderForm(props.stixCoreRelationship)
+                    : ''}
+                </div>
+              );
+            }
+            return renderLoader();
+          }}
+        />
+      </Drawer>
+    </div>
+  );
+};
 
 StixCoreRelationshipCreationFromRelation.propTypes = {
   entityId: PropTypes.string,
@@ -608,14 +601,9 @@ StixCoreRelationshipCreationFromRelation.propTypes = {
   allowedRelationshipTypes: PropTypes.array,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fsd: PropTypes.func,
   variant: PropTypes.string,
   onCreate: PropTypes.func,
   paddingRight: PropTypes.bool,
 };
 
-export default R.compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipCreationFromRelation);
+export default withStyles(styles)(StixCoreRelationshipCreationFromRelation);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
-import { map, keys, groupBy, assoc, compose } from 'ramda';
+import { map, keys, groupBy, assoc } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -14,7 +14,7 @@ import { ExpandMore } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   container: {
@@ -43,95 +43,86 @@ const styles = (theme) => ({
   },
 });
 
-class StixCoreRelationshipCreationFromRelationStixCyberObservablesLinesContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedPanels: {} };
-  }
+const StixCoreRelationshipCreationFromRelationStixCyberObservablesLinesContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expandedPanels, setExpandedPanels] = useState({});
+  const handleChangePanel = (panelKey, event, expanded) => {
+    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+  };
 
-  handleChangePanel(panelKey, event, expanded) {
-    this.setState({
-      expandedPanels: assoc(panelKey, expanded, this.state.expandedPanels),
-    });
-  }
-
-  isExpanded(type, numberOfEntities, numberOfTypes) {
-    if (this.state.expandedPanels[type] !== undefined) {
-      return this.state.expandedPanels[type];
+  const isExpanded = (type, numberOfEntities, numberOfTypes) => {
+    if (expandedPanels[type] !== undefined) {
+      return expandedPanels[type];
     }
     if (numberOfEntities === 1) {
       return true;
     }
     return numberOfTypes === 1;
-  }
+  };
 
-  render() {
-    const { t, classes, data, handleSelect } = this.props;
-    const stixCyberObservablesNodes = map(
-      (n) => n.node,
-      data.stixCyberObservables.edges,
-    );
-    const byType = groupBy(
-      (stixCyberObservable) => stixCyberObservable.entity_type,
-    );
-    const stixCyberObservables = byType(stixCyberObservablesNodes);
-    const stixCyberObservablesTypes = keys(stixCyberObservables);
+  const { classes, data, handleSelect } = props;
+  const stixCyberObservablesNodes = map(
+    (n) => n.node,
+    data.stixCyberObservables.edges,
+  );
+  const byType = groupBy(
+    (stixCyberObservable) => stixCyberObservable.entity_type,
+  );
+  const stixCyberObservables = byType(stixCyberObservablesNodes);
+  const stixCyberObservablesTypes = keys(stixCyberObservables);
 
-    return (
-      <div className={classes.container}>
-        {stixCyberObservablesTypes.map((type) => (
-          <Accordion
-            key={type}
-            expanded={this.isExpanded(
-              type,
-              stixCyberObservables[type].length,
-              stixCyberObservablesTypes.length,
-            )}
-            onChange={this.handleChangePanel.bind(this, type)}
-            elevation={3}
-          >
-            <AccordionSummary expandIcon={<ExpandMore />}>
-              <Typography className={classes.heading}>
-                {t(`entity_${type}`)}
-              </Typography>
-              <Typography className={classes.secondaryHeading}>
-                {stixCyberObservables[type].length} {t('observable(s)')}
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails classes={{ root: classes.expansionPanelContent }}>
-              <List classes={{ root: classes.list }}>
-                {stixCyberObservables[type].map((stixCyberObservable) => (
-                  <ListItemButton
-                    key={stixCyberObservable.id}
-                    classes={{ root: classes.menuItem }}
-                    divider={true}
-                    onClick={handleSelect.bind(this, stixCyberObservable)}
-                  >
-                    <ListItemIcon>
-                      <ItemIcon type={type} />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={stixCyberObservable.observable_value}
-                      secondary={truncate(stixCyberObservable.description, 100)}
-                    />
-                  </ListItemButton>
-                ))}
-              </List>
-            </AccordionDetails>
-          </Accordion>
-        ))}
-      </div>
-    );
-  }
-}
+  return (
+    <div className={classes.container}>
+      {stixCyberObservablesTypes.map((type) => (
+        <Accordion
+          key={type}
+          expanded={isExpanded(
+            type,
+            stixCyberObservables[type].length,
+            stixCyberObservablesTypes.length,
+          )}
+          onChange={handleChangePanel.bind(null, type)}
+          elevation={3}
+        >
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography className={classes.heading}>
+              {t_i18n(`entity_${type}`)}
+            </Typography>
+            <Typography className={classes.secondaryHeading}>
+              {stixCyberObservables[type].length} {t_i18n('observable(s)')}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails classes={{ root: classes.expansionPanelContent }}>
+            <List classes={{ root: classes.list }}>
+              {stixCyberObservables[type].map((stixCyberObservable) => (
+                <ListItemButton
+                  key={stixCyberObservable.id}
+                  classes={{ root: classes.menuItem }}
+                  divider={true}
+                  onClick={handleSelect.bind(null, stixCyberObservable)}
+                >
+                  <ListItemIcon>
+                    <ItemIcon type={type} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={stixCyberObservable.observable_value}
+                    secondary={truncate(stixCyberObservable.description, 100)}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </div>
+  );
+};
 
 StixCoreRelationshipCreationFromRelationStixCyberObservablesLinesContainer.propTypes = {
   handleSelect: PropTypes.func,
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const stixCoreRelationshipCreationFromRelationStixCyberObservablesLinesQuery = graphql`
@@ -217,7 +208,4 @@ const StixCoreRelationshipCreationFromRelationStixCyberObservablesLines = create
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipCreationFromRelationStixCyberObservablesLines);
+export default withStyles(styles)(StixCoreRelationshipCreationFromRelationStixCyberObservablesLines);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixCyberObservablesLines.jsx
@@ -47,7 +47,7 @@ const StixCoreRelationshipCreationFromRelationStixCyberObservablesLinesContainer
   const { t_i18n } = useFormatter();
   const [expandedPanels, setExpandedPanels] = useState({});
   const handleChangePanel = (panelKey, event, expanded) => {
-    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+    setExpandedPanels((current) => assoc(panelKey, expanded, current));
   };
 
   const isExpanded = (type, numberOfEntities, numberOfTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
@@ -57,7 +57,7 @@ const StixCoreRelationshipCreationFromRelationLinesContainer = (props) => {
   const { t_i18n } = useFormatter();
   const [expandedPanels, setExpandedPanels] = useState({});
   const handleChangePanel = (panelKey, event, expanded) => {
-    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+    setExpandedPanels((current) => assoc(panelKey, expanded, current));
   };
 
   const isExpanded = (type, numberOfEntities, numberOfTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromRelationStixDomainObjectsLines.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
-import { map, keys, groupBy, assoc, compose } from 'ramda';
+import { map, keys, groupBy, assoc } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -14,7 +14,7 @@ import { ExpandMore } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 
 const styles = (theme) => ({
@@ -53,129 +53,120 @@ const styles = (theme) => ({
   },
 });
 
-class StixCoreRelationshipCreationFromRelationLinesContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedPanels: {} };
-  }
+const StixCoreRelationshipCreationFromRelationLinesContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expandedPanels, setExpandedPanels] = useState({});
+  const handleChangePanel = (panelKey, event, expanded) => {
+    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+  };
 
-  handleChangePanel(panelKey, event, expanded) {
-    this.setState({
-      expandedPanels: assoc(panelKey, expanded, this.state.expandedPanels),
-    });
-  }
-
-  isExpanded(type, numberOfEntities, numberOfTypes) {
-    if (this.state.expandedPanels[type] !== undefined) {
-      return this.state.expandedPanels[type];
+  const isExpanded = (type, numberOfEntities, numberOfTypes) => {
+    if (expandedPanels[type] !== undefined) {
+      return expandedPanels[type];
     }
     if (numberOfEntities === 1) {
       return true;
     }
     return numberOfTypes === 1;
-  }
+  };
 
-  render() {
-    const { t, classes, data, handleSelect } = this.props;
-    const stixDomainObjectsNodes = map(
-      (n) => n.node,
-      data.stixDomainObjects.edges,
-    );
-    const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
-    const stixDomainObjects = byType(stixDomainObjectsNodes);
-    const stixDomainObjectsTypes = keys(stixDomainObjects);
-    let increment = 0;
+  const { classes, data, handleSelect } = props;
+  const stixDomainObjectsNodes = map(
+    (n) => n.node,
+    data.stixDomainObjects.edges,
+  );
+  const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
+  const stixDomainObjects = byType(stixDomainObjectsNodes);
+  const stixDomainObjectsTypes = keys(stixDomainObjects);
+  let increment = 0;
 
-    return (
-      <div className={classes.container}>
-        {stixDomainObjectsTypes.length > 0 ? (
-          stixDomainObjectsTypes.map((type) => {
-            increment += 1;
-            return (
-              <Accordion
-                key={type}
-                expanded={this.isExpanded(
-                  type,
-                  stixDomainObjects[type].length,
-                  stixDomainObjectsTypes.length,
-                )}
-                onChange={this.handleChangePanel.bind(this, type)}
-                elevation={3}
-                style={{
-                  marginBottom:
-                    increment === stixDomainObjectsTypes.length
-                    && this.isExpanded(
-                      type,
-                      stixDomainObjects[type].length,
-                      stixDomainObjectsTypes.length,
-                    )
-                      ? 16
-                      : 0,
-                }}
+  return (
+    <div className={classes.container}>
+      {stixDomainObjectsTypes.length > 0 ? (
+        stixDomainObjectsTypes.map((type) => {
+          increment += 1;
+          return (
+            <Accordion
+              key={type}
+              expanded={isExpanded(
+                type,
+                stixDomainObjects[type].length,
+                stixDomainObjectsTypes.length,
+              )}
+              onChange={handleChangePanel.bind(null, type)}
+              elevation={3}
+              style={{
+                marginBottom:
+                  increment === stixDomainObjectsTypes.length
+                  && isExpanded(
+                    type,
+                    stixDomainObjects[type].length,
+                    stixDomainObjectsTypes.length,
+                  )
+                    ? 16
+                    : 0,
+              }}
+            >
+              <AccordionSummary expandIcon={<ExpandMore />}>
+                <Typography className={classes.heading}>
+                  {t_i18n(`entity_${type}`)}
+                </Typography>
+                <Typography className={classes.secondaryHeading}>
+                  {stixDomainObjects[type].length} {t_i18n('entitie(s)')}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails
+                classes={{ root: classes.expansionPanelContent }}
               >
-                <AccordionSummary expandIcon={<ExpandMore />}>
-                  <Typography className={classes.heading}>
-                    {t(`entity_${type}`)}
-                  </Typography>
-                  <Typography className={classes.secondaryHeading}>
-                    {stixDomainObjects[type].length} {t('entitie(s)')}
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails
-                  classes={{ root: classes.expansionPanelContent }}
-                >
-                  <List classes={{ root: classes.list }}>
-                    {stixDomainObjects[type].map((stixDomainObject) => (
-                      <ListItemButton
-                        key={stixDomainObject.id}
-                        classes={{ root: classes.menuItem }}
-                        divider={true}
-                        onClick={handleSelect.bind(this, stixDomainObject)}
-                      >
-                        <ListItemIcon>
-                          <ItemIcon type={type} />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={
-                            stixDomainObject.name
-                            || stixDomainObject.attribute_abstract
-                            || truncate(stixDomainObject.content, 30)
-                            || stixDomainObject.opinion
-                          }
-                          secondary={truncate(
-                            stixDomainObject.description,
-                            100,
-                          )}
-                        />
-                        <StixCoreObjectLabels
-                          variant="inList"
-                          labels={stixDomainObject.objectLabel}
-                          revoked={stixDomainObject.revoked}
-                        />
-                      </ListItemButton>
-                    ))}
-                  </List>
-                </AccordionDetails>
-              </Accordion>
-            );
-          })
-        ) : (
-          <div className={classes.noResult}>
-            {t('No entities were found for this search.')}
-          </div>
-        )}
-      </div>
-    );
-  }
-}
+                <List classes={{ root: classes.list }}>
+                  {stixDomainObjects[type].map((stixDomainObject) => (
+                    <ListItemButton
+                      key={stixDomainObject.id}
+                      classes={{ root: classes.menuItem }}
+                      divider={true}
+                      onClick={handleSelect.bind(null, stixDomainObject)}
+                    >
+                      <ListItemIcon>
+                        <ItemIcon type={type} />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          stixDomainObject.name
+                          || stixDomainObject.attribute_abstract
+                          || truncate(stixDomainObject.content, 30)
+                          || stixDomainObject.opinion
+                        }
+                        secondary={truncate(
+                          stixDomainObject.description,
+                          100,
+                        )}
+                      />
+                      <StixCoreObjectLabels
+                        variant="inList"
+                        labels={stixDomainObject.objectLabel}
+                        revoked={stixDomainObject.revoked}
+                      />
+                    </ListItemButton>
+                  ))}
+                </List>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })
+      ) : (
+        <div className={classes.noResult}>
+          {t_i18n('No entities were found for this search.')}
+        </div>
+      )}
+    </div>
+  );
+};
 
 StixCoreRelationshipCreationFromRelationLinesContainer.propTypes = {
   handleSelect: PropTypes.func,
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const stixCoreRelationshipCreationFromRelationStixDomainObjectsLinesQuery = graphql`
@@ -383,7 +374,4 @@ const StixCoreRelationshipCreationFromRelationStixDomainObjectsLines = createPag
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipCreationFromRelationStixDomainObjectsLines);
+export default withStyles(styles)(StixCoreRelationshipCreationFromRelationStixDomainObjectsLines);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
 import { map, keys, groupBy, assoc, compose } from 'ramda';
@@ -17,7 +17,7 @@ import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import { resolveLink } from '../../../../utils/Entity';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 
 const styles = (theme) => ({
@@ -57,117 +57,71 @@ const styles = (theme) => ({
   },
 });
 
-class StixDomainObjectsContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedPanels: {} };
-  }
+const StixDomainObjectsContainer = (props) => {
+  const { t_i18n, fd } = useFormatter();
+  const [expandedPanels, setExpandedPanels] = useState({});
+  const handleChangePanel = (panelKey, event, expanded) => {
+    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+  };
 
-  handleChangePanel(panelKey, event, expanded) {
-    this.setState({
-      expandedPanels: assoc(panelKey, expanded, this.state.expandedPanels),
-    });
-  }
-
-  isExpanded(type, numberOfEntities, numberOfTypes) {
-    if (this.state.expandedPanels[type] !== undefined) {
-      return this.state.expandedPanels[type];
+  const isExpanded = (type, numberOfEntities, numberOfTypes) => {
+    if (expandedPanels[type] !== undefined) {
+      return expandedPanels[type];
     }
     if (numberOfEntities === 1) {
       return true;
     }
     return numberOfTypes === 1;
-  }
+  };
 
-  render() {
-    const { t, classes, data, fd } = this.props;
-    const stixDomainObjectsNodes = map(
-      (n) => n.node,
-      data.stixDomainObjects.edges,
-    );
-    const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
-    const stixDomainObjects = byType(stixDomainObjectsNodes);
-    const stixDomainObjectsTypes = keys(stixDomainObjects);
-    if (stixDomainObjectsTypes.length !== 0) {
-      return (
-        <div className={classes.container}>
-          {stixDomainObjectsTypes.map((type) => (
-            <Accordion
-              key={type}
-              expanded={this.isExpanded(
-                type,
-                stixDomainObjects[type].length,
-                stixDomainObjectsTypes.length,
-              )}
-              onChange={this.handleChangePanel.bind(this, type)}
-              elevation={3}
+  const { classes, data } = props;
+  const stixDomainObjectsNodes = map(
+    (n) => n.node,
+    data.stixDomainObjects.edges,
+  );
+  const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
+  const stixDomainObjects = byType(stixDomainObjectsNodes);
+  const stixDomainObjectsTypes = keys(stixDomainObjects);
+  if (stixDomainObjectsTypes.length !== 0) {
+    return (
+      <div className={classes.container}>
+        {stixDomainObjectsTypes.map((type) => (
+          <Accordion
+            key={type}
+            expanded={isExpanded(
+              type,
+              stixDomainObjects[type].length,
+              stixDomainObjectsTypes.length,
+            )}
+            onChange={handleChangePanel.bind(null, type)}
+            elevation={3}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMore />}
+              className={classes.summary}
             >
-              <AccordionSummary
-                expandIcon={<ExpandMore />}
-                className={classes.summary}
-              >
-                <Typography className={classes.heading}>
-                  {t(`entity_${type}`)}
-                </Typography>
-                <Typography classes={{ root: classes.secondaryHeading }}>
-                  {stixDomainObjects[type].length}{' '}
-                  {stixDomainObjects[type].length < 2
-                    ? t('entity')
-                    : t('entities')}
-                </Typography>
-              </AccordionSummary>
-              <AccordionDetails
-                classes={{ root: classes.expansionPanelContent }}
-              >
-                <List classes={{ root: classes.list }}>
-                  {stixDomainObjects[type].map((stixDomainObject) => {
-                    const link = resolveLink(stixDomainObject.entity_type);
-                    if (link) {
-                      return (
-                        <ListItem
-                          key={stixDomainObject.id}
-                          divider={true}
-                          disablePadding
-                          secondaryAction={(
-                            <StixCoreObjectLabels
-                              labels={stixDomainObject.objectLabel}
-                              variant="inSearch"
-                            />
-                          )}
-                        >
-                          <ListItemButton
-                            component={Link}
-                            to={`${link}/${stixDomainObject.id}`}
-                          >
-                            <ListItemIcon classes={{ root: classes.itemIcon }}>
-                              <ItemIcon type={type} />
-                            </ListItemIcon>
-                            <ListItemText
-                              primary={truncate(
-                                stixDomainObject.x_mitre_id
-                                  ? `[${stixDomainObject.x_mitre_id}] ${stixDomainObject.name}`
-                                  : stixDomainObject.name
-                                    || stixDomainObject.attribute_abstract
-                                    || stixDomainObject.content
-                                    || stixDomainObject.opinion
-                                    || `${fd(
-                                      stixDomainObject.first_observed,
-                                    )} - ${fd(stixDomainObject.last_observed)}`,
-                                100,
-                              )}
-                              secondary={truncate(
-                                stixDomainObject.description,
-                                150,
-                              )}
-                            />
-                          </ListItemButton>
-                        </ListItem>
-                      );
-                    }
+              <Typography className={classes.heading}>
+                {t_i18n(`entity_${type}`)}
+              </Typography>
+              <Typography classes={{ root: classes.secondaryHeading }}>
+                {stixDomainObjects[type].length}{' '}
+                {stixDomainObjects[type].length < 2
+                  ? t_i18n('entity')
+                  : t_i18n('entities')}
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails
+              classes={{ root: classes.expansionPanelContent }}
+            >
+              <List classes={{ root: classes.list }}>
+                {stixDomainObjects[type].map((stixDomainObject) => {
+                  const link = resolveLink(stixDomainObject.entity_type);
+                  if (link) {
                     return (
                       <ListItem
                         key={stixDomainObject.id}
                         divider={true}
+                        disablePadding
                         secondaryAction={(
                           <StixCoreObjectLabels
                             labels={stixDomainObject.objectLabel}
@@ -175,33 +129,72 @@ class StixDomainObjectsContainer extends Component {
                           />
                         )}
                       >
-                        <ListItemIcon classes={{ root: classes.itemIcon }}>
-                          <ItemIcon type={type} />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={truncate(stixDomainObject.name, 100)}
-                          secondary={truncate(
-                            stixDomainObject.description,
-                            150,
-                          )}
-                        />
+                        <ListItemButton
+                          component={Link}
+                          to={`${link}/${stixDomainObject.id}`}
+                        >
+                          <ListItemIcon classes={{ root: classes.itemIcon }}>
+                            <ItemIcon type={type} />
+                          </ListItemIcon>
+                          <ListItemText
+                            primary={truncate(
+                              stixDomainObject.x_mitre_id
+                                ? `[${stixDomainObject.x_mitre_id}] ${stixDomainObject.name}`
+                                : stixDomainObject.name
+                                  || stixDomainObject.attribute_abstract
+                                  || stixDomainObject.content
+                                  || stixDomainObject.opinion
+                                  || `${fd(
+                                    stixDomainObject.first_observed,
+                                  )} - ${fd(stixDomainObject.last_observed)}`,
+                              100,
+                            )}
+                            secondary={truncate(
+                              stixDomainObject.description,
+                              150,
+                            )}
+                          />
+                        </ListItemButton>
                       </ListItem>
                     );
-                  })}
-                </List>
-              </AccordionDetails>
-            </Accordion>
-          ))}
-        </div>
-      );
-    }
-    return (
-      <div className={classes.noResult}>
-        {t('No entities were found for this search.')}
+                  }
+                  return (
+                    <ListItem
+                      key={stixDomainObject.id}
+                      divider={true}
+                      secondaryAction={(
+                        <StixCoreObjectLabels
+                          labels={stixDomainObject.objectLabel}
+                          variant="inSearch"
+                        />
+                      )}
+                    >
+                      <ListItemIcon classes={{ root: classes.itemIcon }}>
+                        <ItemIcon type={type} />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={truncate(stixDomainObject.name, 100)}
+                        secondary={truncate(
+                          stixDomainObject.description,
+                          150,
+                        )}
+                      />
+                    </ListItem>
+                  );
+                })}
+              </List>
+            </AccordionDetails>
+          </Accordion>
+        ))}
       </div>
     );
   }
-}
+  return (
+    <div className={classes.noResult}>
+      {t_i18n('No entities were found for this search.')}
+    </div>
+  );
+};
 
 StixDomainObjectsContainer.propTypes = {
   reportId: PropTypes.string,
@@ -209,9 +202,6 @@ StixDomainObjectsContainer.propTypes = {
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
-  fd: PropTypes.func,
 };
 
 export const stixDomainObjectsLinesSubTypesQuery = graphql`
@@ -600,4 +590,4 @@ const StixDomainObjectsLines = createPaginationContainer(
   },
 );
 
-export default compose(inject18n, withStyles(styles))(StixDomainObjectsLines);
+export default compose(withStyles(styles))(StixDomainObjectsLines);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
@@ -61,7 +61,7 @@ const StixDomainObjectsContainer = (props) => {
   const { t_i18n, fd } = useFormatter();
   const [expandedPanels, setExpandedPanels] = useState({});
   const handleChangePanel = (panelKey, event, expanded) => {
-    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+    setExpandedPanels((current) => assoc(panelKey, expanded, current));
   };
 
   const isExpanded = (type, numberOfEntities, numberOfTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import EventEditionContainer from './EventEditionContainer';
 import { eventEditionOverviewFocus } from './EventEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,56 +15,41 @@ export const eventEditionQuery = graphql`
   }
 `;
 
-class EventEdition extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-  }
-
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
+const EventEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: eventEditionOverviewFocus,
       variables: {
-        id: this.props.eventId,
+        id: props.eventId,
         input: { focusOn: '' },
       },
     });
-    this.setState({ open: false });
-  }
+  };
 
-  render() {
-    const { eventId } = this.props;
-    return (
-      <QueryRenderer
-        query={eventEditionQuery}
-        variables={{ id: eventId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <EventEditionContainer
-                event={props.event}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { eventId } = props;
+  return (
+    <QueryRenderer
+      query={eventEditionQuery}
+      variables={{ id: eventId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <EventEditionContainer
+              event={props.event}
+              handleClose={handleClose}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 EventEdition.propTypes = {
   eventId: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-)(EventEdition);
+export default EventEdition;

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSector.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/AddSubSector.jsx
@@ -1,95 +1,90 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddSubSectorsLines, { addSubSectorsLinesQuery } from './AddSubSectorsLines';
 import SectorCreation from './SectorCreation';
 import SearchInput from '../../../../components/SearchInput';
 
-class AddSubSector extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddSubSector = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, sector, sectorSubSectors } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    return (
-      <div>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          title={t('Add subsectors')}
-          onClose={this.handleClose.bind(this)}
-        >
-          <>
-            <div>
-              <SearchInput
-                variant="small"
-                onSubmit={this.handleSearch.bind(this)}
-                keyword={this.state.search}
-              />
-              <div style={{ float: 'right' }}>
-                <SectorCreation
-                  display={this.state.open}
-                  contextual={true}
-                  inputValue={this.state.search}
-                  paginationOptions={paginationOptions}
-                />
-              </div>
-            </div>
-            <QueryRenderer
-              query={addSubSectorsLinesQuery}
-              variables={{
-                search: this.state.search,
-                count: 20,
-              }}
-              render={({ props }) => {
-                return (
-                  <AddSubSectorsLines
-                    sector={sector}
-                    sectorSubSectors={sectorSubSectors}
-                    data={props}
-                  />
-                );
-              }}
+  const { sector, sectorSubSectors } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  return (
+    <div>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        title={t_i18n('Add subsectors')}
+        onClose={handleClose}
+      >
+        <>
+          <div>
+            <SearchInput
+              variant="small"
+              onSubmit={handleSearch}
+              keyword={search}
             />
-          </>
-        </Drawer>
-      </div>
-    );
-  }
-}
+            <div style={{ float: 'right' }}>
+              <SectorCreation
+                display={open}
+                contextual={true}
+                inputValue={search}
+                paginationOptions={paginationOptions}
+              />
+            </div>
+          </div>
+          <QueryRenderer
+            query={addSubSectorsLinesQuery}
+            variables={{
+              search: search,
+              count: 20,
+            }}
+            render={({ props }) => {
+              return (
+                <AddSubSectorsLines
+                  sector={sector}
+                  sectorSubSectors={sectorSubSectors}
+                  data={props}
+                />
+              );
+            }}
+          />
+        </>
+      </Drawer>
+    </div>
+  );
+};
 
 AddSubSector.propTypes = {
   sector: PropTypes.object,
   sectorSubSectors: PropTypes.array,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddSubSector);
+export default AddSubSector;

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
-import { map, keys, groupBy, assoc, compose } from 'ramda';
+import { map, keys, groupBy, assoc } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -14,7 +14,7 @@ import Typography from '@mui/material/Typography';
 import { ExpandMore } from '@mui/icons-material';
 import { truncate } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   container: {
@@ -43,95 +43,86 @@ const styles = (theme) => ({
   },
 });
 
-class StixSightingRelationshipCreationFromEntityStixCyberObservablesLinesContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedPanels: {} };
-  }
+const StixSightingRelationshipCreationFromEntityStixCyberObservablesLinesContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expandedPanels, setExpandedPanels] = useState({});
+  const handleChangePanel = (panelKey, event, expanded) => {
+    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+  };
 
-  handleChangePanel(panelKey, event, expanded) {
-    this.setState({
-      expandedPanels: assoc(panelKey, expanded, this.state.expandedPanels),
-    });
-  }
-
-  isExpanded(type, numberOfEntities, numberOfTypes) {
-    if (this.state.expandedPanels[type] !== undefined) {
-      return this.state.expandedPanels[type];
+  const isExpanded = (type, numberOfEntities, numberOfTypes) => {
+    if (expandedPanels[type] !== undefined) {
+      return expandedPanels[type];
     }
     if (numberOfEntities === 1) {
       return true;
     }
     return numberOfTypes === 1;
-  }
+  };
 
-  render() {
-    const { t, classes, data, handleSelect } = this.props;
-    const stixCyberObservablesNodes = map(
-      (n) => n.node,
-      data.stixCyberObservables.edges,
-    );
-    const byType = groupBy(
-      (stixCyberObservable) => stixCyberObservable.entity_type,
-    );
-    const stixCyberObservables = byType(stixCyberObservablesNodes);
-    const stixCyberObservablesTypes = keys(stixCyberObservables);
+  const { classes, data, handleSelect } = props;
+  const stixCyberObservablesNodes = map(
+    (n) => n.node,
+    data.stixCyberObservables.edges,
+  );
+  const byType = groupBy(
+    (stixCyberObservable) => stixCyberObservable.entity_type,
+  );
+  const stixCyberObservables = byType(stixCyberObservablesNodes);
+  const stixCyberObservablesTypes = keys(stixCyberObservables);
 
-    return (
-      <div className={classes.container}>
-        {stixCyberObservablesTypes.map((type) => (
-          <Accordion
-            key={type}
-            expanded={this.isExpanded(
-              type,
-              stixCyberObservables[type].length,
-              stixCyberObservablesTypes.length,
-            )}
-            onChange={this.handleChangePanel.bind(this, type)}
-            elevation={3}
-          >
-            <AccordionSummary expandIcon={<ExpandMore />}>
-              <Typography className={classes.heading}>
-                {t(`entity_${type}`)}
-              </Typography>
-              <Typography className={classes.secondaryHeading}>
-                {stixCyberObservables[type].length} {t('observable(s)')}
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails classes={{ root: classes.expansionPanelContent }}>
-              <List classes={{ root: classes.list }}>
-                {stixCyberObservables[type].map((stixCyberObservable) => (
-                  <ListItemButton
-                    key={stixCyberObservable.id}
-                    classes={{ root: classes.menuItem }}
-                    divider={true}
-                    onClick={handleSelect.bind(this, stixCyberObservable)}
-                  >
-                    <ListItemIcon>
-                      <ItemIcon type={type} />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={stixCyberObservable.observable_value}
-                      secondary={truncate(stixCyberObservable.description, 100)}
-                    />
-                  </ListItemButton>
-                ))}
-              </List>
-            </AccordionDetails>
-          </Accordion>
-        ))}
-      </div>
-    );
-  }
-}
+  return (
+    <div className={classes.container}>
+      {stixCyberObservablesTypes.map((type) => (
+        <Accordion
+          key={type}
+          expanded={isExpanded(
+            type,
+            stixCyberObservables[type].length,
+            stixCyberObservablesTypes.length,
+          )}
+          onChange={handleChangePanel.bind(null, type)}
+          elevation={3}
+        >
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography className={classes.heading}>
+              {t_i18n(`entity_${type}`)}
+            </Typography>
+            <Typography className={classes.secondaryHeading}>
+              {stixCyberObservables[type].length} {t_i18n('observable(s)')}
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails classes={{ root: classes.expansionPanelContent }}>
+            <List classes={{ root: classes.list }}>
+              {stixCyberObservables[type].map((stixCyberObservable) => (
+                <ListItemButton
+                  key={stixCyberObservable.id}
+                  classes={{ root: classes.menuItem }}
+                  divider={true}
+                  onClick={handleSelect.bind(null, stixCyberObservable)}
+                >
+                  <ListItemIcon>
+                    <ItemIcon type={type} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={stixCyberObservable.observable_value}
+                    secondary={truncate(stixCyberObservable.description, 100)}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </div>
+  );
+};
 
 StixSightingRelationshipCreationFromEntityStixCyberObservablesLinesContainer.propTypes = {
   handleSelect: PropTypes.func,
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const stixSightingRelationshipCreationFromEntityStixCyberObservablesLinesQuery = graphql`
@@ -217,7 +208,4 @@ const StixSightingRelationshipCreationFromEntityStixCyberObservablesLines = crea
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixSightingRelationshipCreationFromEntityStixCyberObservablesLines);
+export default withStyles(styles)(StixSightingRelationshipCreationFromEntityStixCyberObservablesLines);

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixCyberObservablesLines.jsx
@@ -47,7 +47,7 @@ const StixSightingRelationshipCreationFromEntityStixCyberObservablesLinesContain
   const { t_i18n } = useFormatter();
   const [expandedPanels, setExpandedPanels] = useState({});
   const handleChangePanel = (panelKey, event, expanded) => {
-    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+    setExpandedPanels((current) => assoc(panelKey, expanded, current));
   };
 
   const isExpanded = (type, numberOfEntities, numberOfTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createPaginationContainer } from 'react-relay';
-import { map, keys, groupBy, assoc, compose } from 'ramda';
+import { map, keys, groupBy, assoc } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -14,7 +14,7 @@ import { ExpandMore } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 
 const styles = (theme) => ({
   container: {
@@ -46,119 +46,110 @@ const styles = (theme) => ({
   },
 });
 
-class StixSightingRelationshipCreationFromEntityLinesContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedPanels: {} };
-  }
+const StixSightingRelationshipCreationFromEntityLinesContainer = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expandedPanels, setExpandedPanels] = useState({});
+  const handleChangePanel = (panelKey, event, expanded) => {
+    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+  };
 
-  handleChangePanel(panelKey, event, expanded) {
-    this.setState({
-      expandedPanels: assoc(panelKey, expanded, this.state.expandedPanels),
-    });
-  }
-
-  isExpanded(type, numberOfEntities, numberOfTypes) {
-    if (this.state.expandedPanels[type] !== undefined) {
-      return this.state.expandedPanels[type];
+  const isExpanded = (type, numberOfEntities, numberOfTypes) => {
+    if (expandedPanels[type] !== undefined) {
+      return expandedPanels[type];
     }
     if (numberOfEntities === 1) {
       return true;
     }
     return numberOfTypes === 1;
-  }
+  };
 
-  render() {
-    const { t, classes, data, handleSelect } = this.props;
-    const stixDomainObjectsNodes = map(
-      (n) => n.node,
-      data.stixDomainObjects.edges,
-    );
-    const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
-    const stixDomainObjects = byType(stixDomainObjectsNodes);
-    const stixDomainObjectsTypes = keys(stixDomainObjects);
-    let increment = 0;
+  const { classes, data, handleSelect } = props;
+  const stixDomainObjectsNodes = map(
+    (n) => n.node,
+    data.stixDomainObjects.edges,
+  );
+  const byType = groupBy((stixDomainObject) => stixDomainObject.entity_type);
+  const stixDomainObjects = byType(stixDomainObjectsNodes);
+  const stixDomainObjectsTypes = keys(stixDomainObjects);
+  let increment = 0;
 
-    return (
-      <div className={classes.container}>
-        {stixDomainObjectsTypes.length > 0 ? (
-          stixDomainObjectsTypes.map((type) => {
-            increment += 1;
-            return (
-              <Accordion
-                key={type}
-                expanded={this.isExpanded(
-                  type,
-                  stixDomainObjects[type].length,
-                  stixDomainObjectsTypes.length,
-                )}
-                onChange={this.handleChangePanel.bind(this, type)}
-                elevation={3}
-                style={{
-                  marginBottom:
-                    increment === stixDomainObjectsTypes.length
-                    && this.isExpanded(
-                      type,
-                      stixDomainObjects[type].length,
-                      stixDomainObjectsTypes.length,
-                    )
-                      ? 16
-                      : 0,
-                }}
+  return (
+    <div className={classes.container}>
+      {stixDomainObjectsTypes.length > 0 ? (
+        stixDomainObjectsTypes.map((type) => {
+          increment += 1;
+          return (
+            <Accordion
+              key={type}
+              expanded={isExpanded(
+                type,
+                stixDomainObjects[type].length,
+                stixDomainObjectsTypes.length,
+              )}
+              onChange={handleChangePanel.bind(null, type)}
+              elevation={3}
+              style={{
+                marginBottom:
+                  increment === stixDomainObjectsTypes.length
+                  && isExpanded(
+                    type,
+                    stixDomainObjects[type].length,
+                    stixDomainObjectsTypes.length,
+                  )
+                    ? 16
+                    : 0,
+              }}
+            >
+              <AccordionSummary expandIcon={<ExpandMore />}>
+                <Typography className={classes.heading}>
+                  {t_i18n(`entity_${type}`)}
+                </Typography>
+                <Typography className={classes.secondaryHeading}>
+                  {stixDomainObjects[type].length} {t_i18n('entitie(s)')}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails
+                classes={{ root: classes.expansionPanelContent }}
               >
-                <AccordionSummary expandIcon={<ExpandMore />}>
-                  <Typography className={classes.heading}>
-                    {t(`entity_${type}`)}
-                  </Typography>
-                  <Typography className={classes.secondaryHeading}>
-                    {stixDomainObjects[type].length} {t('entitie(s)')}
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails
-                  classes={{ root: classes.expansionPanelContent }}
-                >
-                  <List classes={{ root: classes.list }}>
-                    {stixDomainObjects[type].map((stixDomainObject) => (
-                      <ListItemButton
-                        key={stixDomainObject.id}
-                        classes={{ root: classes.menuItem }}
-                        divider={true}
-                        onClick={handleSelect.bind(this, stixDomainObject)}
-                      >
-                        <ListItemIcon>
-                          <ItemIcon type={type} />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={stixDomainObject.name}
-                          secondary={truncate(
-                            stixDomainObject.description,
-                            100,
-                          )}
-                        />
-                      </ListItemButton>
-                    ))}
-                  </List>
-                </AccordionDetails>
-              </Accordion>
-            );
-          })
-        ) : (
-          <div className={classes.noResult}>
-            {t('No entities were found for this search.')}
-          </div>
-        )}
-      </div>
-    );
-  }
-}
+                <List classes={{ root: classes.list }}>
+                  {stixDomainObjects[type].map((stixDomainObject) => (
+                    <ListItemButton
+                      key={stixDomainObject.id}
+                      classes={{ root: classes.menuItem }}
+                      divider={true}
+                      onClick={handleSelect.bind(null, stixDomainObject)}
+                    >
+                      <ListItemIcon>
+                        <ItemIcon type={type} />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={stixDomainObject.name}
+                        secondary={truncate(
+                          stixDomainObject.description,
+                          100,
+                        )}
+                      />
+                    </ListItemButton>
+                  ))}
+                </List>
+              </AccordionDetails>
+            </Accordion>
+          );
+        })
+      ) : (
+        <div className={classes.noResult}>
+          {t_i18n('No entities were found for this search.')}
+        </div>
+      )}
+    </div>
+  );
+};
 
 StixSightingRelationshipCreationFromEntityLinesContainer.propTypes = {
   handleSelect: PropTypes.func,
   data: PropTypes.object,
   limit: PropTypes.number,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
 export const stixSightingRelationshipCreationFromEntityStixDomainObjectsLinesQuery = graphql`
@@ -320,7 +311,4 @@ const StixSightingRelationshipCreationFromEntityStixDomainObjectsLines = createP
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixSightingRelationshipCreationFromEntityStixDomainObjectsLines);
+export default withStyles(styles)(StixSightingRelationshipCreationFromEntityStixDomainObjectsLines);

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationFromEntityStixDomainObjectsLines.jsx
@@ -50,7 +50,7 @@ const StixSightingRelationshipCreationFromEntityLinesContainer = (props) => {
   const { t_i18n } = useFormatter();
   const [expandedPanels, setExpandedPanels] = useState({});
   const handleChangePanel = (panelKey, event, expanded) => {
-    setExpandedPanels(assoc(panelKey, expanded, expandedPanels));
+    setExpandedPanels((current) => assoc(panelKey, expanded, current));
   };
 
   const isExpanded = (type, numberOfEntities, numberOfTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorAddObservables.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import List from '@mui/material/List';
@@ -6,137 +7,129 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import { Component } from 'react';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import Drawer from '../../common/drawer/Drawer';
 import StixCyberObservableCreation from '../stix_cyber_observables/StixCyberObservableCreation';
 import IndicatorAddObservablesLines, { indicatorAddObservablesLinesQuery } from './IndicatorAddObservablesLines';
 
-class IndicatorAddObservables extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const IndicatorAddObservables = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+  };
 
-  handleClose() {
-    this.setState({ open: false });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, indicator, indicatorObservables } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-      orderBy: 'created_at',
-      orderMode: 'desc',
-    };
-    return (
-      <>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add observables')}
-          subHeader={{
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="searchInput"
-              />
-            )],
+  const { indicator, indicatorObservables } = props;
+  const paginationOptions = {
+    search: search,
+    orderBy: 'created_at',
+    orderMode: 'desc',
+  };
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add observables')}
+        subHeader={{
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="searchInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={indicatorAddObservablesLinesQuery}
+          variables={{
+            search: search,
+            orderBy: 'created_at',
+            orderMode: 'desc',
+            count: 50,
           }}
-        >
-          <QueryRenderer
-            query={indicatorAddObservablesLinesQuery}
-            variables={{
-              search: this.state.search,
-              orderBy: 'created_at',
-              orderMode: 'desc',
-              count: 50,
-            }}
-            render={({ props }) => {
-              if (props) {
-                return (
-                  <IndicatorAddObservablesLines
-                    indicator={indicator}
-                    indicatorObservables={indicatorObservables}
-                    data={props}
-                  />
-                );
-              }
+          render={({ props }) => {
+            if (props) {
               return (
-                <List>
-                  {Array.from(Array(20), (e, i) => (
-                    <ListItem key={i} divider={true}>
-                      <ListItemIcon>
+                <IndicatorAddObservablesLines
+                  indicator={indicator}
+                  indicatorObservables={indicatorObservables}
+                  data={props}
+                />
+              );
+            }
+            return (
+              <List>
+                {Array.from(Array(20), (e, i) => (
+                  <ListItem key={i} divider={true}>
+                    <ListItemIcon>
+                      <Skeleton
+                        animation="wave"
+                        variant="circular"
+                        width={30}
+                        height={30}
+                      />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={(
                         <Skeleton
                           animation="wave"
-                          variant="circular"
-                          width={30}
-                          height={30}
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                          style={{ marginBottom: 10 }}
                         />
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                            style={{ marginBottom: 10 }}
-                          />
-                        )}
-                        secondary={(
-                          <Skeleton
-                            animation="wave"
-                            variant="rectangular"
-                            width="90%"
-                            height={15}
-                          />
-                        )}
-                      />
-                    </ListItem>
-                  ))}
-                </List>
-              );
-            }}
-          />
-        </Drawer>
-        <StixCyberObservableCreation
-          display={this.state.open}
-          contextual={true}
-          inputValue={this.state.search}
-          paginationKey="Pagination_stixCyberObservables"
-          paginationOptions={paginationOptions}
+                      )}
+                      secondary={(
+                        <Skeleton
+                          animation="wave"
+                          variant="rectangular"
+                          width="90%"
+                          height={15}
+                        />
+                      )}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            );
+          }}
         />
-      </>
-    );
-  }
-}
+      </Drawer>
+      <StixCyberObservableCreation
+        display={open}
+        contextual={true}
+        inputValue={search}
+        paginationKey="Pagination_stixCyberObservables"
+        paginationOptions={paginationOptions}
+      />
+    </>
+  );
+};
 
 IndicatorAddObservables.propTypes = {
   indicator: PropTypes.object,
   indicatorObservables: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
 };
 
-export default compose(inject18n)(IndicatorAddObservables);
+export default IndicatorAddObservables;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableAddIndicators.jsx
@@ -1,8 +1,7 @@
+import { useState } from 'react';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import { Component } from 'react';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import Drawer from '../../common/drawer/Drawer';
@@ -16,92 +15,87 @@ const styles = () => ({
   },
 });
 
-class StixCyberObservableAddIndicators extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { search: '' };
-  }
+const StixCyberObservableAddIndicators = (props) => {
+  const { t_i18n } = useFormatter();
+  const [search, setSearch] = useState('');
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
+  const {
 
-  render() {
-    const {
-      t,
-      classes,
-      stixCyberObservable,
-      stixCyberObservableIndicators,
-      open,
-      handleClose,
-    } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-      orderBy: 'created_at',
-      orderMode: 'desc',
-    };
-    return (
-      <>
-        <Drawer
-          open={open}
-          onClose={handleClose.bind(this)}
-          title={t('Add indicators')}
-          subHeader={{
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="searchInput"
-              />
-            )],
+    classes,
+
+    stixCyberObservable,
+
+    stixCyberObservableIndicators,
+
+    open,
+
+    handleClose,
+
+  } = props;
+  const paginationOptions = {
+    search: search,
+    orderBy: 'created_at',
+    orderMode: 'desc',
+  };
+  return (
+    <>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add indicators')}
+        subHeader={{
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="searchInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={stixCyberObservableAddIndicatorsLinesQuery}
+          variables={{
+            search: search,
+            orderBy: 'created_at',
+            orderMode: 'desc',
+            count: 50,
           }}
-        >
-          <QueryRenderer
-            query={stixCyberObservableAddIndicatorsLinesQuery}
-            variables={{
-              search: this.state.search,
-              orderBy: 'created_at',
-              orderMode: 'desc',
-              count: 50,
-            }}
-            render={({ props }) => {
-              return (
-                <div>
-                  <StixCyberObservableAddIndicatorsLines
-                    stixCyberObservable={stixCyberObservable}
-                    stixCyberObservableIndicators={
-                      stixCyberObservableIndicators
-                    }
-                    data={props}
+          render={({ props }) => {
+            return (
+              <div>
+                <StixCyberObservableAddIndicatorsLines
+                  stixCyberObservable={stixCyberObservable}
+                  stixCyberObservableIndicators={
+                    stixCyberObservableIndicators
+                  }
+                  data={props}
+                />
+                <div className={classes.createButton}>
+                  <IndicatorCreation
+                    display={open}
+                    contextual
+                    paginationOptions={paginationOptions}
                   />
-                  <div className={classes.createButton}>
-                    <IndicatorCreation
-                      display={open}
-                      contextual
-                      paginationOptions={paginationOptions}
-                    />
-                  </div>
                 </div>
-              );
-            }}
-          />
-        </Drawer>
-      </>
-    );
-  }
-}
+              </div>
+            );
+          }}
+        />
+      </Drawer>
+    </>
+  );
+};
 
 StixCyberObservableAddIndicators.propTypes = {
   stixCyberObservable: PropTypes.object,
   stixCyberObservableIndicators: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   open: PropTypes.bool,
   handleClose: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservableAddIndicators);
+export default withStyles(styles)(StixCyberObservableAddIndicators);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -9,7 +8,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import Card from '@common/card/Card';
 import { QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import StixCyberObservableEntitiesLines, { stixCyberObservableEntitiesLinesQuery } from './StixCyberObservableEntitiesLines';
 import StixCoreRelationshipCreationFromEntity from '../../common/stix_core_relationships/StixCoreRelationshipCreationFromEntity';
 import Security from '../../../../utils/Security';
@@ -150,33 +149,27 @@ const inlineStylesHeaders = {
   },
 };
 
-class StixCyberObservableEntities extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      sortBy: null,
-      orderAsc: false,
-      searchTerm: '',
-      view: 'lines',
-      relationReversed: false,
-    };
-  }
+const StixCyberObservableEntities = (props) => {
+  const { t_i18n } = useFormatter();
+  const [sortBy, setSortBy] = useState(null);
+  const [orderAsc, setOrderAsc] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [relationReversed, setRelationReversed] = useState(false);
+  const handleReverseRelation = () => {
+    setRelationReversed(!relationReversed);
+  };
 
-  handleReverseRelation() {
-    this.setState({ relationReversed: !this.state.relationReversed });
-  }
+  const handleSort = (field, orderAsc) => {
+    setSortBy(field);
+    setOrderAsc(orderAsc);
+  };
 
-  handleSort(field, orderAsc) {
-    this.setState({ sortBy: field, orderAsc });
-  }
+  const handleSearch = (value) => {
+    setSearchTerm(value);
+  };
 
-  handleSearch(value) {
-    this.setState({ searchTerm: value });
-  }
-
-  SortHeader(field, label, isSortable) {
-    const { t } = this.props;
-    const sortComponent = this.state.orderAsc ? (
+  const SortHeader = (field, label, isSortable) => {
+    const sortComponent = orderAsc ? (
       <ArrowDropDown style={inlineStylesHeaders.iconSort} />
     ) : (
       <ArrowDropUp style={inlineStylesHeaders.iconSort} />
@@ -185,119 +178,112 @@ class StixCyberObservableEntities extends Component {
       return (
         <div
           style={inlineStylesHeaders[field]}
-          onClick={this.handleSort.bind(this, field, !this.state.orderAsc)}
+          onClick={handleSort.bind(null, field, !orderAsc)}
         >
-          <span>{t(label)}</span>
-          {this.state.sortBy === field ? sortComponent : ''}
+          <span>{t_i18n(label)}</span>
+          {sortBy === field ? sortComponent : ''}
         </div>
       );
     }
     return (
       <div style={inlineStylesHeaders[field]}>
-        <span>{t(label)}</span>
+        <span>{t_i18n(label)}</span>
       </div>
     );
-  }
+  };
 
-  render() {
-    const { sortBy, orderAsc, searchTerm, relationReversed } = this.state;
-    const { classes, t, entityId, defaultStartTime, defaultStopTime } = this.props;
-    const paginationOptions = {
-      fromOrToId: entityId,
-      search: searchTerm,
-      orderBy: sortBy,
-      orderMode: orderAsc ? 'asc' : 'desc',
-    };
-    return (
-      <div style={{ height: '100%' }}>
-        <Card
-          title={t('Relations')}
-          action={(
-            <Stack direction="row" gap={1}>
-              <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                <StixCoreRelationshipCreationFromEntity
-                  paginationOptions={paginationOptions}
-                  handleReverseRelation={this.handleReverseRelation.bind(this)}
-                  entityId={entityId}
-                  variant="inLine"
-                  isRelationReversed={relationReversed}
-                  targetStixDomainObjectTypes={['Stix-Domain-Object']}
-                  targetStixCyberObservableTypes={['Stix-Cyber-Observable']}
-                  defaultStartTime={defaultStartTime}
-                  defaultStopTime={defaultStopTime}
-                />
-              </Security>
-              <SearchInput
-                variant="thin"
-                onSubmit={this.handleSearch.bind(this)}
-                keyword={searchTerm}
+  const { classes, entityId, defaultStartTime, defaultStopTime } = props;
+  const paginationOptions = {
+    fromOrToId: entityId,
+    search: searchTerm,
+    orderBy: sortBy,
+    orderMode: orderAsc ? 'asc' : 'desc',
+  };
+  return (
+    <div style={{ height: '100%' }}>
+      <Card
+        title={t_i18n('Relations')}
+        action={(
+          <Stack direction="row" gap={1}>
+            <Security needs={[KNOWLEDGE_KNUPDATE]}>
+              <StixCoreRelationshipCreationFromEntity
+                paginationOptions={paginationOptions}
+                handleReverseRelation={handleReverseRelation}
+                entityId={entityId}
+                variant="inLine"
+                isRelationReversed={relationReversed}
+                targetStixDomainObjectTypes={['Stix-Domain-Object']}
+                targetStixCyberObservableTypes={['Stix-Cyber-Observable']}
+                defaultStartTime={defaultStartTime}
+                defaultStopTime={defaultStopTime}
               />
-            </Stack>
-          )}
-        >
-          <List style={{ marginTop: -10 }}>
-            <ListItem
-              classes={{ root: classes.itemHead }}
-              divider={false}
-              style={{ paddingTop: 0 }}
-              secondaryAction={<> &nbsp; </>}
-            >
-              <ListItemIcon>
-                <span
-                  style={{
-                    padding: '0 8px 0 8px',
-                    fontWeight: 700,
-                    fontSize: 12,
-                  }}
-                >
-                  &nbsp;
-                </span>
-              </ListItemIcon>
-              <ListItemText
-                primary={(
-                  <div>
-                    {this.SortHeader('relationship_type', 'Relationship', true)}
-                    {this.SortHeader('entity_tyoe', 'Entity type', false)}
-                    {this.SortHeader('name', 'Name', false)}
-                    {this.SortHeader('createdBy', 'Author', false)}
-                    {this.SortHeader('creator', 'Creator', false)}
-                    {this.SortHeader('start_time', 'Start time', true)}
-                    {this.SortHeader('stop_time', 'Stop time', true)}
-                    {this.SortHeader('confidence', 'Confidence level', true)}
-                  </div>
-                )}
-              />
-            </ListItem>
-            <QueryRenderer
-              query={stixCyberObservableEntitiesLinesQuery}
-              variables={{ count: 200, ...paginationOptions }}
-              render={({ props }) => (
-                <StixCyberObservableEntitiesLines
-                  data={props}
-                  paginationOptions={paginationOptions}
-                  displayRelation={true}
-                  stixCyberObservableId={entityId}
-                />
+            </Security>
+            <SearchInput
+              variant="thin"
+              onSubmit={handleSearch}
+              keyword={searchTerm}
+            />
+          </Stack>
+        )}
+      >
+        <List style={{ marginTop: -10 }}>
+          <ListItem
+            classes={{ root: classes.itemHead }}
+            divider={false}
+            style={{ paddingTop: 0 }}
+            secondaryAction={<> &nbsp; </>}
+          >
+            <ListItemIcon>
+              <span
+                style={{
+                  padding: '0 8px 0 8px',
+                  fontWeight: 700,
+                  fontSize: 12,
+                }}
+              >
+                &nbsp;
+              </span>
+            </ListItemIcon>
+            <ListItemText
+              primary={(
+                <div>
+                  {SortHeader('relationship_type', 'Relationship', true)}
+                  {SortHeader('entity_tyoe', 'Entity type', false)}
+                  {SortHeader('name', 'Name', false)}
+                  {SortHeader('createdBy', 'Author', false)}
+                  {SortHeader('creator', 'Creator', false)}
+                  {SortHeader('start_time', 'Start time', true)}
+                  {SortHeader('stop_time', 'Stop time', true)}
+                  {SortHeader('confidence', 'Confidence level', true)}
+                </div>
               )}
             />
-          </List>
-        </Card>
-      </div>
-    );
-  }
-}
+          </ListItem>
+          <QueryRenderer
+            query={stixCyberObservableEntitiesLinesQuery}
+            variables={{ count: 200, ...paginationOptions }}
+            render={({ props }) => (
+              <StixCyberObservableEntitiesLines
+                data={props}
+                paginationOptions={paginationOptions}
+                displayRelation={true}
+                stixCyberObservableId={entityId}
+              />
+            )}
+          />
+        </List>
+      </Card>
+    </div>
+  );
+};
 
 StixCyberObservableEntities.propTypes = {
   entityId: PropTypes.string,
   relationship_type: PropTypes.string,
   classes: PropTypes.object,
-  t: PropTypes.func,
   navigate: PropTypes.func,
   defaultStartTime: PropTypes.string,
   defaultStopTime: PropTypes.string,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservableEntities);
+export default withStyles(styles)(StixCyberObservableEntities);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
@@ -156,7 +156,7 @@ const StixCyberObservableEntities = (props) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [relationReversed, setRelationReversed] = useState(false);
   const handleReverseRelation = () => {
-    setRelationReversed(!relationReversed);
+    setRelationReversed((current) => !current);
   };
 
   const handleSort = (field, orderAsc) => {

--- a/opencti-platform/opencti-front/src/private/components/settings/kill_chain_phases/KillChainPhasePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/kill_chain_phases/KillChainPhasePopover.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import Dialog from '@common/dialog/Dialog';
@@ -9,9 +10,8 @@ import MenuItem from '@mui/material/MenuItem';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import { Component } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import KillChainPhaseEdition from './KillChainPhaseEdition';
@@ -30,128 +30,120 @@ const killChainPhasePopoverDeletionMutation = graphql`
   }
 `;
 
-class KillChainPhasePopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
+const KillChainPhasePopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: killChainPhasePopoverDeletionMutation,
       variables: {
-        id: this.props.killChainPhase.id,
+        id: props.killChainPhase.id,
       },
       updater: (store) => {
         deleteNode(
           store,
           'Pagination_killChainPhases',
-          this.props.paginationOptions,
-          this.props.killChainPhase.id,
+          props.paginationOptions,
+          props.killChainPhase.id,
         );
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
+        setDeleting(false);
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <KillChainPhaseEdition
-          killChainPhase={this.props.killChainPhase}
-          handleClose={this.handleCloseUpdate.bind(this)}
-          open={this.state.displayUpdate}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this kill chain phase?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <KillChainPhaseEdition
+        killChainPhase={props.killChainPhase}
+        handleClose={handleCloseUpdate}
+        open={displayUpdate}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this kill chain phase?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 KillChainPhasePopover.propTypes = {
   killChainPhase: PropTypes.object,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(KillChainPhasePopover);
+export default compose(withStyles(styles))(KillChainPhasePopover);

--- a/opencti-platform/opencti-front/src/private/components/settings/labels/LabelPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/labels/LabelPopover.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import Dialog from '@common/dialog/Dialog';
@@ -9,9 +10,8 @@ import MenuItem from '@mui/material/MenuItem';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import { Component } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import LabelEdition from './LabelEdition';
@@ -30,127 +30,119 @@ const labelPopoverDeletionMutation = graphql`
   }
 `;
 
-class LabelPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
+const LabelPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: labelPopoverDeletionMutation,
       variables: {
-        id: this.props.label.id,
+        id: props.label.id,
       },
       updater: (store) => deleteNode(
         store,
         'Pagination_labels',
-        this.props.paginationOptions,
-        this.props.label.id,
+        props.paginationOptions,
+        props.label.id,
       ),
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
+        setDeleting(false);
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <LabelEdition
-          label={this.props.label}
-          handleClose={this.handleCloseUpdate.bind(this)}
-          open={this.state.displayUpdate}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to delete this label?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <LabelEdition
+        label={props.label}
+        handleClose={handleCloseUpdate}
+        open={displayUpdate}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this label?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 LabelPopover.propTypes = {
   label: PropTypes.object,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(LabelPopover);
+export default compose(withStyles(styles))(LabelPopover);

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfAction.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddCoursesOfAction.jsx
@@ -1,96 +1,91 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddCoursesOfActionLines, { addCoursesOfActionLinesQuery } from './AddCoursesOfActionLines';
 import CourseOfActionCreation from '../courses_of_action/CourseOfActionCreation';
 
-class AddCoursesOfAction extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddCoursesOfAction = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, attackPattern, attackPatternCoursesOfAction } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    return (
-      <>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add courses of action')}
-          subHeader={{
-            right: [(
-              <CourseOfActionCreation
-                display={this.state.open}
-                contextual={true}
-                inputValue={this.state.search}
-                paginationOptions={paginationOptions}
-                key="rightButton"
-              />
-            )],
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
+  const { attackPattern, attackPatternCoursesOfAction } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add courses of action')}
+        subHeader={{
+          right: [(
+            <CourseOfActionCreation
+              display={open}
+              contextual={true}
+              inputValue={search}
+              paginationOptions={paginationOptions}
+              key="rightButton"
+            />
+          )],
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addCoursesOfActionLinesQuery}
+          variables={{
+            search: search,
+            count: 20,
           }}
-        >
-          <QueryRenderer
-            query={addCoursesOfActionLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 20,
-            }}
-            render={({ props }) => {
-              return (
-                <AddCoursesOfActionLines
-                  attackPattern={attackPattern}
-                  attackPatternCoursesOfAction={attackPatternCoursesOfAction}
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-      </>
-    );
-  }
-}
+          render={({ props }) => {
+            return (
+              <AddCoursesOfActionLines
+                attackPattern={attackPattern}
+                attackPatternCoursesOfAction={attackPatternCoursesOfAction}
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
+    </>
+  );
+};
 
 AddCoursesOfAction.propTypes = {
   attackPattern: PropTypes.object,
   attackPatternCoursesOfAction: PropTypes.array,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddCoursesOfAction);
+export default AddCoursesOfAction;

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPattern.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AddSubAttackPattern.jsx
@@ -1,99 +1,94 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddSubAttackPatternsLines, { addSubAttackPatternsLinesQuery } from './AddSubAttackPatternsLines';
 import AttackPatternCreation from './AttackPatternCreation';
 
-class AddSubAttackPattern extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddSubAttackPattern = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, attackPattern, attackPatternSubAttackPatterns } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    return (
-      <>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add sub attack patterns')}
-          subHeader={{
-            right: [(
-              <AttackPatternCreation
-                display={this.state.open}
-                contextual={true}
-                inputValue={this.state.search}
-                paginationOptions={paginationOptions}
-                key="rightButton"
-              />
-            )],
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
+  const { attackPattern, attackPatternSubAttackPatterns } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add sub attack patterns')}
+        subHeader={{
+          right: [(
+            <AttackPatternCreation
+              display={open}
+              contextual={true}
+              inputValue={search}
+              paginationOptions={paginationOptions}
+              key="rightButton"
+            />
+          )],
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addSubAttackPatternsLinesQuery}
+          variables={{
+            search: search,
+            count: 20,
           }}
-        >
-          <QueryRenderer
-            query={addSubAttackPatternsLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 20,
-            }}
-            render={({ props }) => {
-              return (
-                <AddSubAttackPatternsLines
-                  attackPattern={attackPattern}
-                  attackPatternSubAttackPatterns={
-                    attackPatternSubAttackPatterns
-                  }
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-      </>
-    );
-  }
-}
+          render={({ props }) => {
+            return (
+              <AddSubAttackPatternsLines
+                attackPattern={attackPattern}
+                attackPatternSubAttackPatterns={
+                  attackPatternSubAttackPatterns
+                }
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
+    </>
+  );
+};
 
 AddSubAttackPattern.propTypes = {
   attackPattern: PropTypes.object,
   attackPatternSubAttackPatterns: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddSubAttackPattern);
+export default AddSubAttackPattern;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/AddAttackPatterns.jsx
@@ -1,93 +1,91 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddAttackPatternsLines, { addAttackPatternsLinesQuery } from './AddAttackPatternsLines';
 
-class AddAttackPatterns extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddAttackPatterns = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
+  const {
 
-  render() {
-    const {
-      t,
-      courseOfAction,
-      courseOfActionAttackPatterns,
-      courseOfActionPaginationOptions,
-    } = this.props;
-    return (
-      <div>
-        <IconButton
-          color="primary"
-          aria-label="Attack Pattern"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add attack patterns')}
-          subHeader={{
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="searchInput"
-              />
-            )],
+    courseOfAction,
+
+    courseOfActionAttackPatterns,
+
+    courseOfActionPaginationOptions,
+
+  } = props;
+  return (
+    <div>
+      <IconButton
+        color="primary"
+        aria-label="Attack Pattern"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add attack patterns')}
+        subHeader={{
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="searchInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addAttackPatternsLinesQuery}
+          variables={{
+            search: search,
+            count: 20,
           }}
-        >
-          <QueryRenderer
-            query={addAttackPatternsLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 20,
-            }}
-            render={({ props }) => {
-              return (
-                <AddAttackPatternsLines
-                  courseOfAction={courseOfAction}
-                  courseOfActionAttackPatterns={courseOfActionAttackPatterns}
-                  courseOfActionPaginationOptions={
-                    courseOfActionPaginationOptions
-                  }
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-      </div>
-    );
-  }
-}
+          render={({ props }) => {
+            return (
+              <AddAttackPatternsLines
+                courseOfAction={courseOfAction}
+                courseOfActionAttackPatterns={courseOfActionAttackPatterns}
+                courseOfActionPaginationOptions={
+                  courseOfActionPaginationOptions
+                }
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
+    </div>
+  );
+};
 
 AddAttackPatterns.propTypes = {
   courseOfAction: PropTypes.object,
   courseOfActionAttackPatterns: PropTypes.array,
   courseOfActionPaginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddAttackPatterns);
+export default AddAttackPatterns;

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
@@ -44,7 +44,7 @@ const CourseOfActionAttackPatternComponent = (props) => {
   const { t_i18n } = useFormatter();
   const [expanded, setExpanded] = useState(false);
   const handleToggleExpand = () => {
-    setExpanded(!expanded);
+    setExpanded((current) => !current);
   };
 
   const removeAttackPattern = (attackPatternEdge) => {

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose, filter } from 'ramda';
+import { filter } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -17,7 +17,7 @@ import { truncate } from '../../../../utils/String';
 import AddAttackPatterns from './AddAttackPatterns';
 import { addAttackPatternsLinesMutationRelationDelete } from './AddAttackPatternsLines';
 import { commitMutation } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Label from '../../../../components/common/label/Label';
 
 const styles = (theme) => ({
@@ -40,28 +40,23 @@ const styles = (theme) => ({
   },
 });
 
-class CourseOfActionAttackPatternComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      expanded: false,
-    };
-  }
+const CourseOfActionAttackPatternComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expanded, setExpanded] = useState(false);
+  const handleToggleExpand = () => {
+    setExpanded(!expanded);
+  };
 
-  handleToggleExpand() {
-    this.setState({ expanded: !this.state.expanded });
-  }
-
-  removeAttackPattern(attackPatternEdge) {
+  const removeAttackPattern = (attackPatternEdge) => {
     commitMutation({
       mutation: addAttackPatternsLinesMutationRelationDelete,
       variables: {
-        fromId: this.props.courseOfAction.id,
+        fromId: props.courseOfAction.id,
         toId: attackPatternEdge.node.id,
         relationship_type: 'mitigates',
       },
       updater: (store) => {
-        const node = store.get(this.props.courseOfAction.id);
+        const node = store.get(props.courseOfAction.id);
         const attackPatterns = node.getLinkedRecord('attackPatterns');
         const edges = attackPatterns.getLinkedRecords('edges');
         const newEdges = filter(
@@ -72,86 +67,81 @@ class CourseOfActionAttackPatternComponent extends Component {
         attackPatterns.setLinkedRecords(newEdges, 'edges');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, classes, courseOfAction } = this.props;
-    const { expanded } = this.state;
-    const attackPatternsEdges = courseOfAction.attackPatterns.edges;
-    const expandable = attackPatternsEdges.length > 7;
-    return (
-      <Box sx={{ marginTop: 2 }}>
-        <Label action={(
-          <>
-            <AddAttackPatterns
-              courseOfAction={courseOfAction}
-              courseOfActionAttackPatterns={courseOfAction.attackPatterns.edges}
-            />
-            {expandable && (
-              <IconButton
-                aria-label={expanded ? t('Collapse') : t('Expand')}
-                color="primary"
-                onClick={this.handleToggleExpand.bind(this)}
-                aria-expanded={expanded}
-              >
-                {expanded ? <ExpandLessOutlined /> : <ExpandMoreOutlined />}
-              </IconButton>
-            )}
-          </>
-        )}
-        >
-          {t('Mitigated attack patterns')}
-        </Label>
-        <List classes={{ root: classes.list }}>
-          {R.take(expanded ? 200 : 7, attackPatternsEdges).map(
-            (attackPatternEdge) => {
-              const attackPattern = attackPatternEdge.node;
-              return (
-                <ListItem
-                  key={attackPattern.id}
-                  dense={true}
-                  divider={true}
-                  disablePadding={true}
-                  secondaryAction={(
-                    <IconButton
-                      aria-label="Remove"
-                      onClick={this.removeAttackPattern.bind(
-                        this,
-                        attackPatternEdge,
-                      )}
-                    >
-                      <LinkOff />
-                    </IconButton>
-                  )}
-                >
-                  <ListItemButton
-                    component={Link}
-                    to={`/dashboard/techniques/attack_patterns/${attackPattern.id}`}
-                  >
-                    <ListItemIcon>
-                      <Avatar classes={{ root: classes.avatar }}>
-                        {attackPattern.name.substring(0, 1)}
-                      </Avatar>
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={attackPattern.name}
-                      secondary={truncate(attackPattern.description, 60)}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              );
-            },
+  const { classes, courseOfAction } = props;
+  const attackPatternsEdges = courseOfAction.attackPatterns.edges;
+  const expandable = attackPatternsEdges.length > 7;
+  return (
+    <Box sx={{ marginTop: 2 }}>
+      <Label action={(
+        <>
+          <AddAttackPatterns
+            courseOfAction={courseOfAction}
+            courseOfActionAttackPatterns={courseOfAction.attackPatterns.edges}
+          />
+          {expandable && (
+            <IconButton
+              aria-label={expanded ? t_i18n('Collapse') : t_i18n('Expand')}
+              color="primary"
+              onClick={handleToggleExpand}
+              aria-expanded={expanded}
+            >
+              {expanded ? <ExpandLessOutlined /> : <ExpandMoreOutlined />}
+            </IconButton>
           )}
-        </List>
-      </Box>
-    );
-  }
-}
+        </>
+      )}
+      >
+        {t_i18n('Mitigated attack patterns')}
+      </Label>
+      <List classes={{ root: classes.list }}>
+        {R.take(expanded ? 200 : 7, attackPatternsEdges).map(
+          (attackPatternEdge) => {
+            const attackPattern = attackPatternEdge.node;
+            return (
+              <ListItem
+                key={attackPattern.id}
+                dense={true}
+                divider={true}
+                disablePadding={true}
+                secondaryAction={(
+                  <IconButton
+                    aria-label="Remove"
+                    onClick={removeAttackPattern.bind(
+                      null,
+                      attackPatternEdge,
+                    )}
+                  >
+                    <LinkOff />
+                  </IconButton>
+                )}
+              >
+                <ListItemButton
+                  component={Link}
+                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}`}
+                >
+                  <ListItemIcon>
+                    <Avatar classes={{ root: classes.avatar }}>
+                      {attackPattern.name.substring(0, 1)}
+                    </Avatar>
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={attackPattern.name}
+                    secondary={truncate(attackPattern.description, 60)}
+                  />
+                </ListItemButton>
+              </ListItem>
+            );
+          },
+        )}
+      </List>
+    </Box>
+  );
+};
 
 CourseOfActionAttackPatternComponent.propTypes = {
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fld: PropTypes.func,
   courseOfAction: PropTypes.object,
 };
 
@@ -179,7 +169,4 @@ const CourseOfActionAttackPattern = createFragmentContainer(
   },
 );
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(CourseOfActionAttackPattern);
+export default withStyles(styles)(CourseOfActionAttackPattern);

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/AddSubNarrative.jsx
@@ -1,97 +1,92 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddSubNarrativesLines, { addSubNarrativesLinesQuery } from './AddSubNarrativesLines';
 import NarrativeCreation from './NarrativeCreation';
 
-class AddSubNarrative extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddSubNarrative = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, narrative, narrativeSubNarratives } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    return (
-      <div>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add subnarratives')}
-          subHeader={{
-            right: [(
-              <NarrativeCreation
-                display={this.state.open}
-                contextual={true}
-                inputValue={this.state.search}
-                paginationOptions={paginationOptions}
-                key="rightButton"
-              />
-            )],
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
+  const { narrative, narrativeSubNarratives } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  return (
+    <div>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add subnarratives')}
+        subHeader={{
+          right: [(
+            <NarrativeCreation
+              display={open}
+              contextual={true}
+              inputValue={search}
+              paginationOptions={paginationOptions}
+              key="rightButton"
+            />
+          )],
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addSubNarrativesLinesQuery}
+          variables={{
+            search: search,
+            count: 20,
           }}
-        >
-          <QueryRenderer
-            query={addSubNarrativesLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 20,
-            }}
-            render={({ props }) => {
-              return (
-                <AddSubNarrativesLines
-                  narrative={narrative}
-                  narrativeSubNarratives={narrativeSubNarratives}
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-      </div>
-    );
-  }
-}
+          render={({ props }) => {
+            return (
+              <AddSubNarrativesLines
+                narrative={narrative}
+                narrativeSubNarratives={narrativeSubNarratives}
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
+    </div>
+  );
+};
 
 AddSubNarrative.propTypes = {
   narrative: PropTypes.object,
   narrativeSubNarratives: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(AddSubNarrative);
+export default AddSubNarrative;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEdition.jsx
@@ -1,9 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import { graphql } from 'react-relay';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
-import inject18n from '../../../../components/i18n';
 import CampaignEditionContainer from './CampaignEditionContainer';
 import { campaignEditionOverviewFocus } from './CampaignEditionOverview';
 import Loader from '../../../../components/Loader';
@@ -17,54 +15,41 @@ export const campaignEditionQuery = graphql`
   }
 `;
 
-class CampaignEdition extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false };
-  }
-
-  handleOpen() {
-    this.setState({ open: true });
-  }
-
-  handleClose() {
+const CampaignEdition = (props) => {
+  const handleClose = () => {
     commitMutation({
       mutation: campaignEditionOverviewFocus,
       variables: {
-        id: this.props.campaignId,
+        id: props.campaignId,
         input: { focusOn: '' },
       },
     });
-    this.setState({ open: false });
-  }
+  };
 
-  render() {
-    const { campaignId } = this.props;
-    return (
-      <QueryRenderer
-        query={campaignEditionQuery}
-        variables={{ id: campaignId }}
-        render={({ props }) => {
-          if (props) {
-            return (
-              <CampaignEditionContainer
-                campaign={props.campaign}
-                handleClose={this.handleClose.bind(this)}
-                controlledDial={EditEntityControlledDial}
-              />
-            );
-          }
-          return <Loader variant="inline" />;
-        }}
-      />
-    );
-  }
-}
+  const { campaignId } = props;
+  return (
+    <QueryRenderer
+      query={campaignEditionQuery}
+      variables={{ id: campaignId }}
+      render={({ props }) => {
+        if (props) {
+          return (
+            <CampaignEditionContainer
+              campaign={props.campaign}
+              handleClose={handleClose}
+              controlledDial={EditEntityControlledDial}
+            />
+          );
+        }
+        return <Loader variant="inline" />;
+      }}
+    />
+  );
+};
 
 CampaignEdition.propTypes = {
   campaignId: PropTypes.string,
   theme: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n)(CampaignEdition);
+export default CampaignEdition;

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/AddLocations.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import AddLocationsLines, { addLocationsLinesQuery } from './AddLocationsLines';
@@ -19,95 +19,91 @@ const styles = () => ({
   },
 });
 
-class AddLocations extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddLocations = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, intrusionSet, intrusionSetLocations } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    const updater = (store) => insertNode(
-      store,
-      'Pagination_locations',
-      paginationOptions,
-      'locationAdd',
-    );
-    return (
-      <>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add locations')}
-          subHeader={{
-            right: [(
-              <LocationCreation
-                display={this.state.open}
-                contextual={true}
-                inputValue={this.state.search}
-                paginationOptions={paginationOptions}
-                updater={updater}
-                key="rightButton"
-              />
-            )],
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
+  const { intrusionSet, intrusionSetLocations } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  const updater = (store) => insertNode(
+    store,
+    'Pagination_locations',
+    paginationOptions,
+    'locationAdd',
+  );
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add locations')}
+        subHeader={{
+          right: [(
+            <LocationCreation
+              display={open}
+              contextual={true}
+              inputValue={search}
+              paginationOptions={paginationOptions}
+              updater={updater}
+              key="rightButton"
+            />
+          )],
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addLocationsLinesQuery}
+          variables={{
+            search: search,
+            count: 20,
           }}
-        >
-          <QueryRenderer
-            query={addLocationsLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 20,
-            }}
-            render={({ props }) => {
-              return (
-                <AddLocationsLines
-                  intrusionSet={intrusionSet}
-                  intrusionSetLocations={intrusionSetLocations}
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
-      </>
-    );
-  }
-}
+          render={({ props }) => {
+            return (
+              <AddLocationsLines
+                intrusionSet={intrusionSet}
+                intrusionSetLocations={intrusionSetLocations}
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
+    </>
+  );
+};
 
 AddLocations.propTypes = {
   intrusionSet: PropTypes.object,
   intrusionSetLocations: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(AddLocations);
+export default compose(withStyles(styles))(AddLocations);

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroup.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/AddLocationsThreatActorGroup.jsx
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import Drawer from '../../common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import SearchInput from '../../../../components/SearchInput';
 import { QueryRenderer } from '../../../../relay/environment';
 import LocationCreation from '../../common/location/LocationCreation';
@@ -19,99 +18,92 @@ const styles = () => ({
   },
 });
 
-class AddLocationsThreatActorGroup extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, search: '' };
-  }
+const AddLocationsThreatActorGroup = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+    setSearch('');
+  };
 
-  handleClose() {
-    this.setState({ open: false, search: '' });
-  }
+  const handleSearch = (keyword) => {
+    setSearch(keyword);
+  };
 
-  handleSearch(keyword) {
-    this.setState({ search: keyword });
-  }
-
-  render() {
-    const { t, threatActorGroup, threatActorGroupLocations } = this.props;
-    const paginationOptions = {
-      search: this.state.search,
-    };
-    const updater = (store) => insertNode(
-      store,
-      'Pagination_threatActorGroup_locations',
-      paginationOptions,
-      'locationAdd',
-    );
-    return (
-      <>
-        <IconButton
-          color="primary"
-          aria-label="Add"
-          onClick={this.handleOpen.bind(this)}
-        >
-          <Add fontSize="small" />
-        </IconButton>
-        <Drawer
-          open={this.state.open}
-          onClose={this.handleClose.bind(this)}
-          title={t('Add locations')}
-          subHeader={{
-            right: [(
-              <LocationCreation
-                display={this.state.open}
-                contextual={true}
-                inputValue={this.state.search}
-                paginationOptions={paginationOptions}
-                updater={updater}
-                key="rightButton"
-              />
-            )],
-            left: [(
-              <SearchInput
-                variant="inDrawer"
-                onSubmit={this.handleSearch.bind(this)}
-                key="leftInput"
-              />
-            )],
+  const { threatActorGroup, threatActorGroupLocations } = props;
+  const paginationOptions = {
+    search: search,
+  };
+  const updater = (store) => insertNode(
+    store,
+    'Pagination_threatActorGroup_locations',
+    paginationOptions,
+    'locationAdd',
+  );
+  return (
+    <>
+      <IconButton
+        color="primary"
+        aria-label="Add"
+        onClick={handleOpen}
+      >
+        <Add fontSize="small" />
+      </IconButton>
+      <Drawer
+        open={open}
+        onClose={handleClose}
+        title={t_i18n('Add locations')}
+        subHeader={{
+          right: [(
+            <LocationCreation
+              display={open}
+              contextual={true}
+              inputValue={search}
+              paginationOptions={paginationOptions}
+              updater={updater}
+              key="rightButton"
+            />
+          )],
+          left: [(
+            <SearchInput
+              variant="inDrawer"
+              onSubmit={handleSearch}
+              key="leftInput"
+            />
+          )],
+        }}
+      >
+        <QueryRenderer
+          query={addLocationsThreatActorGroupLinesQuery}
+          variables={{
+            search: search,
+            count: 100,
           }}
-        >
-          <QueryRenderer
-            query={addLocationsThreatActorGroupLinesQuery}
-            variables={{
-              search: this.state.search,
-              count: 100,
-            }}
-            render={({ props }) => {
-              return (
-                <AddLocationsThreatActorGroupLines
-                  threatActorGroup={threatActorGroup}
-                  threatActorGroupLocations={threatActorGroupLocations}
-                  data={props}
-                />
-              );
-            }}
-          />
-        </Drawer>
+          render={({ props }) => {
+            return (
+              <AddLocationsThreatActorGroupLines
+                threatActorGroup={threatActorGroup}
+                threatActorGroupLocations={threatActorGroupLocations}
+                data={props}
+              />
+            );
+          }}
+        />
+      </Drawer>
 
-      </>
-    );
-  }
-}
+    </>
+  );
+};
 
 AddLocationsThreatActorGroup.propTypes = {
   threatActorGroup: PropTypes.object,
   threatActorGroupLocations: PropTypes.array,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(AddLocationsThreatActorGroup);
+export default withStyles(styles)(AddLocationsThreatActorGroup);


### PR DESCRIPTION
Closes #17971

> Base branch is `issue/17967-inject18n-class-components` (#17969), so this diff only shows this tranche.

## Proposed changes

Second tranche of the `inject18n` migration: the **26 consumers whose class carries state but no lifecycle method and no ref**. `this.state` becomes `useState`, `this.setState` becomes the matching setter, and the injected props come from `useFormatter`.

Every `setState` in this set used the object-literal form — none took an updater function or a completion callback — so each call maps to exactly one setter.

`inject18n` consumers go from 75 to 49. The remainder need lifecycle or ref conversions and come in the last tranche, together with `StixCoreRelationshipOverview` (4877 lines) and `StixSightingRelationshipOverview` (3258), which are stateful too but would have made this change unreviewable.

## Dead state the conversion exposed

`no-unused-vars` does not look at class fields or methods, so a class can carry state nothing reads without anything flagging it. Turning these into consts made five cases visible:

- **`ChannelEdition`, `EventEdition`, `CampaignEdition`** each declared an `open` state and a `handleOpen` method. `open` was never read and `handleOpen` never called.
- **`StixCyberObservableEntities`** declared a `view` state nothing read.
- **`IdentityCreation`** declared an `open` state plus `handleOpen` / `handleClose` methods that were shadowed by props of the same name. `render()` read the props, so the internal ones only mutated state nothing read.

All of it is removed. Since the state was never read, removing the writes that fed it changes nothing observable.

## One thing left alone

In `IdentityCreation`, the `else` branch of `onSubmit` called the *internal* `handleClose`, which only set dead state — so the branch did nothing at all. It most likely meant `props.handleClose()`.

I dropped the branch as the no-op it was rather than repointing it, because repointing it would change behaviour. Worth a decision from someone who knows the intent.

## Verification

Measured against the base branch, which is clean on all of these:

| | base | this branch |
|---|---|---|
| `yarn check-ts` | 0 errors | 0 errors |
| `yarn lint` on touched files | clean | clean |
| `yarn build` | passes | passes |
| `TZ=UTC yarn test` | 150 files / 1326 tests | 150 files / 1326 tests |

Also checked across the 26 files: no `extends Component`, no `setState`, no `this`, no `inject18n` reference left, and no injected prop still destructured from `props`.

## Related issues

Closes #17971

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/updated the relevant documentation (not applicable, internal refactor)
