### PR TITLE
refactor(frontend): convert the remaining lifecycle-free inject18n classes to function components (#17973)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "Keine Akkumulation von Erstellern",
   "No custom field for this entity type": "Kein benutzerdefiniertes Feld für diesen Entitätstyp",
   "No custom map uploaded, using the bundled map": "Es wurde keine benutzerdefinierte Karte hochgeladen, es wird die mitgelieferte Karte verwendet",
+  "No data": "Keine Daten",
   "No data available.": "Keine Daten verfügbar.",
   "No data has been found.": "Es wurden keine Daten gefunden.",
   "No default": "Keine Voreinstellung",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "No creators accumulation",
   "No custom field for this entity type": "No custom field for this entity type",
   "No custom map uploaded, using the bundled map": "No custom map uploaded, using the bundled map",
+  "No data": "No data",
   "No data available.": "No data available.",
   "No data has been found.": "No data has been found.",
   "No default": "No default",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "Sin acumulación de creadores",
   "No custom field for this entity type": "No hay ningún campo personalizado para este tipo de entidad",
   "No custom map uploaded, using the bundled map": "No se ha subido ningún mapa personalizado; se utilizará el mapa incluido",
+  "No data": "No hay datos",
   "No data available.": "No hay datos disponibles.",
   "No data has been found.": "No se han encontrado datos.",
   "No default": "No por defecto",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "Pas d'accumulation de créateurs",
   "No custom field for this entity type": "Aucun champ personnalisé pour ce type d’entité",
   "No custom map uploaded, using the bundled map": "Aucune carte personnalisée n'a été téléchargée ; utilisation de la carte fournie par défaut",
+  "No data": "Aucune donnée",
   "No data available.": "Pas de données disponibles.",
   "No data has been found.": "Aucune donnée n'a été trouvée.",
   "No default": "Pas de défaut",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "Nessun accumulo di creatori",
   "No custom field for this entity type": "Nessun campo personalizzato per questo tipo di entità",
   "No custom map uploaded, using the bundled map": "Nessuna mappa personalizzata caricata; si utilizza la mappa inclusa nel pacchetto",
+  "No data": "Nessun dato",
   "No data available.": "Nessun dato disponibile.",
   "No data has been found.": "Nessun dato è stato trovato.",
   "No default": "Nessun valore predefinito",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "クリエーターの蓄積がない",
   "No custom field for this entity type": "このエンティティタイプにはカスタムフィールドがありません",
   "No custom map uploaded, using the bundled map": "カスタムマップがアップロードされていないため、同梱のマップを使用します",
+  "No data": "データなし",
   "No data available.": "データなし",
   "No data has been found.": "データは見つかっていない。",
   "No default": "デフォルトなし",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "크리에이터 누적 없음",
   "No custom field for this entity type": "이 엔티티 유형에 대한 사용자 정의 필드가 없습니다",
   "No custom map uploaded, using the bundled map": "사용자 정의 맵이 업로드되지 않았으므로 기본 제공 맵을 사용합니다.",
+  "No data": "데이터 없음",
   "No data available.": "사용 가능한 데이터가 없습니다.",
   "No data has been found.": "데이터를 찾을 수 없습니다.",
   "No default": "기본값 없음",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "Не накапливать творцов",
   "No custom field for this entity type": "Для этого типа сущности пользовательские поля отсутствуют",
   "No custom map uploaded, using the bundled map": "Пользовательская карта не загружена, используется карта из комплекта поставки",
+  "No data": "Данных нет",
   "No data available.": "Данные отсутствуют.",
   "No data has been found.": "Никаких данных не найдено.",
   "No default": "Нет по умолчанию",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3208,6 +3208,7 @@
   "No creators accumulation": "没有创作者积累",
   "No custom field for this entity type": "此实体类型没有自定义字段",
   "No custom map uploaded, using the bundled map": "未上传自定义地图，使用内置地图",
+  "No data": "无数据",
   "No data available.": "无数据。",
   "No data has been found.": "未找到数据。",
   "No default": "无默认值",

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFilePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFilePopover.jsx
@@ -10,9 +10,9 @@ import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../../components/i18n';
+import { useFormatter } from '../../../../../components/i18n';
 import { APP_BASE_PATH, commitMutation } from '../../../../../relay/environment';
 import { resolveLink } from '../../../../../utils/Entity';
 import withRouter from '../../../../../utils/compat_router/withRouter';
@@ -45,118 +45,109 @@ const workbenchFilePopoverDeleteMutation = graphql`
   }
 `;
 
-class WorkbenchFilePopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
+const WorkbenchFilePopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
-    const { file } = this.props;
+  const submitDelete = () => {
+    setDeleting(true);
+    const { file } = props;
     commitMutation({
       mutation: workbenchFilePopoverDeleteMutation,
       variables: { fileName: file.id },
       onCompleted: () => {
-        if (this.props.file.metaData.entity) {
+        if (props.file.metaData.entity) {
           const entityLink = `${resolveLink(
-            this.props.file.metaData.entity.entity_type,
-          )}/${this.props.file.metaData.entity.id}`;
-          this.props.navigate(`${entityLink}/files`);
+            props.file.metaData.entity.entity_type,
+          )}/${props.file.metaData.entity.id}`;
+          props.navigate(`${entityLink}/files`);
         } else {
-          this.props.navigate('/dashboard/data/import');
+          props.navigate('/dashboard/data/import');
         }
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, file } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          onClick={this.handleOpen.bind(this)}
-          aria-label={t('Open menu')}
-          aria-haspopup="true"
-          size="default"
-          variant="secondary"
+  const { classes, file } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        onClick={handleOpen}
+        aria-label={t_i18n('Open menu')}
+        aria-haspopup="true"
+        size="default"
+        variant="secondary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem
+          component="a"
+          href={`${APP_BASE_PATH}/storage/get/${encodeURIComponent(file.id)}`}
         >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem
-            component="a"
-            href={`${APP_BASE_PATH}/storage/get/${encodeURIComponent(file.id)}`}
+          {t_i18n('Download')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this workbench?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
           >
-            {t('Download')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this workbench?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 WorkbenchFilePopover.propTypes = {
   file: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   navigate: PropTypes.func,
 };
 
 export default compose(
-  inject18n,
   withRouter,
   withStyles(styles),
 )(WorkbenchFilePopover);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipPopover.jsx
@@ -9,10 +9,9 @@ import MenuItem from '@mui/material/MenuItem';
 import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNodeFromContainer } from '../../../../utils/store';
 import StixCoreRelationshipEdition from './StixCoreRelationshipEdition';
@@ -47,54 +46,49 @@ const stixCoreRelationshipPopoverDeletionMutation = graphql`
   }
 `;
 
-class StixCoreRelationshipPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
+const StixCoreRelationshipPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
     event.stopPropagation();
-  }
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: stixCoreRelationshipPopoverDeletionMutation,
       variables: {
-        id: this.props.stixCoreRelationshipId,
+        id: props.stixCoreRelationshipId,
       },
       updater: (store) => {
-        if (typeof this.props.onDelete !== 'function') {
-          const { stixCoreRelationshipId, paginationOptions, connectionKey, objectId } = this.props;
+        if (typeof props.onDelete !== 'function') {
+          const { stixCoreRelationshipId, paginationOptions, connectionKey, objectId } = props;
           const currentConnectionKey = connectionKey || 'Pagination_stixCoreRelationships';
           if (stixCoreRelationshipId) {
             deleteNodeFromContainer(
@@ -108,91 +102,85 @@ class StixCoreRelationshipPopover extends Component {
         }
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
-        if (typeof this.props.onDelete === 'function') {
-          this.props.onDelete();
+        setDeleting(false);
+        handleCloseDelete();
+        if (typeof props.onDelete === 'function') {
+          props.onDelete();
         }
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, stixCoreRelationshipId, disabled, isCoverage } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          disabled={disabled}
-          color="primary"
-        >
-          <MoreVertOutlined />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        {stixCoreRelationshipId && (
-          <StixCoreRelationshipEdition
-            variant="noGraph"
-            stixCoreRelationshipId={stixCoreRelationshipId}
-            open={this.state.displayUpdate}
-            handleClose={this.handleCloseUpdate.bind(this)}
-            noStoreUpdate={true}
-            isCoverage={isCoverage}
-          />
-        )}
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this relation?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes, stixCoreRelationshipId, disabled, isCoverage } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        disabled={disabled}
+        color="primary"
+      >
+        <MoreVertOutlined />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      {stixCoreRelationshipId && (
+        <StixCoreRelationshipEdition
+          variant="noGraph"
+          stixCoreRelationshipId={stixCoreRelationshipId}
+          open={displayUpdate}
+          handleClose={handleCloseUpdate}
+          noStoreUpdate={true}
+          isCoverage={isCoverage}
+        />
+      )}
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this relation?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 StixCoreRelationshipPopover.propTypes = {
   stixCoreRelationshipId: PropTypes.string,
   disabled: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   onDelete: PropTypes.func,
   connectionKey: PropTypes.string,
   objectId: PropTypes.string,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipPopover);
+export default withStyles(styles)(StixCoreRelationshipPopover);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExportCreation.jsx
@@ -9,11 +9,11 @@ import withStyles from '@mui/styles/withStyles';
 import { Field, Form, Formik } from 'formik';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import * as Yup from 'yup';
 import SelectField from '../../../../components/fields/SelectField';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
 import { commitMutation, MESSAGING$, QueryRenderer } from '../../../../relay/environment';
 import { ExportContext } from '../../../../utils/ExportContextProvider';
@@ -75,18 +75,15 @@ export const scopesConn = (exportConnectors) => {
   return R.fromPairs(zipped);
 };
 
-class StixCoreRelationshipsExportCreationComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { selectedContentMaxMarkingsIds: [] };
-  }
+const StixCoreRelationshipsExportCreationComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState([]);
+  const handleSelectedContentMaxMarkingsChange = (values) => {
+    setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
+  };
 
-  handleSelectedContentMaxMarkingsChange(values) {
-    this.setState({ selectedContentMaxMarkingsIds: values.map(({ value }) => value) });
-  }
-
-  onSubmit(selectedIds, availableFilterKeys, values, { setSubmitting, resetForm }) {
-    const { paginationOptions, exportContext } = this.props;
+  const onSubmit = (selectedIds, availableFilterKeys, values, { setSubmitting, resetForm }) => {
+    const { paginationOptions, exportContext } = props;
     const { orderBy, orderMode, filters, search } = paginationOptions;
     const contentMaxMarkings = values.contentMaxMarkings.map(({ value }) => value);
     const fileMarkings = values.fileMarkings.map(({ value }) => value);
@@ -120,161 +117,159 @@ class StixCoreRelationshipsExportCreationComponent extends Component {
       onCompleted: () => {
         setSubmitting(false);
         resetForm();
-        if (this.props.onExportAsk) this.props.onExportAsk();
-        this.props.onClose();
+        if (props.onExportAsk) props.onExportAsk();
+        props.onClose();
         MESSAGING$.notifySuccess('Export successfully started');
       },
     });
-  }
+  };
 
-  render() {
-    const { t, data, open, onClose } = this.props;
-    const connectorsExport = data?.connectorsForExport ?? [];
-    const exportScopes = R.uniq(
-      R.flatten(R.map((c) => c.connector_scope, connectorsExport)),
-    );
-    const exportConnsPerFormat = scopesConn(connectorsExport);
+  const { data, open, onClose } = props;
+  const connectorsExport = data?.connectorsForExport ?? [];
+  const exportScopes = R.uniq(
+    R.flatten(R.map((c) => c.connector_scope, connectorsExport)),
+  );
+  const exportConnsPerFormat = scopesConn(connectorsExport);
 
-    const isExportActive = (format) => exportConnsPerFormat[format].filter((x) => x.data.active).length > 0;
-    const visibleColumnExportEnabledFormats = ['text/csv'];
+  const isExportActive = (format) => exportConnsPerFormat[format].filter((x) => x.data.active).length > 0;
+  const visibleColumnExportEnabledFormats = ['text/csv'];
 
-    return (
-      <UserContext.Consumer>
-        {({ schema }) => {
-          const availableFilterKeys = Array.from(schema.filterKeysSchema.get('stix-core-relationship')?.keys() ?? []).concat(['entity_type']);
-          return (
-            <ExportContext.Consumer>
-              {({ selectedIds }) => {
-                return (
-                  <div>
-                    <Formik
-                      enableReinitialize={true}
-                      initialValues={{
-                        format: '',
-                        contentMaxMarkings: [],
-                        fileMarkings: [],
-                        columns: 'all',
-                      }}
-                      validationSchema={exportValidation(t)}
-                      onSubmit={this.onSubmit.bind(this, selectedIds, availableFilterKeys)}
-                      onReset={onClose}
-                    >
-                      {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue, values }) => (
-                        <Form>
-                          <Dialog
-                            data-testid="StixCoreRelationshipsExportCreationDialog"
-                            open={open}
-                            onClose={() => {
-                              resetForm();
-                              onClose();
-                            }}
-                            title={(
-                              <>
-                                {t('Generate an export')}
-                                <Tooltip title={t('Your max shareable markings will be applied to the content max markings')}>
-                                  <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
-                                </Tooltip>
-                              </>
-                            )}
-                          >
-                            <QueryRenderer
-                              query={markingDefinitionsLinesSearchQuery}
-                              variables={{ first: 200 }}
-                              render={({ props }) => {
-                                if (props && props.markingDefinitions) {
-                                  return (
-                                    <>
-                                      <Field
-                                        component={SelectField}
-                                        variant="standard"
-                                        name="format"
-                                        label={t('Export format')}
-                                        fullWidth={true}
-                                        containerstyle={{ width: '100%' }}
-                                      >
-                                        {exportScopes.map((value, i) => (
-                                          <MenuItem
-                                            key={i}
-                                            value={value}
-                                            disabled={!isExportActive(value)}
+  return (
+    <UserContext.Consumer>
+      {({ schema }) => {
+        const availableFilterKeys = Array.from(schema.filterKeysSchema.get('stix-core-relationship')?.keys() ?? []).concat(['entity_type']);
+        return (
+          <ExportContext.Consumer>
+            {({ selectedIds }) => {
+              return (
+                <div>
+                  <Formik
+                    enableReinitialize={true}
+                    initialValues={{
+                      format: '',
+                      contentMaxMarkings: [],
+                      fileMarkings: [],
+                      columns: 'all',
+                    }}
+                    validationSchema={exportValidation(t_i18n)}
+                    onSubmit={onSubmit.bind(null, selectedIds, availableFilterKeys)}
+                    onReset={onClose}
+                  >
+                    {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue, values }) => (
+                      <Form>
+                        <Dialog
+                          data-testid="StixCoreRelationshipsExportCreationDialog"
+                          open={open}
+                          onClose={() => {
+                            resetForm();
+                            onClose();
+                          }}
+                          title={(
+                            <>
+                              {t_i18n('Generate an export')}
+                              <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
+                                <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
+                              </Tooltip>
+                            </>
+                          )}
+                        >
+                          <QueryRenderer
+                            query={markingDefinitionsLinesSearchQuery}
+                            variables={{ first: 200 }}
+                            render={({ props }) => {
+                              if (props && props.markingDefinitions) {
+                                return (
+                                  <>
+                                    <Field
+                                      component={SelectField}
+                                      variant="standard"
+                                      name="format"
+                                      label={t_i18n('Export format')}
+                                      fullWidth={true}
+                                      containerstyle={{ width: '100%' }}
+                                    >
+                                      {exportScopes.map((value, i) => (
+                                        <MenuItem
+                                          key={i}
+                                          value={value}
+                                          disabled={!isExportActive(value)}
+                                        >
+                                          {value}
+                                        </MenuItem>
+                                      ))}
+                                    </Field>
+                                    <ObjectMarkingField
+                                      name="contentMaxMarkings"
+                                      label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
+                                      onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
+                                      style={fieldSpacingContainerStyle}
+                                      setFieldValue={setFieldValue}
+                                      limitToMaxSharing
+                                      helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
+                                    />
+                                    <ObjectMarkingField
+                                      name="fileMarkings"
+                                      label={t_i18n('File marking definition levels')}
+                                      filterTargetIds={selectedContentMaxMarkingsIds}
+                                      style={fieldSpacingContainerStyle}
+                                      setFieldValue={setFieldValue}
+                                    />
+                                    {visibleColumnExportEnabledFormats.includes(values.format)
+                                      ? (
+                                          <Field
+                                            component={SelectField}
+                                            variant="standard"
+                                            name="columns"
+                                            label={t_i18n('Choose column to export')}
+                                            fullWidth={true}
+                                            containerstyle={fieldSpacingContainerStyle}
                                           >
-                                            {value}
-                                          </MenuItem>
-                                        ))}
-                                      </Field>
-                                      <ObjectMarkingField
-                                        name="contentMaxMarkings"
-                                        label={t(CONTENT_MAX_MARKINGS_TITLE)}
-                                        onChange={(_, values) => this.handleSelectedContentMaxMarkingsChange(values)}
-                                        style={fieldSpacingContainerStyle}
-                                        setFieldValue={setFieldValue}
-                                        limitToMaxSharing
-                                        helpertext={t(CONTENT_MAX_MARKINGS_HELPERTEXT)}
-                                      />
-                                      <ObjectMarkingField
-                                        name="fileMarkings"
-                                        label={t('File marking definition levels')}
-                                        filterTargetIds={this.state.selectedContentMaxMarkingsIds}
-                                        style={fieldSpacingContainerStyle}
-                                        setFieldValue={setFieldValue}
-                                      />
-                                      {visibleColumnExportEnabledFormats.includes(values.format)
-                                        ? (
-                                            <Field
-                                              component={SelectField}
-                                              variant="standard"
-                                              name="columns"
-                                              label={t('Choose column to export')}
-                                              fullWidth={true}
-                                              containerstyle={fieldSpacingContainerStyle}
-                                            >
-                                              <MenuItem value="all">
-                                                {t('All attributes')}
-                                              </MenuItem>
-                                              <MenuItem value="view">
-                                                {t('Current view')}
-                                              </MenuItem>
-                                            </Field>
-                                          )
-                                        : undefined}
-                                    </>
-                                  );
-                                }
-                                return <Loader variant="inElement" />;
+                                            <MenuItem value="all">
+                                              {t_i18n('All attributes')}
+                                            </MenuItem>
+                                            <MenuItem value="view">
+                                              {t_i18n('Current view')}
+                                            </MenuItem>
+                                          </Field>
+                                        )
+                                      : undefined}
+                                  </>
+                                );
+                              }
+                              return <Loader variant="inElement" />;
+                            }}
+                          />
+                          <DialogActions>
+                            <Button
+                              variant="secondary"
+                              onClick={() => {
+                                handleReset();
+                                onClose();
                               }}
-                            />
-                            <DialogActions>
-                              <Button
-                                variant="secondary"
-                                onClick={() => {
-                                  handleReset();
-                                  onClose();
-                                }}
-                                disabled={isSubmitting}
-                              >
-                                {t('Cancel')}
-                              </Button>
-                              <Button
-                                onClick={submitForm}
-                                disabled={isSubmitting}
-                              >
-                                {t('Create')}
-                              </Button>
-                            </DialogActions>
-                          </Dialog>
-                        </Form>
-                      )}
-                    </Formik>
-                  </div>
-                );
-              }}
-            </ExportContext.Consumer>
-          );
-        }}
-      </UserContext.Consumer>
-    );
-  }
-}
+                              disabled={isSubmitting}
+                            >
+                              {t_i18n('Cancel')}
+                            </Button>
+                            <Button
+                              onClick={submitForm}
+                              disabled={isSubmitting}
+                            >
+                              {t_i18n('Create')}
+                            </Button>
+                          </DialogActions>
+                        </Dialog>
+                      </Form>
+                    )}
+                  </Formik>
+                </div>
+              );
+            }}
+          </ExportContext.Consumer>
+        );
+      }}
+    </UserContext.Consumer>
+  );
+};
 
 const StixCoreRelationshipsExportCreations = createFragmentContainer(
   StixCoreRelationshipsExportCreationComponent,
@@ -295,7 +290,6 @@ const StixCoreRelationshipsExportCreations = createFragmentContainer(
 
 StixCoreRelationshipsExportCreations.propTypes = {
   classes: PropTypes.object.isRequired,
-  t: PropTypes.func,
   data: PropTypes.object,
   exportContext: PropTypes.object,
   paginationOptions: PropTypes.object,
@@ -304,7 +298,4 @@ StixCoreRelationshipsExportCreations.propTypes = {
   onClose: PropTypes.func,
 };
 
-export default R.compose(
-  inject18n,
-  withStyles(styles),
-)(StixCoreRelationshipsExportCreations);
+export default withStyles(styles)(StixCoreRelationshipsExportCreations);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExports.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipsExports.jsx
@@ -1,44 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import Slide from '@mui/material/Slide';
 import Drawer from '../drawer/Drawer';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixCoreRelationshipsExportsContent, { stixCoreRelationshipsExportsContentQuery } from './StixCoreRelationshipsExportsContent';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 
 const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
 ));
 Transition.displayName = 'TransitionSlide';
 
-class StixCoreRelationshipsExports extends Component {
-  render() {
-    const { t, paginationOptions, open, handleToggle, exportContext } = this.props;
-    return (
-      <Drawer
-        open={open}
-        onClose={handleToggle.bind(this)}
-        title={t('Exports list')}
-        size="medium"
-      >
-        <QueryRenderer
-          query={stixCoreRelationshipsExportsContentQuery}
-          variables={{ count: 25, exportContext }}
-          render={({ props }) => (
-            <StixCoreRelationshipsExportsContent
-              handleToggle={handleToggle.bind(this)}
-              data={props}
-              paginationOptions={paginationOptions}
-              exportContext={exportContext}
-              isOpen={open}
-            />
-          )}
-        />
-      </Drawer>
-    );
-  }
-}
+const StixCoreRelationshipsExports = (props) => {
+  const { t_i18n } = useFormatter();
+  const { paginationOptions, open, handleToggle, exportContext } = props;
+  return (
+    <Drawer
+      open={open}
+      onClose={handleToggle}
+      title={t_i18n('Exports list')}
+      size="medium"
+    >
+      <QueryRenderer
+        query={stixCoreRelationshipsExportsContentQuery}
+        variables={{ count: 25, exportContext }}
+        render={({ props }) => (
+          <StixCoreRelationshipsExportsContent
+            handleToggle={handleToggle}
+            data={props}
+            paginationOptions={paginationOptions}
+            exportContext={exportContext}
+            isOpen={open}
+          />
+        )}
+      />
+    </Drawer>
+  );
+};
 
 StixCoreRelationshipsExports.propTypes = {
   open: PropTypes.bool,
@@ -48,4 +46,4 @@ StixCoreRelationshipsExports.propTypes = {
   exportContext: PropTypes.object,
 };
 
-export default compose(inject18n)(StixCoreRelationshipsExports);
+export default StixCoreRelationshipsExports;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Link } from 'react-router-dom';
@@ -14,7 +14,7 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { createRefetchContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import { yearFormat } from '../../../../utils/Time';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import StixCoreRelationshipPopover from '../stix_core_relationships/StixCoreRelationshipPopover';
 import ItemYears from '../../../../components/ItemYears';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -32,234 +32,227 @@ const styles = (theme) => ({
   },
 });
 
-class StixDomainObjectGlobalKillChainComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expandedLines: {} };
-  }
+const StixDomainObjectGlobalKillChainComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const [expandedLines, setExpandedLines] = useState({});
+  const handleToggleLine = (lineKey) => {
+    setExpandedLines(R.assoc(
+      lineKey,
+      expandedLines[lineKey] !== undefined
+        ? !expandedLines[lineKey]
+        : false,
+      expandedLines,
+    ));
+  };
 
-  handleToggleLine(lineKey) {
-    this.setState({
-      expandedLines: R.assoc(
-        lineKey,
-        this.state.expandedLines[lineKey] !== undefined
-          ? !this.state.expandedLines[lineKey]
-          : false,
-        this.state.expandedLines,
-      ),
-    });
-  }
+  const { classes, data, entityLink, paginationOptions, stixDomainObjectId } = props;
+  // Extract all kill chain phases
+  const killChainPhases = R.pipe(
 
-  render() {
-    const { t, classes, data, entityLink, paginationOptions, stixDomainObjectId } = this.props;
-    // Extract all kill chain phases
-    const killChainPhases = R.pipe(
+    R.map((n) => (n.node
+      && n.node.killChainPhases
+      && n.node.killChainPhases.length > 0
+      ? n.node.killChainPhases[0]
+      : n.node
+        && n.node.to
+        && n.node.to.killChainPhases
+        && n.node.to.killChainPhases.length > 0
+        ? n.node.to.killChainPhases[0]
+        : { id: 'unknown', phase_name: t_i18n('Unknown'), x_opencti_order: 99 })),
+    R.uniq,
+    R.indexBy(R.prop('id')),
+  )(data.stixRelationships.edges);
+  const stixRelationships = R.pipe(
+    R.map((n) => n.node),
+    R.map((n) => R.assoc(
+      'startTimeYear',
+      yearFormat(n.start_time) === '1970'
+        ? t_i18n('None')
+        : yearFormat(n.start_time),
+      n,
+    )),
+    R.map((n) => R.assoc(
+      'stopTimeYear',
+      yearFormat(n.stop_time) === '5138'
+        ? t_i18n('None')
+        : yearFormat(n.stop_time),
+      n,
+    )),
+    R.map((n) => R.assoc(
+      'years',
+      n.startTimeYear === n.stopTimeYear
+        ? n.startTimeYear
+        : `${n.startTimeYear} - ${n.stopTimeYear}`,
+      n,
+    )),
+    R.map((n) => R.assoc(
+      'killChainPhase',
 
-      R.map((n) => (n.node
-        && n.node.killChainPhases
-        && n.node.killChainPhases.length > 0
-        ? n.node.killChainPhases[0]
-        : n.node
-          && n.node.to
-          && n.node.to.killChainPhases
-          && n.node.to.killChainPhases.length > 0
-          ? n.node.to.killChainPhases[0]
-          : { id: 'unknown', phase_name: t('Unknown'), x_opencti_order: 99 })),
-      R.uniq,
-      R.indexBy(R.prop('id')),
-    )(data.stixRelationships.edges);
-    const stixRelationships = R.pipe(
-      R.map((n) => n.node),
-      R.map((n) => R.assoc(
-        'startTimeYear',
-        yearFormat(n.start_time) === '1970'
-          ? t('None')
-          : yearFormat(n.start_time),
-        n,
-      )),
-      R.map((n) => R.assoc(
-        'stopTimeYear',
-        yearFormat(n.stop_time) === '5138'
-          ? t('None')
-          : yearFormat(n.stop_time),
-        n,
-      )),
-      R.map((n) => R.assoc(
-        'years',
-        n.startTimeYear === n.stopTimeYear
-          ? n.startTimeYear
-          : `${n.startTimeYear} - ${n.stopTimeYear}`,
-        n,
-      )),
-      R.map((n) => R.assoc(
-        'killChainPhase',
-
-        n && n.killChainPhases && n.killChainPhases.length > 0
-          ? n.killChainPhases[0]
-          : n
-            && n.to
-            && n.to.killChainPhases
-            && n.to.killChainPhases.length > 0
-            ? n.to.killChainPhases[0]
-            : { id: 'unknown', phase_name: t('Unknown'), x_opencti_order: 99 },
-        n,
-      )),
-      R.sortWith([R.ascend(R.prop('years'))]),
-      R.groupBy(R.path(['killChainPhase', 'id'])),
-      R.mapObjIndexed((value, key) => R.assoc('stixDomainObjects', value, killChainPhases[key])),
-      R.values,
-      R.sortWith([R.ascend(R.prop('x_opencti_order'))]),
-    )(data.stixRelationships.edges);
-    return (
-      <div style={{ marginBottom: 90 }}>
-        <div id="container">
-          <List id="test">
-            {stixRelationships.map((stixRelationship) => (
-              <div key={stixRelationship.id}>
-                <ListItem
-                  divider={true}
-                  disablePadding
-                  secondaryAction={(
-                    <IconButton
-                      aria-label={this.state.expandedLines[stixRelationship.id] ? t('Collapse') : t('Expand')}
-                      onClick={this.handleToggleLine.bind(
-                        this,
-                        stixRelationship.id,
-                      )}
-                      aria-expanded={this.state.expandedLines[stixRelationship.id]}
-                    >
-                      {this.state.expandedLines[stixRelationship.id]
-                        === false ? (
-                            <ExpandMore />
-                          ) : (
-                            <ExpandLess />
-                          )}
-                    </IconButton>
-                  )}
-                >
-                  <ListItemButton
-                    onClick={this.handleToggleLine.bind(
-                      this,
+      n && n.killChainPhases && n.killChainPhases.length > 0
+        ? n.killChainPhases[0]
+        : n
+          && n.to
+          && n.to.killChainPhases
+          && n.to.killChainPhases.length > 0
+          ? n.to.killChainPhases[0]
+          : { id: 'unknown', phase_name: t_i18n('Unknown'), x_opencti_order: 99 },
+      n,
+    )),
+    R.sortWith([R.ascend(R.prop('years'))]),
+    R.groupBy(R.path(['killChainPhase', 'id'])),
+    R.mapObjIndexed((value, key) => R.assoc('stixDomainObjects', value, killChainPhases[key])),
+    R.values,
+    R.sortWith([R.ascend(R.prop('x_opencti_order'))]),
+  )(data.stixRelationships.edges);
+  return (
+    <div style={{ marginBottom: 90 }}>
+      <div id="container">
+        <List id="test">
+          {stixRelationships.map((stixRelationship) => (
+            <div key={stixRelationship.id}>
+              <ListItem
+                divider={true}
+                disablePadding
+                secondaryAction={(
+                  <IconButton
+                    aria-label={expandedLines[stixRelationship.id] ? t_i18n('Collapse') : t_i18n('Expand')}
+                    onClick={handleToggleLine.bind(
+                      null,
                       stixRelationship.id,
                     )}
+                    aria-expanded={expandedLines[stixRelationship.id]}
                   >
-                    <ListItemIcon>
-                      <Launch color="primary" role="img" />
-                    </ListItemIcon>
-                    <ListItemText primary={stixRelationship.phase_name} />
-                  </ListItemButton>
-                </ListItem>
-                <Collapse
-                  in={this.state.expandedLines[stixRelationship.id] !== false}
+                    {expandedLines[stixRelationship.id]
+                      === false ? (
+                          <ExpandMore />
+                        ) : (
+                          <ExpandLess />
+                        )}
+                  </IconButton>
+                )}
+              >
+                <ListItemButton
+                  onClick={handleToggleLine.bind(
+                    null,
+                    stixRelationship.id,
+                  )}
                 >
-                  <List>
-                    {stixRelationship.stixDomainObjects.map(
-                      (stixDomainObject) => {
-                        const entityToDisplay = (stixDomainObject.to?.id === stixDomainObjectId) ? stixDomainObject.from : stixDomainObject.to;
-                        const restricted = entityToDisplay === null;
-                        const link = `${entityLink}/relations/${stixDomainObject.id}`;
-                        const buildDomainObjectPrimaryText = () => {
-                          if (!restricted) {
-                            if (entityToDisplay.entity_type === 'Attack-Pattern') {
-                              if (entityToDisplay.x_mitre_id) {
-                                return defaultRender(
-                                  <span>
-                                    <strong>
-                                      {entityToDisplay.x_mitre_id}
-                                    </strong>{'  '}
-                                    - {entityToDisplay.name}
-                                  </span>,
-                                );
-                              }
+                  <ListItemIcon>
+                    <Launch color="primary" role="img" />
+                  </ListItemIcon>
+                  <ListItemText primary={stixRelationship.phase_name} />
+                </ListItemButton>
+              </ListItem>
+              <Collapse
+                in={expandedLines[stixRelationship.id] !== false}
+              >
+                <List>
+                  {stixRelationship.stixDomainObjects.map(
+                    (stixDomainObject) => {
+                      const entityToDisplay = (stixDomainObject.to?.id === stixDomainObjectId) ? stixDomainObject.from : stixDomainObject.to;
+                      const restricted = entityToDisplay === null;
+                      const link = `${entityLink}/relations/${stixDomainObject.id}`;
+                      const buildDomainObjectPrimaryText = () => {
+                        if (!restricted) {
+                          if (entityToDisplay.entity_type === 'Attack-Pattern') {
+                            if (entityToDisplay.x_mitre_id) {
                               return defaultRender(
                                 <span>
-                                  {entityToDisplay.name}
+                                  <strong>
+                                    {entityToDisplay.x_mitre_id}
+                                  </strong>{'  '}
+                                  - {entityToDisplay.name}
                                 </span>,
                               );
                             }
-                            return defaultRender(entityToDisplay.name);
+                            return defaultRender(
+                              <span>
+                                {entityToDisplay.name}
+                              </span>,
+                            );
                           }
-                          return t('Restricted');
-                        };
-                        const domainObjectPrimaryText = buildDomainObjectPrimaryText();
+                          return defaultRender(entityToDisplay.name);
+                        }
+                        return t_i18n('Restricted');
+                      };
+                      const domainObjectPrimaryText = buildDomainObjectPrimaryText();
 
-                        return (
-                          <ListItem
-                            key={stixDomainObject.id}
-                            divider={true}
-                            dense={true}
-                            disablePadding
-                            secondaryAction={(
-                              <StixCoreRelationshipPopover
-                                stixCoreRelationshipId={stixDomainObject.id}
-                                paginationOptions={paginationOptions}
-                                onDelete={this.props.relay.refetch.bind(this)}
-                              />
-                            )}
+                      return (
+                        <ListItem
+                          key={stixDomainObject.id}
+                          divider={true}
+                          dense={true}
+                          disablePadding
+                          secondaryAction={(
+                            <StixCoreRelationshipPopover
+                              stixCoreRelationshipId={stixDomainObject.id}
+                              paginationOptions={paginationOptions}
+                              onDelete={props.relay.refetch}
+                            />
+                          )}
+                        >
+                          <ListItemButton
+                            classes={{ root: classes.nested }}
+                            component={Link}
+                            to={link}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 3,
+                            }}
                           >
-                            <ListItemButton
-                              classes={{ root: classes.nested }}
-                              component={Link}
-                              to={link}
+                            <ListItemIcon className={classes.itemIcon}>
+                              <ItemIcon
+                                type={
+                                  !restricted
+                                    ? entityToDisplay.entity_type
+                                    : 'restricted'
+                                }
+                              />
+                            </ListItemIcon>
+                            <ListItemText
+                              sx={{ marginRight: 8, width: '100%' }}
+                              primary={domainObjectPrimaryText}
+                              secondary={(
+                                <MarkdownDisplay
+                                  content={stixDomainObject.description}
+                                  remarkGfmPlugin={true}
+                                  commonmark={true}
+                                />
+                              )}
+                            />
+                            <Box
                               sx={{
+                                width: 150,
+                                marginRight: 6,
                                 display: 'flex',
-                                alignItems: 'center',
-                                gap: 3,
+                                justifyContent: 'center',
                               }}
                             >
-                              <ListItemIcon className={classes.itemIcon}>
-                                <ItemIcon
-                                  type={
-                                    !restricted
-                                      ? entityToDisplay.entity_type
-                                      : 'restricted'
-                                  }
-                                />
-                              </ListItemIcon>
-                              <ListItemText
-                                sx={{ marginRight: 8, width: '100%' }}
-                                primary={domainObjectPrimaryText}
-                                secondary={(
-                                  <MarkdownDisplay
-                                    content={stixDomainObject.description}
-                                    remarkGfmPlugin={true}
-                                    commonmark={true}
-                                  />
-                                )}
+                              <ItemMarkings
+                                markingDefinitions={stixDomainObject.objectMarking ?? []}
+                                limit={1}
                               />
-                              <Box
-                                sx={{
-                                  width: 150,
-                                  marginRight: 6,
-                                  display: 'flex',
-                                  justifyContent: 'center',
-                                }}
-                              >
-                                <ItemMarkings
-                                  markingDefinitions={stixDomainObject.objectMarking ?? []}
-                                  limit={1}
-                                />
-                              </Box>
-                              <Box sx={{ marginRight: 8 }}>
-                                <ItemYears
-                                  years={stixDomainObject.years}
-                                />
-                              </Box>
-                            </ListItemButton>
-                          </ListItem>
-                        );
-                      },
-                    )}
-                  </List>
-                </Collapse>
-              </div>
-            ))}
-          </List>
-        </div>
+                            </Box>
+                            <Box sx={{ marginRight: 8 }}>
+                              <ItemYears
+                                years={stixDomainObject.years}
+                              />
+                            </Box>
+                          </ListItemButton>
+                        </ListItem>
+                      );
+                    },
+                  )}
+                </List>
+              </Collapse>
+            </div>
+          ))}
+        </List>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 StixDomainObjectGlobalKillChainComponent.propTypes = {
   stixDomainObjectId: PropTypes.string,
@@ -267,7 +260,6 @@ StixDomainObjectGlobalKillChainComponent.propTypes = {
   entityLink: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
 const StixDomainObjectGlobalKillChain = createRefetchContainer(
@@ -479,7 +471,4 @@ const StixDomainObjectGlobalKillChain = createRefetchContainer(
   stixDomainObjectThreatKnowledgeStixRelationshipsQuery,
 );
 
-export default R.compose(
-  inject18n,
-  withStyles(styles),
-)(StixDomainObjectGlobalKillChain);
+export default withStyles(styles)(StixDomainObjectGlobalKillChain);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -36,12 +36,10 @@ const StixDomainObjectGlobalKillChainComponent = (props) => {
   const { t_i18n } = useFormatter();
   const [expandedLines, setExpandedLines] = useState({});
   const handleToggleLine = (lineKey) => {
-    setExpandedLines(R.assoc(
+    setExpandedLines((current) => R.assoc(
       lineKey,
-      expandedLines[lineKey] !== undefined
-        ? !expandedLines[lineKey]
-        : false,
-      expandedLines,
+      current[lineKey] !== undefined ? !current[lineKey] : false,
+      current,
     ));
   };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTimeline.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTimeline.jsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose, pipe, map, assoc } from 'ramda';
+import { pipe, map, assoc } from 'ramda';
 import withTheme from '@mui/styles/withTheme';
 import Typography from '@mui/material/Typography';
 import Timeline from '@mui/lab/Timeline';
@@ -15,7 +15,7 @@ import { graphql, createRefetchContainer } from 'react-relay';
 import { Link } from 'react-router-dom';
 import Slide from '@mui/material/Slide';
 import ItemIcon from '../../../../components/ItemIcon';
-import inject18n, { isDateStringNone } from '../../../../components/i18n';
+import { useFormatter, isDateStringNone } from '../../../../components/i18n';
 import { stixDomainObjectThreatKnowledgeStixRelationshipsQuery } from './StixDomainObjectThreatKnowledgeQuery';
 import { truncate } from '../../../../utils/String';
 import { getSecondaryRepresentative, getMainRepresentative } from '../../../../utils/defaultRepresentatives';
@@ -27,93 +27,63 @@ const Transition = React.forwardRef((props, ref) => (
 ));
 Transition.displayName = 'TransitionSlide';
 
-class StixDomainObjectTimelineComponent extends Component {
-  render() {
-    const {
-      fldt,
-      theme,
-      data,
-      stixDomainObjectId,
-      entityLink,
-      timeField,
-      t,
-    } = this.props;
-    const stixRelationships = pipe(
-      map((n) => n.node),
-      map((n) => (n.from && n.from.id === stixDomainObjectId
-        ? assoc('targetEntity', n.to, n)
-        : assoc('targetEntity', n.from, n))),
-    )(data.stixRelationships.edges);
+const StixDomainObjectTimelineComponent = (props) => {
+  const { fldt, t_i18n } = useFormatter();
+  const {
+    theme,
+    data,
+    stixDomainObjectId,
+    entityLink,
+    timeField,
+  } = props;
+  const stixRelationships = pipe(
+    map((n) => n.node),
+    map((n) => (n.from && n.from.id === stixDomainObjectId
+      ? assoc('targetEntity', n.to, n)
+      : assoc('targetEntity', n.from, n))),
+  )(data.stixRelationships.edges);
 
-    const getDate = (relationship) => {
-      const dateList = timeField === 'technical'
-        ? [relationship.created, relationship.created_at]
-        : [relationship.start_time, relationship.first_seen, relationship.created_at];
+  const getDate = (relationship) => {
+    const dateList = timeField === 'technical'
+      ? [relationship.created, relationship.created_at]
+      : [relationship.start_time, relationship.first_seen, relationship.created_at];
 
-      const usableDate = dateList.find((date) => date && !isDateStringNone(date));
-      return fldt(usableDate);
-    };
+    const usableDate = dateList.find((date) => date && !isDateStringNone(date));
+    return fldt(usableDate);
+  };
 
-    return (
-      <div style={{ marginBottom: 90 }}>
-        <div id="container">
-          <Timeline position="alternate">
-            {stixRelationships.map((stixRelationship) => {
-              let link = null;
-              if (
-                stixRelationship.parent_types.includes('stix-core-relationship')
-              ) {
-                link = `${entityLink}/relations/${stixRelationship.id}`;
-              } else if (
-                stixRelationship.entity_type === 'stix-sighting-relationship'
-              ) {
-                link = `${entityLink}/sightings/${stixRelationship.id}`;
-              }
-              const restricted = stixRelationship.targetEntity === null;
-              return (
-                <TimelineItem key={stixRelationship.id}>
-                  <TimelineOppositeContent
-                    sx={{ paddingTop: '18px' }}
-                    color="text.secondary"
-                  >
-                    {getDate(stixRelationship)}
-                  </TimelineOppositeContent>
-                  <TimelineSeparator>
-                    {link ? (
-                      <Link to={link}>
-                        <Tooltip
-                          title={
-                            !restricted
-                              ? getMainRepresentative(stixRelationship.targetEntity)
-                              : t('Restricted')
-                          }
-                        >
-                          <TimelineDot
-                            sx={{
-                              borderColor: !restricted
-                                ? itemColor(
-                                    stixRelationship.targetEntity.entity_type,
-                                  )
-                                : theme.palette.primary.main,
-                            }}
-                            variant="outlined"
-                          >
-                            <ItemIcon
-                              type={
-                                !restricted
-                                  ? stixRelationship.targetEntity.entity_type
-                                  : t('Restricted')
-                              }
-                            />
-                          </TimelineDot>
-                        </Tooltip>
-                      </Link>
-                    ) : (
+  return (
+    <div style={{ marginBottom: 90 }}>
+      <div id="container">
+        <Timeline position="alternate">
+          {stixRelationships.map((stixRelationship) => {
+            let link = null;
+            if (
+              stixRelationship.parent_types.includes('stix-core-relationship')
+            ) {
+              link = `${entityLink}/relations/${stixRelationship.id}`;
+            } else if (
+              stixRelationship.entity_type === 'stix-sighting-relationship'
+            ) {
+              link = `${entityLink}/sightings/${stixRelationship.id}`;
+            }
+            const restricted = stixRelationship.targetEntity === null;
+            return (
+              <TimelineItem key={stixRelationship.id}>
+                <TimelineOppositeContent
+                  sx={{ paddingTop: '18px' }}
+                  color="text.secondary"
+                >
+                  {getDate(stixRelationship)}
+                </TimelineOppositeContent>
+                <TimelineSeparator>
+                  {link ? (
+                    <Link to={link}>
                       <Tooltip
                         title={
                           !restricted
                             ? getMainRepresentative(stixRelationship.targetEntity)
-                            : t('Restricted')
+                            : t_i18n('Restricted')
                         }
                       >
                         <TimelineDot
@@ -130,49 +100,76 @@ class StixDomainObjectTimelineComponent extends Component {
                             type={
                               !restricted
                                 ? stixRelationship.targetEntity.entity_type
-                                : t('Restricted')
+                                : t_i18n('Restricted')
                             }
                           />
                         </TimelineDot>
                       </Tooltip>
-                    )}
-                    <TimelineConnector />
-                  </TimelineSeparator>
-                  <TimelineContent>
-                    <Card>
-                      <Typography variant="h2">
-                        {!restricted
-                          ? truncate(
-                              getMainRepresentative(stixRelationship.targetEntity),
-                              50,
-                            )
-                          : t('Restricted')}
-                      </Typography>
-                      <span style={{ color: '#a8a8a8' }}>
-                        {truncate(
+                    </Link>
+                  ) : (
+                    <Tooltip
+                      title={
+                        !restricted
+                          ? getMainRepresentative(stixRelationship.targetEntity)
+                          : t_i18n('Restricted')
+                      }
+                    >
+                      <TimelineDot
+                        sx={{
+                          borderColor: !restricted
+                            ? itemColor(
+                                stixRelationship.targetEntity.entity_type,
+                              )
+                            : theme.palette.primary.main,
+                        }}
+                        variant="outlined"
+                      >
+                        <ItemIcon
+                          type={
+                            !restricted
+                              ? stixRelationship.targetEntity.entity_type
+                              : t_i18n('Restricted')
+                          }
+                        />
+                      </TimelineDot>
+                    </Tooltip>
+                  )}
+                  <TimelineConnector />
+                </TimelineSeparator>
+                <TimelineContent>
+                  <Card>
+                    <Typography variant="h2">
+                      {!restricted
+                        ? truncate(
+                            getMainRepresentative(stixRelationship.targetEntity),
+                            50,
+                          )
+                        : t_i18n('Restricted')}
+                    </Typography>
+                    <span style={{ color: '#a8a8a8' }}>
+                      {truncate(
 
-                          stixRelationship.description
-                          && stixRelationship.description.length > 0
-                            ? stixRelationship.description
-                            : !restricted
-                                ? getSecondaryRepresentative(
-                                    stixRelationship.targetEntity,
-                                  )
-                                : t('Restricted'),
-                          100,
-                        )}
-                      </span>
-                    </Card>
-                  </TimelineContent>
-                </TimelineItem>
-              );
-            })}
-          </Timeline>
-        </div>
+                        stixRelationship.description
+                        && stixRelationship.description.length > 0
+                          ? stixRelationship.description
+                          : !restricted
+                              ? getSecondaryRepresentative(
+                                  stixRelationship.targetEntity,
+                                )
+                              : t_i18n('Restricted'),
+                        100,
+                      )}
+                    </span>
+                  </Card>
+                </TimelineContent>
+              </TimelineItem>
+            );
+          })}
+        </Timeline>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 StixDomainObjectTimelineComponent.propTypes = {
   stixDomainObjectId: PropTypes.string,
@@ -180,7 +177,6 @@ StixDomainObjectTimelineComponent.propTypes = {
   entityLink: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   timeField: PropTypes.string,
 };
 
@@ -581,7 +577,4 @@ const StixDomainObjectTimeline = createRefetchContainer(
   stixDomainObjectThreatKnowledgeStixRelationshipsQuery,
 );
 
-export default compose(
-  inject18n,
-  withTheme,
-)(StixDomainObjectTimeline);
+export default withTheme(StixDomainObjectTimeline);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipPopover.jsx
@@ -9,11 +9,10 @@ import MenuItem from '@mui/material/MenuItem';
 import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import stopEvent from '../../../../utils/domEvent';
 import StixNestedRefRelationshipEdition from './StixNestedRefRelationshipEdition';
@@ -48,54 +47,49 @@ const stixNestedRefRelationshipPopoverDeletionMutation = graphql`
   }
 `;
 
-class StixNestedRefRelationshipPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
+const StixNestedRefRelationshipPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
     stopEvent(event);
-    this.setState({ anchorEl: event.currentTarget });
-  }
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleClose(event) {
-    this.setState({ anchorEl: null });
+  const handleClose = (event) => {
+    setAnchorEl(null);
     stopEvent(event);
-  }
+  };
 
-  handleOpenUpdate(event) {
-    this.setState({ displayUpdate: true });
-    this.handleClose(event);
-  }
+  const handleOpenUpdate = (event) => {
+    setDisplayUpdate(true);
+    handleClose(event);
+  };
 
-  handleCloseUpdate(event) {
-    this.setState({ displayUpdate: false });
+  const handleCloseUpdate = (event) => {
+    setDisplayUpdate(false);
     stopEvent(event);
-  }
+  };
 
-  handleOpenDelete(event) {
-    this.setState({ displayDelete: true });
-    this.handleClose(event);
-  }
+  const handleOpenDelete = (event) => {
+    setDisplayDelete(true);
+    handleClose(event);
+  };
 
-  handleCloseDelete(event) {
-    this.setState({ displayDelete: false });
+  const handleCloseDelete = (event) => {
+    setDisplayDelete(false);
     stopEvent(event);
-  }
+  };
 
-  submitDelete(event) {
-    this.setState({ deleting: true });
+  const submitDelete = (event) => {
+    setDeleting(true);
     stopEvent(event);
     commitMutation({
       mutation: stixNestedRefRelationshipPopoverDeletionMutation,
       variables: {
-        id: this.props.stixNestedRefRelationshipId,
+        id: props.stixNestedRefRelationshipId,
       },
       updater: (store) => {
         const container = store.getRoot();
@@ -106,87 +100,81 @@ class StixNestedRefRelationshipPopover extends Component {
         const conn = ConnectionHandler.getConnection(
           userProxy,
           'Pagination_stixNestedRefRelationships',
-          this.props.paginationOptions,
+          props.paginationOptions,
         );
         ConnectionHandler.deleteNode(conn, payload.getValue('delete'));
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete(event);
+        setDeleting(false);
+        handleCloseDelete(event);
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, stixNestedRefRelationshipId, disabled } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          disabled={disabled}
-          color="primary"
-        >
-          <MoreVertOutlined />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <StixNestedRefRelationshipEdition
-          variant="noGraph"
-          stixNestedRefRelationshipId={stixNestedRefRelationshipId}
-          open={this.state.displayUpdate}
-          handleClose={this.handleCloseUpdate.bind(this)}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to delete this relation?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes, stixNestedRefRelationshipId, disabled } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        disabled={disabled}
+        color="primary"
+      >
+        <MoreVertOutlined />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <StixNestedRefRelationshipEdition
+        variant="noGraph"
+        stixNestedRefRelationshipId={stixNestedRefRelationshipId}
+        open={displayUpdate}
+        handleClose={handleCloseUpdate}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this relation?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 StixNestedRefRelationshipPopover.propTypes = {
   stixNestedRefRelationshipId: PropTypes.string,
   disabled: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixNestedRefRelationshipPopover);
+export default withStyles(styles)(StixNestedRefRelationshipPopover);

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedLine.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
@@ -7,12 +7,11 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { MoreVert } from '@mui/icons-material';
 import { FileDelimitedOutline } from 'mdi-material-ui';
-import { compose } from 'ramda';
 import Slide from '@mui/material/Slide';
 import Skeleton from '@mui/material/Skeleton';
 import { ListItemButton } from '@mui/material';
 import FeedPopover from './FeedPopover';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 import { TAXIIAPI_SETCOLLECTIONS } from '../../../../utils/hooks/useGranted';
@@ -60,79 +59,78 @@ const styles = (theme) => ({
   },
 });
 
-class FeedLineLineComponent extends Component {
-  render() {
-    const { classes, node, dataColumns, paginationOptions, t } = this.props;
-    const filters = deserializeFilterGroupForFrontend(node.filters);
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={(
-          <Security needs={[TAXIIAPI_SETCOLLECTIONS]}>
-            <FeedPopover feedId={node.id} paginationOptions={paginationOptions} />
-          </Security>
-        )}
-      >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component="a"
-          href={`/feeds/${node.id}`}
-          target="_blank" // open in new tab
+const FeedLineLineComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const { classes, node, dataColumns, paginationOptions } = props;
+  const filters = deserializeFilterGroupForFrontend(node.filters);
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={(
+        <Security needs={[TAXIIAPI_SETCOLLECTIONS]}>
+          <FeedPopover feedId={node.id} paginationOptions={paginationOptions} />
+        </Security>
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component="a"
+        href={`/feeds/${node.id}`}
+        target="_blank" // open in new tab
 
-        >
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <FileDelimitedOutline />
-          </ListItemIcon>
-          <ListItemText
-            primary={(
-              <>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.name.width }}
-                >
-                  {node.name}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.feed_types.width }}
-                >
-                  {node.feed_types.map((type) => t(`entity_${type}`)).join(', ')}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.rolling_time.width }}
-                >
-                  <code>{node.rolling_time}</code>
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.columns.width }}
-                >
-                  {node.feed_attributes.map((n) => n.attribute).join(`${node.separator} `)}
-                </div>
-                <div
-                  className={classes.filtersItem}
-                  style={{ width: dataColumns.filters.width }}
-                >
-                  {isFilterGroupNotEmpty(filters)
-                    ? (
-                        <FilterIconButton
-                          filters={filters}
-                          variant="small"
-                          dataColumns={dataColumns}
-                        />
-                      )
-                    : EMPTY_VALUE}
-                </div>
-              </>
-            )}
-          />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+      >
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <FileDelimitedOutline />
+        </ListItemIcon>
+        <ListItemText
+          primary={(
+            <>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.name.width }}
+              >
+                {node.name}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.feed_types.width }}
+              >
+                {node.feed_types.map((type) => t_i18n(`entity_${type}`)).join(', ')}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.rolling_time.width }}
+              >
+                <code>{node.rolling_time}</code>
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.columns.width }}
+              >
+                {node.feed_attributes.map((n) => n.attribute).join(`${node.separator} `)}
+              </div>
+              <div
+                className={classes.filtersItem}
+                style={{ width: dataColumns.filters.width }}
+              >
+                {isFilterGroupNotEmpty(filters)
+                  ? (
+                      <FilterIconButton
+                        filters={filters}
+                        variant="small"
+                        dataColumns={dataColumns}
+                      />
+                    )
+                  : EMPTY_VALUE}
+              </div>
+            </>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 FeedLineLineComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -140,8 +138,6 @@ FeedLineLineComponent.propTypes = {
   paginationOptions: PropTypes.object,
   me: PropTypes.object,
   classes: PropTypes.object,
-  fd: PropTypes.func,
-  t: PropTypes.func,
 };
 
 const FeedLineFragment = createFragmentContainer(FeedLineLineComponent, {
@@ -169,100 +165,92 @@ const FeedLineFragment = createFragmentContainer(FeedLineLineComponent, {
   `,
 });
 
-export const FeedLine = compose(
-  inject18n,
-  withStyles(styles),
-)(FeedLineFragment);
+export const FeedLine = withStyles(styles)(FeedLineFragment);
 
-class FeedDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={<MoreVert classes={classes.itemIconDisabled} />}
-      >
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.name.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.feed_types.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.rolling_time.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.columns.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.filters.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-            </>
-          )}
+const FeedDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={<MoreVert classes={classes.itemIconDisabled} />}
+    >
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        primary={(
+          <>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.name.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.feed_types.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.rolling_time.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.columns.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.filters.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+          </>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 FeedDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const FeedLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(FeedDummyComponent);
+export const FeedLineDummy = withStyles(styles)(FeedDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
@@ -169,11 +169,11 @@ const FeedPopover = (props) => {
       <QueryRenderer
         query={feedDuplicateQuery}
         variables={{ id: feedId }}
-        render={({ props }) => {
-          if (props) {
+        render={({ props: queryProps }) => {
+          if (queryProps) {
             return (
               <FeedCreation
-                feed={props.feed}
+                feed={queryProps.feed}
                 onDrawerClose={handleCloseDuplicate}
                 open={displayDuplicate}
                 paginationOptions={props.paginationOptions}

--- a/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/feeds/FeedPopover.jsx
@@ -10,10 +10,10 @@ import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import FeedCreation from './FeedCreation';
 import FeedEdition from './FeedEdition';
@@ -55,59 +55,54 @@ const feedDuplicateQuery = graphql`
   }
 `;
 
-class FeedPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-      displayDuplicate: false,
-    };
-  }
+const FeedPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [displayDuplicate, setDisplayDuplicate] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDuplicate = () => {
+    setDisplayDuplicate(true);
+    handleClose();
+  };
 
-  handleOpenDuplicate() {
-    this.setState({ displayDuplicate: true });
-    this.handleClose();
-  }
+  const handleCloseDuplicate = () => {
+    setDisplayDuplicate(false);
+  };
 
-  handleCloseDuplicate() {
-    this.setState({ displayDuplicate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: feedPopoverDeletionMutation,
       variables: {
-        id: this.props.feedId,
+        id: props.feedId,
       },
       updater: (store) => {
         const container = store.getRoot();
@@ -115,116 +110,113 @@ class FeedPopover extends Component {
         const conn = ConnectionHandler.getConnection(
           userProxy,
           'Pagination_feeds',
-          this.props.paginationOptions,
+          props.paginationOptions,
         );
-        ConnectionHandler.deleteNode(conn, this.props.feedId);
+        ConnectionHandler.deleteNode(conn, props.feedId);
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
+        setDeleting(false);
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, feedId } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          onClick={this.handleOpen.bind(this)}
-          aria-label={t('Open menu')}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDuplicate.bind(this)}>
-            {t('Duplicate')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <QueryRenderer
-          query={feedEditionQuery}
-          variables={{ id: feedId }}
-          render={({ props }) => {
-            if (props) {
-              return (
-                <>
-                  <FeedEdition
-                    feed={props.feed}
-                    handleClose={this.handleCloseUpdate.bind(this)}
-                    open={this.state.displayUpdate}
-                  />
-                </>
-              );
-            }
-            return <div />;
-          }}
-        />
-        <QueryRenderer
-          query={feedDuplicateQuery}
-          variables={{ id: feedId }}
-          render={({ props }) => {
-            if (props) {
-              return (
-                <FeedCreation
+  const { classes, feedId } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        onClick={handleOpen}
+        aria-label={t_i18n('Open menu')}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDuplicate}>
+          {t_i18n('Duplicate')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <QueryRenderer
+        query={feedEditionQuery}
+        variables={{ id: feedId }}
+        render={({ props }) => {
+          if (props) {
+            return (
+              <>
+                <FeedEdition
                   feed={props.feed}
-                  onDrawerClose={this.handleCloseDuplicate.bind(this)}
-                  open={this.state.displayDuplicate}
-                  paginationOptions={this.props.paginationOptions}
-                  isDuplicated={true}
+                  handleClose={handleCloseUpdate}
+                  open={displayUpdate}
                 />
-              );
-            }
-            return <div />;
-          }}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          size="small"
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this feed?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+              </>
+            );
+          }
+          return <div />;
+        }}
+      />
+      <QueryRenderer
+        query={feedDuplicateQuery}
+        variables={{ id: feedId }}
+        render={({ props }) => {
+          if (props) {
+            return (
+              <FeedCreation
+                feed={props.feed}
+                onDrawerClose={handleCloseDuplicate}
+                open={displayDuplicate}
+                paginationOptions={props.paginationOptions}
+                isDuplicated={true}
+              />
+            );
+          }
+          return <div />;
+        }}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        size="small"
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this feed?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 FeedPopover.propTypes = {
   feedId: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(FeedPopover);
+export default compose(withStyles(styles))(FeedPopover);

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionRss/IngestionRssPopover.jsx
@@ -10,13 +10,12 @@ import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import { useFormatter } from '../../../../components/i18n';
+import { commitMutation, QueryRenderer, fetchQuery } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import IngestionRssEdition, { ingestionRssMutationFieldPatch } from './IngestionRssEdition';
-import { fetchQuery } from '../../../../relay/environment';
 import fileDownload from 'js-file-download';
 import stopEvent from '../../../../utils/domEvent';
 
@@ -70,94 +69,89 @@ const ingestionRssEditionQuery = graphql`
   }
 `;
 
-class IngestionRssPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-      displayStart: false,
-      starting: false,
-      displayStop: false,
-      stopping: false,
-    };
-  }
+const IngestionRssPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [displayStart, setDisplayStart] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [displayStop, setDisplayStop] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
+  const handleOpenStart = () => {
+    setDisplayStart(true);
+    handleClose();
+  };
 
-  handleOpenStart() {
-    this.setState({ displayStart: true });
-    this.handleClose();
-  }
+  const handleCloseStart = () => {
+    setDisplayStart(false);
+  };
 
-  handleCloseStart() {
-    this.setState({ displayStart: false });
-  }
+  const handleOpenStop = () => {
+    setDisplayStop(true);
+    handleClose();
+  };
 
-  handleOpenStop() {
-    this.setState({ displayStop: true });
-    this.handleClose();
-  }
+  const handleCloseStop = () => {
+    setDisplayStop(false);
+  };
 
-  handleCloseStop() {
-    this.setState({ displayStop: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: ingestionRssPopoverDeletionMutation,
       variables: {
-        id: this.props.ingestionRssId,
+        id: props.ingestionRssId,
       },
       updater: (store) => {
         deleteNode(
           store,
           'Pagination_ingestionRsss',
-          this.props.paginationOptions,
-          this.props.ingestionRssId,
+          props.paginationOptions,
+          props.ingestionRssId,
         );
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
-        if (this.props.onDeleteComplete) {
-          this.props.onDeleteComplete();
+        setDeleting(false);
+        handleCloseDelete();
+        if (props.onDeleteComplete) {
+          props.onDeleteComplete();
         }
       },
     });
-  }
+  };
 
-  async exportRssFeed() {
+  const exportRssFeed = async () => {
     const { ingestionRss } = await fetchQuery(
       ingestionRssPopoverExportQuery,
-      { id: this.props.ingestionRssId },
+      { id: props.ingestionRssId },
     ).toPromise();
 
     if (ingestionRss) {
@@ -168,181 +162,178 @@ class IngestionRssPopover extends Component {
     }
   };
 
-  async handleExport(e) {
+  const handleExport = async (e) => {
     stopEvent(e);
-    this.handleClose();
-    await this.exportRssFeed();
+    handleClose();
+    await exportRssFeed();
   };
 
-  submitStart() {
-    this.setState({ starting: true });
+  const submitStart = () => {
+    setStarting(true);
     commitMutation({
       mutation: ingestionRssMutationFieldPatch,
       variables: {
-        id: this.props.ingestionRssId,
+        id: props.ingestionRssId,
         input: { key: 'ingestion_running', value: ['true'] },
       },
       onCompleted: () => {
-        this.setState({ starting: false });
-        this.handleCloseStart();
+        setStarting(false);
+        handleCloseStart();
       },
     });
-  }
+  };
 
-  submitStop() {
-    this.setState({ stopping: true });
+  const submitStop = () => {
+    setStopping(true);
     commitMutation({
       mutation: ingestionRssMutationFieldPatch,
       variables: {
-        id: this.props.ingestionRssId,
+        id: props.ingestionRssId,
         input: { key: 'ingestion_running', value: ['false'] },
       },
       onCompleted: () => {
-        this.setState({ stopping: false });
-        this.handleCloseStop();
+        setStopping(false);
+        handleCloseStop();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, ingestionRssId, running } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          {!running && (
-            <MenuItem onClick={this.handleOpenStart.bind(this)}>
-              {t('Start')}
-            </MenuItem>
-          )}
-          {running && (
-            <MenuItem onClick={this.handleOpenStop.bind(this)}>
-              {t('Stop')}
-            </MenuItem>
-          )}
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
+  const { classes, ingestionRssId, running } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        {!running && (
+          <MenuItem onClick={handleOpenStart}>
+            {t_i18n('Start')}
           </MenuItem>
-          <MenuItem onClick={this.handleExport.bind(this)}>
-            {t('Export')}
+        )}
+        {running && (
+          <MenuItem onClick={handleOpenStop}>
+            {t_i18n('Stop')}
           </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <QueryRenderer
-          query={ingestionRssEditionQuery}
-          variables={{ id: ingestionRssId }}
-          render={({ props }) => {
-            if (props) {
-              return (
-                <IngestionRssEdition
-                  ingestionRss={props.ingestionRss}
-                  handleClose={this.handleCloseUpdate.bind(this)}
-                  open={this.state.displayUpdate}
-                />
-              );
-            }
-            return <div />;
-          }}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this RSS ingester?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          open={this.state.displayStart}
-          slots={{ transition: Transition }}
-          onClose={this.handleCloseStart.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to start this RSS ingester?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseStart.bind(this)}
-              disabled={this.state.starting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitStart.bind(this)}
-              disabled={this.state.starting}
-            >
-              {t('Start')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          open={this.state.displayStop}
-          onClose={this.handleCloseStop.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to stop this RSS ingester?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseStop.bind(this)}
-              disabled={this.state.stopping}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitStop.bind(this)}
-              disabled={this.state.stopping}
-            >
-              {t('Stop')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+        )}
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleExport}>
+          {t_i18n('Export')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <QueryRenderer
+        query={ingestionRssEditionQuery}
+        variables={{ id: ingestionRssId }}
+        render={({ props }) => {
+          if (props) {
+            return (
+              <IngestionRssEdition
+                ingestionRss={props.ingestionRss}
+                handleClose={handleCloseUpdate}
+                open={displayUpdate}
+              />
+            );
+          }
+          return <div />;
+        }}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this RSS ingester?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={displayStart}
+        slots={{ transition: Transition }}
+        onClose={handleCloseStart}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to start this RSS ingester?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseStart}
+            disabled={starting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitStart}
+            disabled={starting}
+          >
+            {t_i18n('Start')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={displayStop}
+        onClose={handleCloseStop}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to stop this RSS ingester?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseStop}
+            disabled={stopping}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitStop}
+            disabled={stopping}
+          >
+            {t_i18n('Stop')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 IngestionRssPopover.propTypes = {
   ingestionRssId: PropTypes.string,
   running: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   onDeleteComplete: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(IngestionRssPopover);
+export default compose(withStyles(styles))(IngestionRssPopover);

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncLine.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql, createFragmentContainer } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
@@ -9,12 +9,11 @@ import ListItemText from '@mui/material/ListItemText';
 import Chip from '@mui/material/Chip';
 import { MoreVert } from '@mui/icons-material';
 import { DatabaseImportOutline } from 'mdi-material-ui';
-import { compose } from 'ramda';
 import Slide from '@mui/material/Slide';
 import Skeleton from '@mui/material/Skeleton';
 import SyncPopover from './SyncPopover';
 import SyncConsumersDrawer from './SyncConsumersDrawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import Security from '../../../../utils/Security';
 import { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
@@ -78,138 +77,131 @@ const styles = (theme) => ({
   },
 });
 
-class SyncLineLineComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      displayConsumers: false,
-    };
-  }
+const SyncLineLineComponent = (props) => {
+  const { t_i18n, nsdt, n } = useFormatter();
+  const [displayConsumers, setDisplayConsumers] = useState(false);
+  const handleOpenConsumers = () => {
+    setDisplayConsumers(true);
+  };
 
-  handleOpenConsumers() {
-    this.setState({ displayConsumers: true });
-  }
+  const handleCloseConsumers = () => {
+    setDisplayConsumers(false);
+  };
 
-  handleCloseConsumers() {
-    this.setState({ displayConsumers: false });
-  }
-
-  computeConsumerHealth() {
-    const { node, t } = this.props;
+  const computeConsumerHealth = () => {
+    const { node } = props;
     const metrics = node.consumer_metrics;
     if (!metrics) {
-      return { label: t('No data'), hexColor: null };
+      return { label: t_i18n('No data'), hexColor: null };
     }
     const ONE_HOUR = 3600;
     const ONE_DAY = 86400;
     const { estimatedOutOfDepth } = metrics;
     if (estimatedOutOfDepth > 0 && estimatedOutOfDepth < ONE_HOUR) {
-      return { label: t('At risk'), hexColor: '#c62828' };
+      return { label: t_i18n('At risk'), hexColor: '#c62828' };
     }
     if (estimatedOutOfDepth >= ONE_HOUR && estimatedOutOfDepth < ONE_DAY) {
-      return { label: t('Degraded'), hexColor: '#d84315' };
+      return { label: t_i18n('Degraded'), hexColor: '#d84315' };
     }
-    return { label: t('Healthy'), hexColor: '#2e7d32' };
-  }
+    return { label: t_i18n('Healthy'), hexColor: '#2e7d32' };
+  };
 
-  render() {
-    const { classes, node, dataColumns, paginationOptions, t, nsdt, n } = this.props;
-    const health = this.computeConsumerHealth();
-    return (
-      <>
-        <ListItem
-          divider={true}
-          disablePadding
-          secondaryAction={(
-            <Security needs={[INGESTION_SETINGESTIONS]}>
-              <SyncPopover
-                syncId={node.id}
-                paginationOptions={paginationOptions}
-                running={node.running}
-              />
-            </Security>
-          )}
-        >
-          <ListItemButton
-            classes={{ root: classes.item }}
-            onClick={this.handleOpenConsumers.bind(this)}
-          >
-            <ListItemIcon classes={{ root: classes.itemIcon }}>
-              <DatabaseImportOutline />
-            </ListItemIcon>
-            <ListItemText
-              primary={(
-                <>
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.name.width }}
-                  >
-                    {node.name}
-                  </div>
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.uri.width }}
-                  >
-                    {node.uri}
-                  </div>
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.messages.width }}
-                  >
-                    {n(node.queue_messages)}
-                  </div>
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.running.width }}
-                  >
-                    <ItemBoolean
-                      variant="inList"
-                      label={node.running ? t('Active') : t('Inactive')}
-                      status={node.running}
-                    />
-                  </div>
-                  <div
-                    className={classes.bodyItem}
-                    style={{ width: dataColumns.current_state_date.width }}
-                  >
-                    {nsdt(node.current_state_date)}
-                  </div>
-                  <div
-                    className={classes.producerItem}
-                    style={{ width: dataColumns.producer.width }}
-                  >
-                    {!health.hexColor
-                      ? <span style={{ color: '#9e9e9e' }}>-</span>
-                      : (
-                          <Chip
-                            label={health.label}
-                            style={{
-                              fontSize: 12,
-                              lineHeight: '12px',
-                              borderRadius: 4,
-                              height: 20,
-                              backgroundColor: `${health.hexColor}33`,
-                              color: health.hexColor,
-                              border: `2px solid ${health.hexColor}`,
-                            }}
-                          />
-                        )}
-                  </div>
-                </>
-              )}
+  const { classes, node, dataColumns, paginationOptions } = props;
+  const health = computeConsumerHealth();
+  return (
+    <>
+      <ListItem
+        divider={true}
+        disablePadding
+        secondaryAction={(
+          <Security needs={[INGESTION_SETINGESTIONS]}>
+            <SyncPopover
+              syncId={node.id}
+              paginationOptions={paginationOptions}
+              running={node.running}
             />
-          </ListItemButton>
-        </ListItem>
-        <SyncConsumersDrawer
-          syncId={node.id}
-          syncName={node.name}
-          open={this.state.displayConsumers}
-          onClose={this.handleCloseConsumers.bind(this)}
-        />
-      </>
-    );
-  }
-}
+          </Security>
+        )}
+      >
+        <ListItemButton
+          classes={{ root: classes.item }}
+          onClick={handleOpenConsumers}
+        >
+          <ListItemIcon classes={{ root: classes.itemIcon }}>
+            <DatabaseImportOutline />
+          </ListItemIcon>
+          <ListItemText
+            primary={(
+              <>
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.name.width }}
+                >
+                  {node.name}
+                </div>
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.uri.width }}
+                >
+                  {node.uri}
+                </div>
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.messages.width }}
+                >
+                  {n(node.queue_messages)}
+                </div>
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.running.width }}
+                >
+                  <ItemBoolean
+                    variant="inList"
+                    label={node.running ? t_i18n('Active') : t_i18n('Inactive')}
+                    status={node.running}
+                  />
+                </div>
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.current_state_date.width }}
+                >
+                  {nsdt(node.current_state_date)}
+                </div>
+                <div
+                  className={classes.producerItem}
+                  style={{ width: dataColumns.producer.width }}
+                >
+                  {!health.hexColor
+                    ? <span style={{ color: '#9e9e9e' }}>-</span>
+                    : (
+                        <Chip
+                          label={health.label}
+                          style={{
+                            fontSize: 12,
+                            lineHeight: '12px',
+                            borderRadius: 4,
+                            height: 20,
+                            backgroundColor: `${health.hexColor}33`,
+                            color: health.hexColor,
+                            border: `2px solid ${health.hexColor}`,
+                          }}
+                        />
+                      )}
+                </div>
+              </>
+            )}
+          />
+        </ListItemButton>
+      </ListItem>
+      <SyncConsumersDrawer
+        syncId={node.id}
+        syncName={node.name}
+        open={displayConsumers}
+        onClose={handleCloseConsumers}
+      />
+    </>
+  );
+};
 
 SyncLineLineComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -217,7 +209,6 @@ SyncLineLineComponent.propTypes = {
   paginationOptions: PropTypes.object,
   me: PropTypes.object,
   classes: PropTypes.object,
-  fd: PropTypes.func,
 };
 
 const SyncLineFragment = createFragmentContainer(SyncLineLineComponent, {
@@ -239,113 +230,105 @@ const SyncLineFragment = createFragmentContainer(SyncLineLineComponent, {
   `,
 });
 
-export const SyncLine = compose(
-  inject18n,
-  withStyles(styles),
-)(SyncLineFragment);
+export const SyncLine = withStyles(styles)(SyncLineFragment);
 
-class SyncDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={
-          <MoreVert classes={classes.itemIconDisabled} />
-        }
-      >
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.name.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.uri.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.messages.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.running.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.current_state_date.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width={100}
-                  height="100%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.producer.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="100%"
-                />
-              </div>
-            </div>
-          )}
+const SyncDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={
+        <MoreVert classes={classes.itemIconDisabled} />
+      }
+    >
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        primary={(
+          <div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.name.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.uri.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.messages.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.running.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.current_state_date.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width={100}
+                height="100%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.producer.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="100%"
+              />
+            </div>
+          </div>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 SyncDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const SyncLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(SyncDummyComponent);
+export const SyncLineDummy = withStyles(styles)(SyncDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncPopover.jsx
@@ -12,9 +12,9 @@ import withStyles from '@mui/styles/withStyles';
 import fileDownload from 'js-file-download';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { fetchQuery, graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, environment, QueryRenderer } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import Drawer from '../../common/drawer/Drawer';
@@ -95,120 +95,115 @@ const syncPopoverExportQuery = graphql`
   }
 `;
 
-class SyncPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-      displayStart: false,
-      starting: false,
-      displayStop: false,
-      stopping: false,
-    };
-  }
+const SyncPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [displayStart, setDisplayStart] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [displayStop, setDisplayStop] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
+  const handleOpenStart = () => {
+    setDisplayStart(true);
+    handleClose();
+  };
 
-  handleOpenStart() {
-    this.setState({ displayStart: true });
-    this.handleClose();
-  }
+  const handleCloseStart = () => {
+    setDisplayStart(false);
+  };
 
-  handleCloseStart() {
-    this.setState({ displayStart: false });
-  }
+  const handleOpenStop = () => {
+    setDisplayStop(true);
+    handleClose();
+  };
 
-  handleOpenStop() {
-    this.setState({ displayStop: true });
-    this.handleClose();
-  }
+  const handleCloseStop = () => {
+    setDisplayStop(false);
+  };
 
-  handleCloseStop() {
-    this.setState({ displayStop: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: syncPopoverDeletionMutation,
       variables: {
-        id: this.props.syncId,
+        id: props.syncId,
       },
       updater: (store) => {
         deleteNode(
           store,
           'Pagination_synchronizers',
-          this.props.paginationOptions,
-          this.props.syncId,
+          props.paginationOptions,
+          props.syncId,
         );
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
-        if (this.props.onDeleteComplete) {
-          this.props.onDeleteComplete();
+        setDeleting(false);
+        handleCloseDelete();
+        if (props.onDeleteComplete) {
+          props.onDeleteComplete();
         }
       },
     });
-  }
+  };
 
-  submitStart() {
-    this.setState({ starting: true });
+  const submitStart = () => {
+    setStarting(true);
     commitMutation({
       mutation: syncPopoverStartMutation,
       variables: {
-        id: this.props.syncId,
+        id: props.syncId,
       },
       onCompleted: () => {
-        this.setState({ starting: false });
-        this.handleCloseStart();
+        setStarting(false);
+        handleCloseStart();
       },
     });
-  }
+  };
 
-  submitStop() {
-    this.setState({ stopping: true });
+  const submitStop = () => {
+    setStopping(true);
     commitMutation({
       mutation: syncPopoverStopMutation,
       variables: {
-        id: this.props.syncId,
+        id: props.syncId,
       },
       onCompleted: () => {
-        this.setState({ stopping: false });
-        this.handleCloseStop();
+        setStopping(false);
+        handleCloseStop();
       },
     });
-  }
+  };
 
-  async exportSync() {
-    const { syncId } = this.props;
+  const exportSync = async () => {
+    const { syncId } = props;
 
     const data = await fetchQuery(environment,
       syncPopoverExportQuery,
@@ -231,169 +226,166 @@ class SyncPopover extends Component {
 
       fileDownload(blob, fileName);
     }
-  }
+  };
 
-  async handleExport(event) {
+  const handleExport = async (event) => {
     if (event) {
       event.preventDefault();
       event.stopPropagation();
     }
 
-    this.setState({ anchorEl: null });
-    await this.exportSync();
-  }
+    setAnchorEl(null);
+    await exportSync();
+  };
 
-  render() {
-    const { classes, t, syncId, running } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          {!running && (
-            <MenuItem onClick={this.handleOpenStart.bind(this)}>
-              {t('Start')}
-            </MenuItem>
-          )}
-          {running && (
-            <MenuItem onClick={this.handleOpenStop.bind(this)}>
-              {t('Stop')}
-            </MenuItem>
-          )}
-          <MenuItem disabled={running} onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
+  const { classes, syncId, running } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        {!running && (
+          <MenuItem onClick={handleOpenStart}>
+            {t_i18n('Start')}
           </MenuItem>
-          <MenuItem onClick={this.handleExport.bind(this)}>
-            {t('Export')}
+        )}
+        {running && (
+          <MenuItem onClick={handleOpenStop}>
+            {t_i18n('Stop')}
           </MenuItem>
-          <MenuItem disabled={running} onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <Drawer
-          open={this.state.displayUpdate}
-          onClose={this.handleCloseUpdate.bind(this)}
-          title={t('Update an OpenCTI stream')}
-        >
-          <QueryRenderer
-            query={syncEditionQuery}
-            variables={{ id: syncId }}
-            render={({ props }) => {
-              if (props) {
-                return (
-                  <SyncEdition
-                    synchronizer={props.synchronizer}
-                  />
-                );
-              }
-              return <div />;
-            }}
-          />
-        </Drawer>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
+        )}
+        <MenuItem disabled={running} onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleExport}>
+          {t_i18n('Export')}
+        </MenuItem>
+        <MenuItem disabled={running} onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <Drawer
+        open={displayUpdate}
+        onClose={handleCloseUpdate}
+        title={t_i18n('Update an OpenCTI stream')}
+      >
+        <QueryRenderer
+          query={syncEditionQuery}
+          variables={{ id: syncId }}
+          render={({ props }) => {
+            if (props) {
+              return (
+                <SyncEdition
+                  synchronizer={props.synchronizer}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
+      </Drawer>
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this OpenCTI stream?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        slotProps={{ paper: { elevation: 1 } }}
+        open={displayStart}
+        keepMounted={true}
+        slots={{ transition: Transition }}
+        onClose={handleCloseStart}
+      >
+        <DialogContent>
           <DialogContentText>
-            {t('Do you want to delete this OpenCTI stream?')}
+            {t_i18n('Do you want to start this OpenCTI stream?')}
           </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          slotProps={{ paper: { elevation: 1 } }}
-          open={this.state.displayStart}
-          keepMounted={true}
-          slots={{ transition: Transition }}
-          onClose={this.handleCloseStart.bind(this)}
-        >
-          <DialogContent>
-            <DialogContentText>
-              {t('Do you want to start this OpenCTI stream?')}
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseStart.bind(this)}
-              disabled={this.state.starting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitStart.bind(this)}
-              disabled={this.state.starting}
-            >
-              {t('Start')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          slotProps={{ paper: { elevation: 1 } }}
-          open={this.state.displayStop}
-          keepMounted={true}
-          slots={{ transition: Transition }}
-          onClose={this.handleCloseStop.bind(this)}
-        >
-          <DialogContent>
-            <DialogContentText>
-              {t('Do you want to stop this OpenCTI stream?')}
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseStop.bind(this)}
-              disabled={this.state.stopping}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitStop.bind(this)}
-              disabled={this.state.stopping}
-            >
-              {t('Stop')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseStart}
+            disabled={starting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitStart}
+            disabled={starting}
+          >
+            {t_i18n('Start')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        slotProps={{ paper: { elevation: 1 } }}
+        open={displayStop}
+        keepMounted={true}
+        slots={{ transition: Transition }}
+        onClose={handleCloseStop}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t_i18n('Do you want to stop this OpenCTI stream?')}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseStop}
+            disabled={stopping}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitStop}
+            disabled={stopping}
+          >
+            {t_i18n('Stop')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 SyncPopover.propTypes = {
   syncId: PropTypes.string,
   running: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   onDeleteComplete: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(SyncPopover);
+export default compose(withStyles(styles))(SyncPopover);

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiLine.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
@@ -8,11 +8,9 @@ import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton } from '@mui/material';
 import { MoreVert } from '@mui/icons-material';
 import { DatabaseExportOutline } from 'mdi-material-ui';
-import { compose } from 'ramda';
 import Slide from '@mui/material/Slide';
 import Skeleton from '@mui/material/Skeleton';
 import TaxiiPopover from './TaxiiPopover';
-import inject18n from '../../../../components/i18n';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import ItemCopy from '../../../../components/ItemCopy';
 import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
@@ -79,75 +77,73 @@ const styles = (theme) => ({
   },
 });
 
-class TaxiiLineLineComponent extends Component {
-  render() {
-    const { classes, node, dataColumns, paginationOptions } = this.props;
-    const filters = deserializeFilterGroupForFrontend(node.filters);
-    return (
-      <ListItem
-        divider={true}
-        disablePadding
-        secondaryAction={(
-          <Security needs={[TAXIIAPI_SETCOLLECTIONS]}>
-            <TaxiiPopover
-              taxiiCollectionId={node.id}
-              paginationOptions={paginationOptions}
-            />
-          </Security>
-        )}
-      >
-        <ListItemButton
-          classes={{ root: classes.item }}
-          component="a"
-          href={`/taxii2/root/collections/${node.id}/objects/`}
-          target="_blank"
-        >
-          <ListItemIcon classes={{ root: classes.itemIcon }}>
-            <DatabaseExportOutline />
-          </ListItemIcon>
-          <ListItemText
-            primary={(
-              <>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.name.width }}
-                >
-                  {node.name}
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.description.width }}
-                >
-                  <FieldOrEmpty source={node.description}>{node.description}</FieldOrEmpty>
-                </div>
-                <div
-                  className={classes.bodyItem}
-                  style={{ width: dataColumns.id.width, paddingRight: 10 }}
-                >
-                  <ItemCopy content={node.id} variant="inLine" />
-                </div>
-                <div
-                  className={classes.filtersItem}
-                  style={{ width: dataColumns.filters.width }}
-                >
-                  {isFilterGroupNotEmpty(filters)
-                    ? (
-                        <FilterIconButton
-                          filters={filters}
-                          dataColumns={dataColumns}
-                          variant="small"
-                        />
-                      )
-                    : EMPTY_VALUE}
-                </div>
-              </>
-            )}
+const TaxiiLineLineComponent = (props) => {
+  const { classes, node, dataColumns, paginationOptions } = props;
+  const filters = deserializeFilterGroupForFrontend(node.filters);
+  return (
+    <ListItem
+      divider={true}
+      disablePadding
+      secondaryAction={(
+        <Security needs={[TAXIIAPI_SETCOLLECTIONS]}>
+          <TaxiiPopover
+            taxiiCollectionId={node.id}
+            paginationOptions={paginationOptions}
           />
-        </ListItemButton>
-      </ListItem>
-    );
-  }
-}
+        </Security>
+      )}
+    >
+      <ListItemButton
+        classes={{ root: classes.item }}
+        component="a"
+        href={`/taxii2/root/collections/${node.id}/objects/`}
+        target="_blank"
+      >
+        <ListItemIcon classes={{ root: classes.itemIcon }}>
+          <DatabaseExportOutline />
+        </ListItemIcon>
+        <ListItemText
+          primary={(
+            <>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.name.width }}
+              >
+                {node.name}
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.description.width }}
+              >
+                <FieldOrEmpty source={node.description}>{node.description}</FieldOrEmpty>
+              </div>
+              <div
+                className={classes.bodyItem}
+                style={{ width: dataColumns.id.width, paddingRight: 10 }}
+              >
+                <ItemCopy content={node.id} variant="inLine" />
+              </div>
+              <div
+                className={classes.filtersItem}
+                style={{ width: dataColumns.filters.width }}
+              >
+                {isFilterGroupNotEmpty(filters)
+                  ? (
+                      <FilterIconButton
+                        filters={filters}
+                        dataColumns={dataColumns}
+                        variant="small"
+                      />
+                    )
+                  : EMPTY_VALUE}
+              </div>
+            </>
+          )}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 TaxiiLineLineComponent.propTypes = {
   dataColumns: PropTypes.object,
@@ -155,7 +151,6 @@ TaxiiLineLineComponent.propTypes = {
   paginationOptions: PropTypes.object,
   me: PropTypes.object,
   classes: PropTypes.object,
-  fd: PropTypes.func,
 };
 
 const TaxiiLineFragment = createFragmentContainer(TaxiiLineLineComponent, {
@@ -169,89 +164,81 @@ const TaxiiLineFragment = createFragmentContainer(TaxiiLineLineComponent, {
   `,
 });
 
-export const TaxiiLine = compose(
-  inject18n,
-  withStyles(styles),
-)(TaxiiLineFragment);
+export const TaxiiLine = withStyles(styles)(TaxiiLineFragment);
 
-class TaxiiDummyComponent extends Component {
-  render() {
-    const { classes, dataColumns } = this.props;
-    return (
-      <ListItem
-        classes={{ root: classes.item }}
-        divider={true}
-        secondaryAction={<MoreVert classes={classes.itemIconDisabled} />}
-      >
-        <ListItemIcon classes={{ root: classes.itemIcon }}>
-          <Skeleton
-            animation="wave"
-            variant="circular"
-            width={30}
-            height={30}
-          />
-        </ListItemIcon>
-        <ListItemText
-          primary={(
-            <>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.name.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.description.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.id.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-              <div
-                className={classes.bodyItem}
-                style={{ width: dataColumns.filters.width }}
-              >
-                <Skeleton
-                  animation="wave"
-                  variant="rectangular"
-                  width="90%"
-                  height="50%"
-                />
-              </div>
-            </>
-          )}
+const TaxiiDummyComponent = (props) => {
+  const { classes, dataColumns } = props;
+  return (
+    <ListItem
+      classes={{ root: classes.item }}
+      divider={true}
+      secondaryAction={<MoreVert classes={classes.itemIconDisabled} />}
+    >
+      <ListItemIcon classes={{ root: classes.itemIcon }}>
+        <Skeleton
+          animation="wave"
+          variant="circular"
+          width={30}
+          height={30}
         />
-      </ListItem>
-    );
-  }
-}
+      </ListItemIcon>
+      <ListItemText
+        primary={(
+          <>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.name.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.description.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.id.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+            <div
+              className={classes.bodyItem}
+              style={{ width: dataColumns.filters.width }}
+            >
+              <Skeleton
+                animation="wave"
+                variant="rectangular"
+                width="90%"
+                height="50%"
+              />
+            </div>
+          </>
+        )}
+      />
+    </ListItem>
+  );
+};
 
 TaxiiDummyComponent.propTypes = {
   dataColumns: PropTypes.object,
   classes: PropTypes.object,
 };
 
-export const TaxiiLineDummy = compose(
-  inject18n,
-  withStyles(styles),
-)(TaxiiDummyComponent);
+export const TaxiiLineDummy = withStyles(styles)(TaxiiDummyComponent);

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiPopover.jsx
@@ -10,10 +10,10 @@ import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
 import { ConnectionHandler } from 'relay-runtime';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import Drawer from '../../common/drawer/Drawer';
 import TaxiiCollectionEdition from './TaxiiCollectionEdition';
@@ -60,49 +60,44 @@ const taxiiCollectionEditionQuery = graphql`
   }
 `;
 
-class TaxiiCollectionPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
+const TaxiiCollectionPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: taxiiCollectionPopoverDeletionMutation,
       variables: {
-        id: this.props.taxiiCollectionId,
+        id: props.taxiiCollectionId,
       },
       updater: (store) => {
         const container = store.getRoot();
@@ -111,97 +106,94 @@ class TaxiiCollectionPopover extends Component {
         const conn = ConnectionHandler.getConnection(
           userProxy,
           'Pagination_taxiiCollections',
-          this.props.paginationOptions,
+          props.paginationOptions,
         );
         ConnectionHandler.deleteNode(conn, payload.getValue('delete'));
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
+        setDeleting(false);
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, taxiiCollectionId } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <Drawer
-          open={this.state.displayUpdate}
-          onClose={this.handleCloseUpdate.bind(this)}
-          title={t('Update a TAXII collection')}
-        >
-          <QueryRenderer
-            query={taxiiCollectionEditionQuery}
-            variables={{ id: taxiiCollectionId }}
-            render={({ props }) => {
-              if (props) {
-                return (
-                  <TaxiiCollectionEdition
-                    taxiiCollection={props.taxiiCollection}
-                  />
-                );
-              }
-              return <div />;
-            }}
-          />
-        </Drawer>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to delete this collection?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes, taxiiCollectionId } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <Drawer
+        open={displayUpdate}
+        onClose={handleCloseUpdate}
+        title={t_i18n('Update a TAXII collection')}
+      >
+        <QueryRenderer
+          query={taxiiCollectionEditionQuery}
+          variables={{ id: taxiiCollectionId }}
+          render={({ props }) => {
+            if (props) {
+              return (
+                <TaxiiCollectionEdition
+                  taxiiCollection={props.taxiiCollection}
+                />
+              );
+            }
+            return <div />;
+          }}
+        />
+      </Drawer>
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this collection?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 TaxiiCollectionPopover.propTypes = {
   taxiiCollectionId: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(TaxiiCollectionPopover);
+export default compose(withStyles(styles))(TaxiiCollectionPopover);

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipPopover.jsx
@@ -9,10 +9,9 @@ import MenuItem from '@mui/material/MenuItem';
 import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import StixSightingRelationshipEdition from './StixSightingRelationshipEdition';
@@ -47,145 +46,134 @@ const stixSightingRelationshipPopoverDeletionMutation = graphql`
   }
 `;
 
-class StixSightingRelationshipPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
+const StixSightingRelationshipPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
     event.stopPropagation();
-  }
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: stixSightingRelationshipPopoverDeletionMutation,
       variables: {
-        id: this.props.stixSightingRelationshipId,
+        id: props.stixSightingRelationshipId,
       },
       updater: (store) => {
-        const isUndefinedCallback = this.props.onDelete === undefined
-          || typeof this.props.onDelete !== 'function';
+        const isUndefinedCallback = props.onDelete === undefined
+          || typeof props.onDelete !== 'function';
         if (isUndefinedCallback) {
           deleteNode(
             store,
             'Pagination_stixSightingRelationships',
-            this.props.paginationOptions,
-            this.props.stixSightingRelationshipId,
+            props.paginationOptions,
+            props.stixSightingRelationshipId,
           );
         }
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
-        this.handleCloseUpdate();
-        if (typeof this.props.onDelete === 'function') {
-          this.props.onDelete();
+        setDeleting(false);
+        handleCloseDelete();
+        handleCloseUpdate();
+        if (typeof props.onDelete === 'function') {
+          props.onDelete();
         }
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, stixSightingRelationshipId, disabled } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          disabled={disabled}
-          color="primary"
-        >
-          <MoreVertOutlined />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-            {t('Update')}
-          </MenuItem>
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Delete')}
-          </MenuItem>
-        </Menu>
-        <StixSightingRelationshipEdition
-          variant="noGraph"
-          stixSightingRelationshipId={stixSightingRelationshipId}
-          open={this.state.displayUpdate}
-          handleClose={this.handleCloseUpdate.bind(this)}
-          handleDelete={this.submitDelete.bind(this)}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this sighting?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes, stixSightingRelationshipId, disabled } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        disabled={disabled}
+        color="primary"
+      >
+        <MoreVertOutlined />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenUpdate}>
+          {t_i18n('Update')}
+        </MenuItem>
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Delete')}
+        </MenuItem>
+      </Menu>
+      <StixSightingRelationshipEdition
+        variant="noGraph"
+        stixSightingRelationshipId={stixSightingRelationshipId}
+        open={displayUpdate}
+        handleClose={handleCloseUpdate}
+        handleDelete={submitDelete}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this sighting?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 StixSightingRelationshipPopover.propTypes = {
   stixSightingRelationshipId: PropTypes.string,
   disabled: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   onDelete: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixSightingRelationshipPopover);
+export default withStyles(styles)(StixSightingRelationshipPopover);

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservablePopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorObservablePopover.jsx
@@ -9,10 +9,9 @@ import MenuItem from '@mui/material/MenuItem';
 import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNodeFromEdge } from '../../../../utils/store';
 
@@ -52,112 +51,106 @@ const indicatorObservablePopoverDeletionMutation = graphql`
   }
 `;
 
-class IndicatorObservablePopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
+const IndicatorObservablePopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ anchorEl: event.currentTarget });
-  }
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleClose(event) {
+  const handleClose = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ anchorEl: null });
-  }
+    setAnchorEl(null);
+  };
 
-  handleOpenDelete(event) {
+  const handleOpenDelete = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ displayDelete: true });
-    this.handleClose(event);
-  }
+    setDisplayDelete(true);
+    handleClose(event);
+  };
 
-  handleCloseDelete(event) {
+  const handleCloseDelete = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ deleting: false, displayDelete: false });
-  }
+    setDeleting(false);
+    setDisplayDelete(false);
+  };
 
-  submitDelete(event) {
+  const submitDelete = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    this.setState({ deleting: true });
+    setDeleting(true);
     commitMutation({
       mutation: indicatorObservablePopoverDeletionMutation,
       variables: {
-        fromId: this.props.indicatorId,
-        toId: this.props.observableId,
+        fromId: props.indicatorId,
+        toId: props.observableId,
         relationship_type: 'based-on',
       },
-      updater: (store) => deleteNodeFromEdge(store, 'observables', this.props.indicatorId, this.props.observableId, { first: 100 }),
+      updater: (store) => deleteNodeFromEdge(store, 'observables', props.indicatorId, props.observableId, { first: 100 }),
       onCompleted: () => {
-        this.handleCloseDelete(event);
-        if (this.props.onDelete) {
-          this.props.onDelete();
+        handleCloseDelete(event);
+        if (props.onDelete) {
+          props.onDelete();
         }
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Remove')}
-          </MenuItem>
-        </Menu>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to remove the observable from this indicator?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Remove')}
+        </MenuItem>
+      </Menu>
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to remove the observable from this indicator?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 IndicatorObservablePopover.propTypes = {
   indicatorId: PropTypes.string,
@@ -166,11 +159,7 @@ IndicatorObservablePopover.propTypes = {
   isRelation: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
   onDelete: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(IndicatorObservablePopover);
+export default withStyles(styles)(IndicatorObservablePopover);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicatorPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicatorPopover.jsx
@@ -9,10 +9,9 @@ import MenuItem from '@mui/material/MenuItem';
 import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { deleteNodeFromId } from '../../../../utils/store';
 
@@ -52,108 +51,102 @@ const stixCyberObservableIndicatorPopoverDeletionMutation = graphql`
   }
 `;
 
-class StixCyberObservableIndicatorPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
-
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
+const StixCyberObservableIndicatorPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
     event.stopPropagation();
-  }
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleCloseDelete() {
-    this.setState({ deleting: false, displayDelete: false });
-  }
+  const handleCloseDelete = () => {
+    setDeleting(false);
+    setDisplayDelete(false);
+  };
 
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: stixCyberObservableIndicatorPopoverDeletionMutation,
       variables: {
-        fromId: this.props.indicatorId,
-        toId: this.props.observableId,
+        fromId: props.indicatorId,
+        toId: props.observableId,
         relationship_type: 'based-on',
       },
       updater: (store) => {
         deleteNodeFromId(
           store,
-          this.props.observableId,
+          props.observableId,
           'Pagination_stixCyberObservables_indicators',
           {},
-          this.props.indicatorId,
+          props.indicatorId,
         );
       },
       onCompleted: () => {
-        this.handleCloseDelete();
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label="stix cyber observable indicator popover button"
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          style={{ marginTop: 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <Menu
-          anchorEl={this.state.anchorEl}
-          open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose.bind(this)}
-        >
-          <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-            {t('Remove')}
-          </MenuItem>
-        </Menu>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to remove the indicator from this observable?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+  const { classes } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label="stix cyber observable indicator popover button"
+        onClick={handleOpen}
+        aria-haspopup="true"
+        style={{ marginTop: 3 }}
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleOpenDelete}>
+          {t_i18n('Remove')}
+        </MenuItem>
+      </Menu>
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to remove the indicator from this observable?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 StixCyberObservableIndicatorPopover.propTypes = {
   observableId: PropTypes.string,
@@ -162,10 +155,6 @@ StixCyberObservableIndicatorPopover.propTypes = {
   isRelation: PropTypes.bool,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservableIndicatorPopover);
+export default withStyles(styles)(StixCyberObservableIndicatorPopover);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
@@ -83,7 +83,7 @@ const StixCyberObservableOverview = (props) => {
   const { t_i18n, fldt } = useFormatter();
   const [openStixIds, setOpenStixIds] = useState(false);
   const handleToggleOpenStixIds = () => {
-    setOpenStixIds(!openStixIds);
+    setOpenStixIds((current) => !current);
   };
 
   const deleteStixId = (stixId) => {

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableOverview.jsx
@@ -14,8 +14,7 @@ import withStyles from '@mui/styles/withStyles';
 import { InformationOutline } from 'mdi-material-ui';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
 import ItemAuthor from '../../../../components/ItemAuthor';
 import ItemCopy from '../../../../components/ItemCopy';
@@ -24,7 +23,7 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemScore from '../../../../components/ItemScore';
 import Label from '../../../../components/common/label/Label';
 import Tag from '../../../../components/common/tag/Tag';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
@@ -80,20 +79,15 @@ const stixCyberObservableMutation = graphql`
   }
 `;
 
-class StixCyberObservableOverview extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      openStixIds: false,
-    };
-  }
+const StixCyberObservableOverview = (props) => {
+  const { t_i18n, fldt } = useFormatter();
+  const [openStixIds, setOpenStixIds] = useState(false);
+  const handleToggleOpenStixIds = () => {
+    setOpenStixIds(!openStixIds);
+  };
 
-  handleToggleOpenStixIds() {
-    this.setState({ openStixIds: !this.state.openStixIds });
-  }
-
-  deleteStixId(stixId) {
-    const { stixCyberObservable } = this.props;
+  const deleteStixId = (stixId) => {
+    const { stixCyberObservable } = props;
     const otherStixIds = stixCyberObservable.x_opencti_stix_ids || [];
     const stixIds = R.filter(
       (n) => n !== stixCyberObservable.standard_id && n !== stixId,
@@ -102,165 +96,158 @@ class StixCyberObservableOverview extends Component {
     commitMutation({
       mutation: stixCyberObservableMutation,
       variables: {
-        id: this.props.stixCyberObservable.id,
+        id: props.stixCyberObservable.id,
         input: {
           key: 'x_opencti_stix_ids',
           value: stixIds,
         },
       },
-      onCompleted: () => MESSAGING$.notifySuccess(this.props.t('The STIX ID has been removed')),
+      onCompleted: () => MESSAGING$.notifySuccess(t_i18n('The STIX ID has been removed')),
     });
-  }
+  };
 
-  render() {
-    const { t, fldt, classes, stixCyberObservable } = this.props;
-    const otherStixIds = stixCyberObservable.x_opencti_stix_ids || [];
-    const stixIds = R.filter(
-      (n) => n !== stixCyberObservable.standard_id,
-      otherStixIds,
-    );
-    return (
-      <>
-        <Card title={t('Basic information')}>
-          <Grid container={true} spacing={2}>
-            <Grid item xs={6}>
-              <Label>
-                {t('Marking')}
-              </Label>
-              <ItemMarkings
-                markingDefinitions={stixCyberObservable.objectMarking ?? []}
-              />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Score')}
-              </Label>
-              <ItemScore score={stixCyberObservable.x_opencti_score} />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Author')}
-              </Label>
-              <ItemAuthor
-                createdBy={stixCyberObservable.createdBy}
-              />
-              <StixCoreObjectLabelsView
-                labels={stixCyberObservable.objectLabel}
-                id={stixCyberObservable.id}
-                sx={{ marginTop: 2 }}
-                entity_type={stixCyberObservable.entity_type}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <Label>
-                {t('Observable type')}
-              </Label>
-              <Tag
-                color="#203af6"
-                label={t(`entity_${stixCyberObservable.entity_type}`)}
-              />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Creators')}
-              </Label>
-              <ItemCreators creators={stixCyberObservable.creators ?? []} />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Platform creation date')}
-              </Label>
-              {fldt(stixCyberObservable.created_at)}
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Modification date')}
-              </Label>
-              {fldt(stixCyberObservable.updated_at)}
-              <div style={{ marginTop: 20 }}>
-                <Label action={(
-                  <>
-                    <Tooltip
-                      title={t(
-                        'In OpenCTI, a predictable STIX ID is generated based on one or multiple attributes of the entity.',
-                      )}
-                    >
-                      <InformationOutline fontSize="small" color="primary" />
-                    </Tooltip>
-                    <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <IconButton
-                        aria-label="Close"
-                        disableRipple={true}
-                        size="small"
-                        disabled={stixIds.length === 0}
-                        onClick={this.handleToggleOpenStixIds.bind(this)}
-                      >
-                        <BrushOutlined
-                          fontSize="small"
-                          color={stixIds.length === 0 ? 'inherit' : 'secondary'}
-                        />
-                      </IconButton>
-                    </Security>
-                  </>
-                )}
-                >
-                  {t('Standard STIX ID')}
-                </Label>
-                <div className={classes.standard_id}>
-                  <ItemCopy content={stixCyberObservable.standard_id} />
-                </div>
-              </div>
-            </Grid>
-          </Grid>
-        </Card>
-        <Dialog
-          open={this.state.openStixIds}
-          onClose={this.handleToggleOpenStixIds.bind(this)}
-          title={t('Other STIX IDs')}
-        >
-          <List>
-            {stixIds.map(
-              (stixId) => stixId.length > 0 && (
-                <ListItem
-                  key={stixId}
-                  disableGutters={true}
-                  dense={true}
-                  secondaryAction={(
-                    <IconButton
-                      edge="end"
-                      aria-label="delete"
-                      onClick={this.deleteStixId.bind(this, stixId)}
-                    >
-                      <Delete />
-                    </IconButton>
-                  )}
-                >
-                  <ListItemText primary={stixId} />
-                </ListItem>
-              ),
-            )}
-          </List>
-          <DialogActions>
-            <Button
-              onClick={this.handleToggleOpenStixIds.bind(this)}
+  const { classes, stixCyberObservable } = props;
+  const otherStixIds = stixCyberObservable.x_opencti_stix_ids || [];
+  const stixIds = R.filter(
+    (n) => n !== stixCyberObservable.standard_id,
+    otherStixIds,
+  );
+  return (
+    <>
+      <Card title={t_i18n('Basic information')}>
+        <Grid container={true} spacing={2}>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Marking')}
+            </Label>
+            <ItemMarkings
+              markingDefinitions={stixCyberObservable.objectMarking ?? []}
+            />
+            <Label
+              sx={{ marginTop: 2 }}
             >
-              {t('Close')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </>
-    );
-  }
-}
+              {t_i18n('Score')}
+            </Label>
+            <ItemScore score={stixCyberObservable.x_opencti_score} />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Author')}
+            </Label>
+            <ItemAuthor
+              createdBy={stixCyberObservable.createdBy}
+            />
+            <StixCoreObjectLabelsView
+              labels={stixCyberObservable.objectLabel}
+              id={stixCyberObservable.id}
+              sx={{ marginTop: 2 }}
+              entity_type={stixCyberObservable.entity_type}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Observable type')}
+            </Label>
+            <Tag
+              color="#203af6"
+              label={t_i18n(`entity_${stixCyberObservable.entity_type}`)}
+            />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Creators')}
+            </Label>
+            <ItemCreators creators={stixCyberObservable.creators ?? []} />
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Platform creation date')}
+            </Label>
+            {fldt(stixCyberObservable.created_at)}
+            <Label
+              sx={{ marginTop: 2 }}
+            >
+              {t_i18n('Modification date')}
+            </Label>
+            {fldt(stixCyberObservable.updated_at)}
+            <div style={{ marginTop: 20 }}>
+              <Label action={(
+                <>
+                  <Tooltip
+                    title={t_i18n(
+                      'In OpenCTI, a predictable STIX ID is generated based on one or multiple attributes of the entity.',
+                    )}
+                  >
+                    <InformationOutline fontSize="small" color="primary" />
+                  </Tooltip>
+                  <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                    <IconButton
+                      aria-label="Close"
+                      disableRipple={true}
+                      size="small"
+                      disabled={stixIds.length === 0}
+                      onClick={handleToggleOpenStixIds}
+                    >
+                      <BrushOutlined
+                        fontSize="small"
+                        color={stixIds.length === 0 ? 'inherit' : 'secondary'}
+                      />
+                    </IconButton>
+                  </Security>
+                </>
+              )}
+              >
+                {t_i18n('Standard STIX ID')}
+              </Label>
+              <div className={classes.standard_id}>
+                <ItemCopy content={stixCyberObservable.standard_id} />
+              </div>
+            </div>
+          </Grid>
+        </Grid>
+      </Card>
+      <Dialog
+        open={openStixIds}
+        onClose={handleToggleOpenStixIds}
+        title={t_i18n('Other STIX IDs')}
+      >
+        <List>
+          {stixIds.map(
+            (stixId) => stixId.length > 0 && (
+              <ListItem
+                key={stixId}
+                disableGutters={true}
+                dense={true}
+                secondaryAction={(
+                  <IconButton
+                    edge="end"
+                    aria-label="delete"
+                    onClick={deleteStixId.bind(null, stixId)}
+                  >
+                    <Delete />
+                  </IconButton>
+                )}
+              >
+                <ListItemText primary={stixId} />
+              </ListItem>
+            ),
+          )}
+        </List>
+        <DialogActions>
+          <Button
+            onClick={handleToggleOpenStixIds}
+          >
+            {t_i18n('Close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
 
 StixCyberObservableOverview.propTypes = {
   stixCyberObservable: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
-  fldt: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservableOverview);
+export default withStyles(styles)(StixCyberObservableOverview);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportCreation.jsx
@@ -10,12 +10,12 @@ import Tooltip from '@mui/material/Tooltip';
 import withStyles from '@mui/styles/withStyles';
 import { Field, Form, Formik } from 'formik';
 import * as PropTypes from 'prop-types';
-import { compose, filter, flatten, fromPairs, includes, map, propOr, uniq, zip } from 'ramda';
-import React, { Component } from 'react';
+import { filter, flatten, fromPairs, includes, map, propOr, uniq, zip } from 'ramda';
+import React, { useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import * as Yup from 'yup';
 import SelectField from '../../../../components/fields/SelectField';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
 import { commitMutation, MESSAGING$, QueryRenderer } from '../../../../relay/environment';
 import { ExportContext } from '../../../../utils/ExportContextProvider';
@@ -76,26 +76,24 @@ export const scopesConn = (exportConnectors) => {
   return fromPairs(zipped);
 };
 
-class StixCyberObservablesExportCreationComponent extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { open: false, selectedContentMaxMarkingsIds: [] };
-  }
+const StixCyberObservablesExportCreationComponent = (props) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState([]);
+  const handleSelectedContentMaxMarkingsChange = (values) => {
+    setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
+  };
 
-  handleSelectedContentMaxMarkingsChange(values) {
-    this.setState({ selectedContentMaxMarkingsIds: values.map(({ value }) => value) });
-  }
+  const handleOpen = () => {
+    setOpen(true);
+  };
 
-  handleOpen() {
-    this.setState({ open: true });
-  }
+  const handleClose = () => {
+    setOpen(false);
+  };
 
-  handleClose() {
-    this.setState({ open: false });
-  }
-
-  onSubmit(selectedIds, values, { setSubmitting, resetForm }) {
-    const { paginationOptions, exportContext } = this.props;
+  const onSubmit = (selectedIds, values, { setSubmitting, resetForm }) => {
+    const { paginationOptions, exportContext } = props;
     const { orderBy, orderMode, filters, search } = paginationOptions;
     const contentMaxMarkings = values.contentMaxMarkings.map(({ value }) => value);
     const fileMarkings = values.fileMarkings.map(({ value }) => value);
@@ -127,180 +125,178 @@ class StixCyberObservablesExportCreationComponent extends Component {
       onCompleted: () => {
         setSubmitting(false);
         resetForm();
-        if (this.props.onExportAsk) this.props.onExportAsk();
-        this.handleClose();
+        if (props.onExportAsk) props.onExportAsk();
+        handleClose();
         MESSAGING$.notifySuccess('Export successfully started');
       },
     });
-  }
+  };
 
-  render() {
-    const { classes, t, data } = this.props;
-    const connectorsExport = propOr([], 'connectorsForExport', data);
-    const exportScopes = uniq(
-      flatten(map((c) => c.connector_scope, connectorsExport)),
-    );
-    const exportConnsPerFormat = scopesConn(connectorsExport);
-    const isExportActive = (format) => filter((x) => x.data.active, exportConnsPerFormat[format]).length > 0;
-    const isExportPossible = filter((x) => isExportActive(x), exportScopes).length > 0;
-    const visibleColumnExportEnabledFormats = ['text/csv'];
-    return (
-      <ExportContext.Consumer>
-        {({ selectedIds }) => {
-          return (
-            <>
-              <Tooltip
-                title={
-                  isExportPossible
-                    ? t('Generate an export')
-                    : t('No export connector available to generate an export')
-                }
-                aria-label="generate-export"
+  const { classes, data } = props;
+  const connectorsExport = propOr([], 'connectorsForExport', data);
+  const exportScopes = uniq(
+    flatten(map((c) => c.connector_scope, connectorsExport)),
+  );
+  const exportConnsPerFormat = scopesConn(connectorsExport);
+  const isExportActive = (format) => filter((x) => x.data.active, exportConnsPerFormat[format]).length > 0;
+  const isExportPossible = filter((x) => isExportActive(x), exportScopes).length > 0;
+  const visibleColumnExportEnabledFormats = ['text/csv'];
+  return (
+    <ExportContext.Consumer>
+      {({ selectedIds }) => {
+        return (
+          <>
+            <Tooltip
+              title={
+                isExportPossible
+                  ? t_i18n('Generate an export')
+                  : t_i18n('No export connector available to generate an export')
+              }
+              aria-label="generate-export"
+            >
+              <Fab
+                onClick={handleOpen}
+                color="primary"
+                aria-label="Add"
+                className={classes.createButton}
+                disabled={!isExportPossible}
+                data-testid="StixCyberObservablesExportCreationAddButton"
               >
-                <Fab
-                  onClick={this.handleOpen.bind(this)}
-                  color="primary"
-                  aria-label="Add"
-                  className={classes.createButton}
-                  disabled={!isExportPossible}
-                  data-testid="StixCyberObservablesExportCreationAddButton"
-                >
-                  <Add />
-                </Fab>
-              </Tooltip>
-              <Formik
-                enableReinitialize={true}
-                initialValues={{
-                  format: '',
-                  type: 'simple',
-                  contentMaxMarkings: [],
-                  fileMarkings: [],
-                  columns: 'all',
-                }}
-                validationSchema={exportValidation(t)}
-                onSubmit={this.onSubmit.bind(this, selectedIds)}
-                onReset={this.handleClose.bind(this)}
-              >
-                {({ submitForm, handleReset, isSubmitting, resetForm, values }) => (
-                  <Form>
-                    <Dialog
-                      open={this.state.open}
-                      onClose={() => {
-                        resetForm();
-                        this.handleClose();
-                      }}
-                      data-testid="StixCyberObservablesExportCreationDialog"
-                      title={(
-                        <Stack direction="row" alignItems="center" gap={1}>
-                          {t('Generate an export')}
-                          <Tooltip title={t('Your max shareable markings will be applied to the content max markings')}>
-                            <InfoOutlined fontSize="small" color="primary" />
-                          </Tooltip>
-                        </Stack>
-                      )}
-                    >
-                      <QueryRenderer
-                        query={markingDefinitionsLinesSearchQuery}
-                        variables={{ first: 200 }}
-                        render={({ props }) => {
-                          if (props && props.markingDefinitions) {
-                            return (
-                              <>
-                                <Field
-                                  component={SelectField}
-                                  variant="standard"
-                                  name="format"
-                                  label={t('Export format')}
-                                  fullWidth={true}
-                                  containerstyle={{ width: '100%' }}
-                                >
-                                  {exportScopes.map((value, i) => (
-                                    <MenuItem
-                                      key={i}
-                                      value={value}
-                                      disabled={!isExportActive(value)}
+                <Add />
+              </Fab>
+            </Tooltip>
+            <Formik
+              enableReinitialize={true}
+              initialValues={{
+                format: '',
+                type: 'simple',
+                contentMaxMarkings: [],
+                fileMarkings: [],
+                columns: 'all',
+              }}
+              validationSchema={exportValidation(t_i18n)}
+              onSubmit={onSubmit.bind(null, selectedIds)}
+              onReset={handleClose}
+            >
+              {({ submitForm, handleReset, isSubmitting, resetForm, values }) => (
+                <Form>
+                  <Dialog
+                    open={open}
+                    onClose={() => {
+                      resetForm();
+                      handleClose();
+                    }}
+                    data-testid="StixCyberObservablesExportCreationDialog"
+                    title={(
+                      <Stack direction="row" alignItems="center" gap={1}>
+                        {t_i18n('Generate an export')}
+                        <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
+                          <InfoOutlined fontSize="small" color="primary" />
+                        </Tooltip>
+                      </Stack>
+                    )}
+                  >
+                    <QueryRenderer
+                      query={markingDefinitionsLinesSearchQuery}
+                      variables={{ first: 200 }}
+                      render={({ props }) => {
+                        if (props && props.markingDefinitions) {
+                          return (
+                            <>
+                              <Field
+                                component={SelectField}
+                                variant="standard"
+                                name="format"
+                                label={t_i18n('Export format')}
+                                fullWidth={true}
+                                containerstyle={{ width: '100%' }}
+                              >
+                                {exportScopes.map((value, i) => (
+                                  <MenuItem
+                                    key={i}
+                                    value={value}
+                                    disabled={!isExportActive(value)}
+                                  >
+                                    {value}
+                                  </MenuItem>
+                                ))}
+                              </Field>
+                              <Field
+                                component={SelectField}
+                                variant="standard"
+                                name="type"
+                                label={t_i18n('Export type')}
+                                fullWidth={true}
+                                containerstyle={fieldSpacingContainerStyle}
+                              >
+                                <MenuItem value="simple">
+                                  {t_i18n('Simple export (just the entity)')}
+                                </MenuItem>
+                                <MenuItem value="full">
+                                  {t_i18n(
+                                    'Full export (entity and first neighbours)',
+                                  )}
+                                </MenuItem>
+                              </Field>
+                              <ObjectMarkingField
+                                name="contentMaxMarkings"
+                                label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
+                                onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
+                                style={fieldSpacingContainerStyle}
+                                limitToMaxSharing
+                                helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
+                              />
+                              <ObjectMarkingField
+                                name="fileMarkings"
+                                label={t_i18n('File marking definition levels')}
+                                filterTargetIds={selectedContentMaxMarkingsIds}
+                                style={fieldSpacingContainerStyle}
+                              />
+                              {visibleColumnExportEnabledFormats.includes(values.format)
+                                ? (
+                                    <Field
+                                      component={SelectField}
+                                      variant="standard"
+                                      name="columns"
+                                      label={t_i18n('Choose column to export')}
+                                      fullWidth={true}
+                                      containerstyle={fieldSpacingContainerStyle}
                                     >
-                                      {value}
-                                    </MenuItem>
-                                  ))}
-                                </Field>
-                                <Field
-                                  component={SelectField}
-                                  variant="standard"
-                                  name="type"
-                                  label={t('Export type')}
-                                  fullWidth={true}
-                                  containerstyle={fieldSpacingContainerStyle}
-                                >
-                                  <MenuItem value="simple">
-                                    {t('Simple export (just the entity)')}
-                                  </MenuItem>
-                                  <MenuItem value="full">
-                                    {t(
-                                      'Full export (entity and first neighbours)',
-                                    )}
-                                  </MenuItem>
-                                </Field>
-                                <ObjectMarkingField
-                                  name="contentMaxMarkings"
-                                  label={t(CONTENT_MAX_MARKINGS_TITLE)}
-                                  onChange={(_, values) => this.handleSelectedContentMaxMarkingsChange(values)}
-                                  style={fieldSpacingContainerStyle}
-                                  limitToMaxSharing
-                                  helpertext={t(CONTENT_MAX_MARKINGS_HELPERTEXT)}
-                                />
-                                <ObjectMarkingField
-                                  name="fileMarkings"
-                                  label={t('File marking definition levels')}
-                                  filterTargetIds={this.state.selectedContentMaxMarkingsIds}
-                                  style={fieldSpacingContainerStyle}
-                                />
-                                {visibleColumnExportEnabledFormats.includes(values.format)
-                                  ? (
-                                      <Field
-                                        component={SelectField}
-                                        variant="standard"
-                                        name="columns"
-                                        label={t('Choose column to export')}
-                                        fullWidth={true}
-                                        containerstyle={fieldSpacingContainerStyle}
-                                      >
-                                        <MenuItem value="all">
-                                          {t('All attributes')}
-                                        </MenuItem>
-                                        <MenuItem value="view">
-                                          {t('Current view')}
-                                        </MenuItem>
-                                      </Field>
-                                    ) : undefined}
-                              </>
-                            );
-                          }
-                          return <Loader variant="inElement" />;
-                        }}
-                      />
-                      <DialogActions>
-                        <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
-                          {t('Cancel')}
-                        </Button>
-                        <Button
-                          onClick={submitForm}
-                          disabled={isSubmitting}
-                        >
-                          {t('Create')}
-                        </Button>
-                      </DialogActions>
-                    </Dialog>
-                  </Form>
-                )}
-              </Formik>
-            </>
-          );
-        }}
-      </ExportContext.Consumer>
-    );
-  }
-}
+                                      <MenuItem value="all">
+                                        {t_i18n('All attributes')}
+                                      </MenuItem>
+                                      <MenuItem value="view">
+                                        {t_i18n('Current view')}
+                                      </MenuItem>
+                                    </Field>
+                                  ) : undefined}
+                            </>
+                          );
+                        }
+                        return <Loader variant="inElement" />;
+                      }}
+                    />
+                    <DialogActions>
+                      <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
+                        {t_i18n('Cancel')}
+                      </Button>
+                      <Button
+                        onClick={submitForm}
+                        disabled={isSubmitting}
+                      >
+                        {t_i18n('Create')}
+                      </Button>
+                    </DialogActions>
+                  </Dialog>
+                </Form>
+              )}
+            </Formik>
+          </>
+        );
+      }}
+    </ExportContext.Consumer>
+  );
+};
 
 const StixCyberObservablesExportCreations = createFragmentContainer(
   StixCyberObservablesExportCreationComponent,
@@ -321,14 +317,10 @@ const StixCyberObservablesExportCreations = createFragmentContainer(
 
 StixCyberObservablesExportCreations.propTypes = {
   classes: PropTypes.object.isRequired,
-  t: PropTypes.func,
   data: PropTypes.object,
   paginationOptions: PropTypes.object,
   exportContext: PropTypes.object,
   onExportAsk: PropTypes.func,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservablesExportCreations);
+export default withStyles(styles)(StixCyberObservablesExportCreations);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExports.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExports.jsx
@@ -1,12 +1,11 @@
-import React, { Component } from 'react';
+import React from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import Slide from '@mui/material/Slide';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixCyberObservablesExportsContent, { stixCyberObservablesExportsContentQuery } from './StixCyberObservablesExportsContent';
 import Drawer from '@components/common/drawer/Drawer';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 
 const Transition = React.forwardRef((props, ref) => (
   <Slide direction="up" ref={ref} {...props} />
@@ -27,34 +26,33 @@ const styles = (theme) => ({
   toolbar: theme.mixins.toolbar,
 });
 
-class StixCyberObservablesExports extends Component {
-  render() {
-    const { paginationOptions, open, handleToggle, exportContext, t } = this.props;
-    return (
-      <Drawer
-        open={open}
-        elevation={1}
-        onClose={handleToggle.bind(this)}
-        title={t('Exports list')}
-        size="medium"
-      >
-        <QueryRenderer
-          query={stixCyberObservablesExportsContentQuery}
-          variables={{ count: 25, exportContext }}
-          render={({ props }) => (
-            <StixCyberObservablesExportsContent
-              handleToggle={handleToggle.bind(this)}
-              data={props}
-              paginationOptions={paginationOptions}
-              isOpen={open}
-              exportContext={exportContext}
-            />
-          )}
-        />
-      </Drawer>
-    );
-  }
-}
+const StixCyberObservablesExports = (props) => {
+  const { t_i18n } = useFormatter();
+  const { paginationOptions, open, handleToggle, exportContext } = props;
+  return (
+    <Drawer
+      open={open}
+      elevation={1}
+      onClose={handleToggle}
+      title={t_i18n('Exports list')}
+      size="medium"
+    >
+      <QueryRenderer
+        query={stixCyberObservablesExportsContentQuery}
+        variables={{ count: 25, exportContext }}
+        render={({ props }) => (
+          <StixCyberObservablesExportsContent
+            handleToggle={handleToggle}
+            data={props}
+            paginationOptions={paginationOptions}
+            isOpen={open}
+            exportContext={exportContext}
+          />
+        )}
+      />
+    </Drawer>
+  );
+};
 
 StixCyberObservablesExports.propTypes = {
   classes: PropTypes.object.isRequired,
@@ -65,7 +63,4 @@ StixCyberObservablesExports.propTypes = {
   exportContext: PropTypes.object,
 };
 
-export default compose(
-  inject18n,
-  withStyles(styles),
-)(StixCyberObservablesExports);
+export default withStyles(styles)(StixCyberObservablesExports);

--- a/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionPopover.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/retention/RetentionPopover.jsx
@@ -10,9 +10,9 @@ import Slide from '@mui/material/Slide';
 import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, QueryRenderer } from '../../../../relay/environment';
 import { deleteNode } from '../../../../utils/store';
 import RetentionEdition from './RetentionEdition';
@@ -61,169 +61,161 @@ const retentionEditionQuery = graphql`
   }
 `;
 
-class RetentionPopover extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      anchorEl: null,
-      displayUpdate: false,
-      displayDelete: false,
-      deleting: false,
-    };
-  }
+const RetentionPopover = (props) => {
+  const { t_i18n } = useFormatter();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [displayUpdate, setDisplayUpdate] = useState(false);
+  const [displayDelete, setDisplayDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-  handleOpen(event) {
-    this.setState({ anchorEl: event.currentTarget });
-  }
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-  handleClose() {
-    this.setState({ anchorEl: null });
-  }
+  const handleOpenUpdate = () => {
+    setDisplayUpdate(true);
+    handleClose();
+  };
 
-  handleOpenUpdate() {
-    this.setState({ displayUpdate: true });
-    this.handleClose();
-  }
+  const handleCloseUpdate = () => {
+    setDisplayUpdate(false);
+  };
 
-  handleCloseUpdate() {
-    this.setState({ displayUpdate: false });
-  }
+  const handleOpenDelete = () => {
+    setDisplayDelete(true);
+    handleClose();
+  };
 
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-    this.handleClose();
-  }
+  const handleCloseDelete = () => {
+    setDisplayDelete(false);
+  };
 
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
+  const submitDelete = () => {
+    setDeleting(true);
     commitMutation({
       mutation: retentionPopoverDeletionMutation,
       variables: {
-        id: this.props.retentionRuleId,
+        id: props.retentionRuleId,
       },
       updater: (store) => {
         deleteNode(
           store,
           'Pagination_retentionRules',
-          this.props.paginationOptions,
-          this.props.retentionRuleId,
+          props.paginationOptions,
+          props.retentionRuleId,
         );
       },
       onCompleted: () => {
-        this.setState({ deleting: false });
-        this.handleCloseDelete();
+        setDeleting(false);
+        handleCloseDelete();
       },
     });
-  }
+  };
 
-  submitToggleActive(currentActive) {
+  const submitToggleActive = (currentActive) => {
     commitMutation({
       mutation: retentionPopoverFieldPatchMutation,
       variables: {
-        id: this.props.retentionRuleId,
+        id: props.retentionRuleId,
         input: [{ key: 'active', value: [String(!currentActive)] }],
       },
     });
-    this.handleClose();
-  }
+    handleClose();
+  };
 
-  render() {
-    const { classes, t, retentionRuleId } = this.props;
-    return (
-      <div className={classes.container}>
-        <IconButton
-          aria-label={t('Open menu')}
-          onClick={this.handleOpen.bind(this)}
-          aria-haspopup="true"
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-        <QueryRenderer
-          query={retentionEditionQuery}
-          variables={{ id: retentionRuleId }}
-          render={({ props }) => {
-            if (props) {
-              const { retentionRule } = props;
-              const isTechnicalRule = retentionRule?.scope && retentionRule.scope !== 'knowledge';
-              return (
-                <>
-                  <Menu
-                    anchorEl={this.state.anchorEl}
-                    open={Boolean(this.state.anchorEl)}
-                    onClose={this.handleClose.bind(this)}
-                  >
-                    <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-                      {t('Update')}
-                    </MenuItem>
-                    <MenuItem onClick={() => this.submitToggleActive(retentionRule?.active)}>
-                      {retentionRule?.active ? t('Deactivate') : t('Activate')}
-                    </MenuItem>
-                    {!isTechnicalRule && (
-                      <MenuItem onClick={this.handleOpenDelete.bind(this)}>
-                        {t('Delete')}
-                      </MenuItem>
-                    )}
-                  </Menu>
-                  <RetentionEdition
-                    retentionRule={retentionRule}
-                    handleClose={this.handleCloseUpdate.bind(this)}
-                    open={this.state.displayUpdate}
-                  />
-                </>
-              );
-            }
+  const { classes, retentionRuleId } = props;
+  return (
+    <div className={classes.container}>
+      <IconButton
+        aria-label={t_i18n('Open menu')}
+        onClick={handleOpen}
+        aria-haspopup="true"
+        color="primary"
+      >
+        <MoreVert />
+      </IconButton>
+      <QueryRenderer
+        query={retentionEditionQuery}
+        variables={{ id: retentionRuleId }}
+        render={({ props }) => {
+          if (props) {
+            const { retentionRule } = props;
+            const isTechnicalRule = retentionRule?.scope && retentionRule.scope !== 'knowledge';
             return (
-              <Menu
-                anchorEl={this.state.anchorEl}
-                open={Boolean(this.state.anchorEl)}
-                onClose={this.handleClose.bind(this)}
-              >
-                <MenuItem onClick={this.handleOpenUpdate.bind(this)}>
-                  {t('Update')}
-                </MenuItem>
-              </Menu>
+              <>
+                <Menu
+                  anchorEl={anchorEl}
+                  open={Boolean(anchorEl)}
+                  onClose={handleClose}
+                >
+                  <MenuItem onClick={handleOpenUpdate}>
+                    {t_i18n('Update')}
+                  </MenuItem>
+                  <MenuItem onClick={() => submitToggleActive(retentionRule?.active)}>
+                    {retentionRule?.active ? t_i18n('Deactivate') : t_i18n('Activate')}
+                  </MenuItem>
+                  {!isTechnicalRule && (
+                    <MenuItem onClick={handleOpenDelete}>
+                      {t_i18n('Delete')}
+                    </MenuItem>
+                  )}
+                </Menu>
+                <RetentionEdition
+                  retentionRule={retentionRule}
+                  handleClose={handleCloseUpdate}
+                  open={displayUpdate}
+                />
+              </>
             );
-          }}
-        />
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-        >
-          <DialogContentText>
-            {t('Do you want to delete this retention policy?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              variant="secondary"
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
+          }
+          return (
+            <Menu
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={handleClose}
             >
-              {t('Cancel')}
-            </Button>
-            <Button
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
+              <MenuItem onClick={handleOpenUpdate}>
+                {t_i18n('Update')}
+              </MenuItem>
+            </Menu>
+          );
+        }}
+      />
+      <Dialog
+        open={displayDelete}
+        onClose={handleCloseDelete}
+        title={t_i18n('Are you sure?')}
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this retention policy?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={handleCloseDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
 
 RetentionPopover.propTypes = {
   retentionRuleId: PropTypes.string,
   paginationOptions: PropTypes.object,
   classes: PropTypes.object,
-  t: PropTypes.func,
 };
 
-export default compose(inject18n, withStyles(styles))(RetentionPopover);
+export default compose(withStyles(styles))(RetentionPopover);


### PR DESCRIPTION
Closes #17973

> Base branch is `issue/17971-inject18n-stateful-classes` (#17972), so this diff only shows this tranche.

## Proposed changes

Third tranche of the `inject18n` migration: the **21 consumers whose class has no lifecycle method and no ref**. Same mechanical conversion as #17972 — `this.state` becomes `useState`, `this.setState` becomes the matching setter, and the injected props come from `useFormatter`.

`inject18n` consumers go from 49 to 28.

## Why these were not in the previous tranche

A faulty classification on my side. The filter for #17972 matched `forwardRef` and `createRef` anywhere in the file, but every hit turned out to be either the module-level `const Transition = React.forwardRef(...)` helper used for MUI dialogs, or Relay's `createRefetchContainer`. Neither has anything to do with the class. Exactly one file in the codebase holds a genuine class ref (`ExportButtons`, `this.csvLink = React.createRef()`).

## Two files deliberately left on the HOC

**`StixDomainObjectVictimologySectors`** reads URL and storage parameters in its constructor before setting state, so it needs a lazy initialiser rather than the mechanical rewrite this tranche applies.

**`StixDomainObjectsExportCreation` — worth a look, this one is a live bug.** Its export mutation's `onCompleted` callback calls `this.handleClose()`, but the class defines no such method and no such prop exists:

```js
onCompleted: () => {
  setSubmitting(false);
  resetForm();
  if (this.props.onExportAsk) this.props.onExportAsk();
  this.handleClose();                                 // TypeError
  MESSAGING$.notifySuccess('Export successfully started');
},
```

The call throws, so the success notification on the following line has never been reached and the dialog never closes itself. The caller in `StixDomainObjectsExportsContent` passes `onClose`, so the intent was `this.props.onClose()`.

Converting this file forces a behaviour change whichever way it is resolved, so it stays on `inject18n` until someone who knows the intent decides. Reported here rather than fixed silently.

## Verification

Measured against the base branch, which is clean on all of these:

| | base | this branch |
|---|---|---|
| `yarn check-ts` | 0 errors | 0 errors |
| `yarn lint` on touched files | clean | clean |
| `yarn build` | passes | passes |
| `TZ=UTC yarn test` | 150 files / 1326 tests | 150 files / 1326 tests |

Also checked across the 21 files: no `extends Component`, no `setState`, no `this`, no `inject18n` reference left, and no injected prop still destructured from `props`.

## Related issues

Closes #17973

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/updated the relevant documentation (not applicable, internal refactor)
