### PR TITLE
feat(backend): use the app encryption key to derive the session signature key (#15353)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/session.js
+++ b/opencti-platform/opencti-graphql/src/database/session.js
@@ -1,12 +1,20 @@
 import session from 'express-session';
 import nconf from 'nconf';
-import * as R from 'ramda';
+import { promisify } from 'node:util';
 import conf, { booleanConf, OPENCTI_SESSION } from '../config/conf';
 import SessionStoreMemory from './sessionStore-memory';
 import RedisStore from './sessionStore-redis';
+import { getPlatformCrypto } from '../utils/platformCrypto';
+import { memoize } from '../utils/memoize';
 
 const sessionManager = nconf.get('app:session_manager');
-const sessionSecret = nconf.get('app:session_secret') || nconf.get('app:admin:password');
+
+// The session cookie signing key is derived from the platform encryption key.
+// It is then automatically shared between all the platform nodes and does not rely on any user provided secret.
+const getSessionSecret = async () => {
+  const factory = await getPlatformCrypto();
+  return factory.deriveSecret(['session', 'signature'], 1);
+};
 
 const createMemorySessionStore = () => {
   return new SessionStoreMemory({
@@ -18,17 +26,24 @@ const createRedisSessionStore = () => {
     ttl: conf.get('app:session_timeout'),
   });
 };
-const createSessionMiddleware = () => {
+const createApplicationSession = async () => {
   const isRedisSession = sessionManager === 'shared';
   const store = isRedisSession ? createRedisSessionStore() : createMemorySessionStore();
   const isSessionCookie = conf.get('app:session_cookie') ?? false;
   const sessionTimeout = isSessionCookie ? undefined : conf.get('app:session_timeout');
   return {
-    store,
+    // The store API is callback based and gives a full read/write access to every user session:
+    // only the promisified operations needed by this module are exposed.
+    sessionStore: {
+      prefix: store.prefix,
+      // the store interface allows an array or an object of sessions, depending on the implementation
+      all: async () => Object.values(await promisify(store.all.bind(store))()),
+      destroy: promisify(store.destroy.bind(store)),
+    },
     session: session({
       name: OPENCTI_SESSION,
       store,
-      secret: sessionSecret,
+      secret: await getSessionSecret(),
       proxy: true,
       rolling: true,
       saveUninitialized: false,
@@ -42,53 +57,45 @@ const createSessionMiddleware = () => {
   };
 };
 
-export const findSessions = () => {
-  const { store } = applicationSession;
-  return new Promise((accept) => {
-    store.all((_, result) => {
-      const sessionsPerUser = R.groupBy((s) => s.user.id, R.filter((n) => n.user, result));
-      const sessions = Object.entries(sessionsPerUser).map(([k, v]) => {
-        const userSessions = v.map((s) => {
-          return {
-            id: s.redis_key_id,
-            created: s.user.session_creation,
-            ttl: s.redis_key_ttl,
-            originalMaxAge: Math.round(s.cookie.originalMaxAge / 1000),
-          };
-        });
-        return { user_id: k, sessions: userSessions };
-      });
-      accept(sessions);
+const getApplicationSession = memoize(createApplicationSession);
+
+const getSessionStore = async () => (await getApplicationSession()).sessionStore;
+
+export const getSessionMiddleware = async () => (await getApplicationSession()).session;
+
+export const findSessions = async () => {
+  const store = await getSessionStore();
+  const storeSessions = await store.all();
+  const sessionsPerUser = Object.groupBy(storeSessions.filter((s) => s.user), (s) => s.user.id);
+  return Object.entries(sessionsPerUser).map(([userId, userStoreSessions]) => {
+    const userSessions = userStoreSessions.map((s) => {
+      return {
+        id: s.redis_key_id,
+        created: s.user.session_creation,
+        ttl: s.redis_key_ttl,
+        originalMaxAge: Math.round(s.cookie.originalMaxAge / 1000),
+      };
     });
+    return { user_id: userId, sessions: userSessions };
   });
 };
 
 export const findUserSessions = async (userId) => {
   const sessions = await findSessions();
-  const userSessions = sessions.filter((s) => s.user_id === userId);
-  if (userSessions.length > 0) {
-    return R.head(userSessions).sessions;
-  }
-  return [];
+  const userSessions = sessions.find((s) => s.user_id === userId);
+  return userSessions?.sessions ?? [];
 };
 
-export const killSession = async (id) => {
-  const { store } = applicationSession;
-  return new Promise((accept) => {
-    // eslint-disable-next-line no-void
-    void store.destroy(id, (_, data) => {
-      accept(data);
-    });
-  });
+// Session ids are exposed with the store prefix, it must be removed before reaching the store
+export const killSession = async (sessionId) => {
+  const store = await getSessionStore();
+  return store.destroy(sessionId.split(store.prefix)[1]);
 };
 
-export const killSessions = async (sessionsIds) => {
-  const { store } = applicationSession;
+const killSessions = async (sessionsIds) => {
   const killedSessions = [];
   for (let index = 0; index < sessionsIds.length; index += 1) {
-    const sessionId = sessionsIds[index];
-    const sessId = sessionId.split(store.prefix)[1];
-    const killedSession = await killSession(sessId);
+    const killedSession = await killSession(sessionsIds[index]);
     killedSessions.push(killedSession);
   }
   return killedSessions;
@@ -100,4 +107,36 @@ export const killUserSessions = async (userId) => {
   return killSessions(sessionsIds);
 };
 
-export const applicationSession = createSessionMiddleware();
+// Kill every session of a user but the current one, the current session id being the raw store id
+export const killOtherUserSessions = async (userId, currentSessionId) => {
+  if (!currentSessionId) {
+    return;
+  }
+  const sessions = await findUserSessions(userId);
+  const otherSessionsIds = sessions.filter((s) => !s.id.endsWith(currentSessionId)).map((s) => s.id);
+  await killSessions(otherSessionsIds);
+};
+
+// Kill the oldest sessions of a user to leave room for a new one, according to the given concurrent
+// sessions limit. Returns the number of killed sessions.
+export const killUserSessionsOverLimit = async (userId, maxConcurrentSessions) => {
+  if (!maxConcurrentSessions || maxConcurrentSessions <= 0) {
+    return 0;
+  }
+  const sessions = await findUserSessions(userId);
+  if (sessions.length < maxConcurrentSessions) {
+    return 0;
+  }
+  const oldestSessionsFirst = [...sessions].sort((a, b) => {
+    if (a.created < b.created) {
+      return -1;
+    }
+    if (a.created > b.created) {
+      return 1;
+    }
+    return 0;
+  });
+  const sessionsToKill = oldestSessionsFirst.slice(0, sessions.length - maxConcurrentSessions + 1);
+  await killSessions(sessionsToKill.map((s) => s.id));
+  return sessionsToKill.length;
+};

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -40,7 +40,7 @@ import {
   storeLoadById,
 } from '../database/middleware-loader';
 import { delEditContext, notify, publishCacheResetEvent, setEditContext } from '../database/redis';
-import { findUserSessions, killSessions, killUserSessions } from '../database/session';
+import { killOtherUserSessions, killUserSessions, killUserSessionsOverLimit } from '../database/session';
 import {
   buildPagination,
   isEmptyField,
@@ -1308,14 +1308,7 @@ export const meEditField = async (context, user, userId, inputs, password = null
   // If password was expired, kill all other sessions of this user (force change scenario)
   const hasPasswordInput = inputs.some((i) => i.key === 'password');
   if (hasPasswordInput && isPasswordExpired(user)) {
-    const currentSessionId = context.req?.session?.id;
-    const userSessions = await findUserSessions(userId);
-    const otherSessionIds = userSessions
-      .filter((s) => currentSessionId && !s.id.endsWith(currentSessionId))
-      .map((s) => s.id);
-    if (otherSessionIds.length > 0) {
-      await killSessions(otherSessionIds);
-    }
+    await killOtherUserSessions(userId, context.req?.session?.id);
   }
   return userEditField(context, user, userId, inputs);
 };
@@ -2181,27 +2174,6 @@ const validateUser = (user, settings, { skipForcePasswordCheck = false } = {}) =
   }
 };
 
-export const enforceSessionLimit = async (user, settings) => {
-  if (settings.platform_session_max_concurrent && settings.platform_session_max_concurrent > 0) {
-    const sessions = await findUserSessions(user.id);
-    if (sessions.length >= settings.platform_session_max_concurrent) {
-      const sortedSessions = sessions.sort((a, b) => {
-        if (a.created < b.created) {
-          return -1;
-        }
-        if (a.created > b.created) {
-          return 1;
-        }
-        return 0;
-      });
-      const sessionsToKill = sortedSessions.slice(0, sessions.length - settings.platform_session_max_concurrent + 1);
-      await killSessions(sessionsToKill.map((s) => s.id));
-      return sessionsToKill.length;
-    }
-  }
-  return 0;
-};
-
 export const sessionAuthenticateUser = async (context, req, user, provider) => {
   let platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
   let logged = platformUsers.get(user.internal_id);
@@ -2216,8 +2188,8 @@ export const sessionAuthenticateUser = async (context, req, user, provider) => {
   const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   // Password expiration is enforced after login by the frontend guard on /change-password.
   validateUser(logged, settings, { skipForcePasswordCheck: true });
+  const numberOfKilledSessions = await killUserSessionsOverLimit(logged.id, settings.platform_session_max_concurrent);
   const withOrigin = userWithOrigin(req, logged);
-  const numberOfKilledSessions = await enforceSessionLimit(withOrigin, settings);
   // Build and save the session
   req.session.user = { id: user.id, session_creation: now(), otp_validated: false, password_valid_until: logged.password_valid_until ?? null };
   req.session.session_provider = provider;

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -1,5 +1,6 @@
 import https from 'node:https';
 import http from 'node:http';
+import { promisify } from 'node:util';
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.mjs';
 
 import nconf from 'nconf';
@@ -15,7 +16,7 @@ import conf, { basePath, booleanConf, loadCert, logApp, PORT } from '../config/c
 import rateLimit from 'express-rate-limit';
 import createApp from './httpPlatform';
 import createApolloServer from '../graphql/graphql';
-import { applicationSession } from '../database/session';
+import { getSessionMiddleware } from '../database/session';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { ForbiddenAccess, WorkNotALiveError } from '../config/errors';
 import { getEntitiesMapFromCache } from '../database/cache';
@@ -50,16 +51,10 @@ export const extractWsSessionContext = async (context) => {
   const req = context.extra.request;
   const webSocket = context.extra.socket;
   // This will be run every time the client sends a subscription request
-  const wsSession = await new Promise((resolve) => {
-    // use same session parser as normal gql queries
-    const { session } = applicationSession;
-    session(req, {}, () => {
-      if (req.session) {
-        resolve(req.session);
-      }
-      return false;
-    });
-  });
+  // use same session parser as normal gql queries
+  const session = await getSessionMiddleware();
+  await promisify(session)(req, {});
+  const wsSession = req.session;
   // We have a good session. attach to context
 
   if (wsSession?.user) {
@@ -88,7 +83,7 @@ const createHttpServer = async () => {
   // Rate limiter must be first registered so it applies to all requests including /graphql
   // Even before session so it avoid creating session on rate limited requests.
   app.use(rateLimit(buildRateLimiterOptions()));
-  app.use(applicationSession.session);
+  app.use(await getSessionMiddleware());
   app.use(passport.initialize({}));
   const { schema, apolloServer } = createApolloServer();
   let httpServer;

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -1,7 +1,7 @@
 import { BUS_TOPICS, ENABLED_DEMO_MODE } from '../config/conf';
 import { internalLoadById } from '../database/middleware-loader';
 import { fetchEditContext } from '../database/redis';
-import { applicationSession, findSessions, findUserSessions, killSession, killUserSessions } from '../database/session';
+import { findSessions, findUserSessions, killSession, killUserSessions } from '../database/session';
 import { addRole } from '../domain/grant';
 import {
   addBookmark,
@@ -146,9 +146,7 @@ const userResolvers = {
     token: async (_, { input }, context) => sessionLogin(context, input),
     connectorJWT: () => issueConnectorJWT(),
     sessionKill: async (_, { id }, context) => {
-      const { store } = applicationSession;
-      const userSessionId = id.split(store.prefix)[1]; // Prefix must be removed on this case
-      const kill = await killSession(userSessionId);
+      const kill = await killSession(id);
       const { user } = kill.session;
       const actionEmail = ENABLED_DEMO_MODE ? REDACTED_USER.name : user.user_email;
       await publishUserAction({

--- a/opencti-platform/opencti-graphql/src/utils/platformCrypto.ts
+++ b/opencti-platform/opencti-graphql/src/utils/platformCrypto.ts
@@ -237,10 +237,25 @@ export const createCryptoKeyFactory = (seed: Buffer) => {
     };
   };
 
+  // Derive a raw secret, base64 encoded.
+  // Only intended for third party libraries requiring a shared secret material, otherwise prefer the
+  // other derivation functions that never expose the derived key material.
+  const deriveSecret = async (
+    derivationPath: string[],
+    version: number,
+    length = 32,
+  ): Promise<string> => {
+    const secret = await deriveBytes([...derivationPath, 'secret'], version, length);
+    const encodedSecret = secret.toString('base64');
+    secret.fill(0); // clean the local secret buffer
+    return encodedSecret;
+  };
+
   return {
     deriveAesKey,
     deriveHmac,
     deriveEd25519KeyPair,
+    deriveSecret,
   };
 };
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/session-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/session-test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+
+// Two distinct valid encryption keys (32 bytes, base64 encoded)
+const ENCRYPTION_KEY_1 = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+const ENCRYPTION_KEY_2 = 'ZmVkY2JhOTg3NjU0MzIxMGZlZGNiYTk4NzY1NDMyMTA=';
+
+// Session store shared by all the simulated nodes, as the Redis store is in a cluster deployment.
+// The session signature key is then the only thing that can prevent a node from resuming a session.
+const sharedSessions = vi.hoisted(() => new Map<string, string>());
+vi.mock('../../../src/database/sessionStore-memory', async (importOriginal) => {
+  const { default: SessionStoreMemory } = await importOriginal<any>();
+  class SharedSessionStore extends SessionStoreMemory {
+    prefix = 'sess:';
+
+    constructor(options = {}) {
+      super(options);
+      this.stopInterval(); // pruning is useless, entries are kept in the shared map
+    }
+
+    get(sid: string, fn: (error?: unknown, session?: unknown) => void) {
+      const data = sharedSessions.get(sid);
+      return data ? fn(null, JSON.parse(data)) : fn();
+    }
+
+    all(fn: (error: unknown, sessions: unknown[]) => void) {
+      // the redis store decorates the sessions with their store key and ttl
+      const sessions = [...sharedSessions.entries()].map(([sid, data]) => ({
+        ...JSON.parse(data),
+        redis_key_id: `sess:${sid}`,
+        redis_key_ttl: 1200,
+      }));
+      return fn(null, sessions);
+    }
+
+    set(sid: string, sess: unknown, fn: () => void) {
+      sharedSessions.set(sid, JSON.stringify(sess));
+      return fn();
+    }
+
+    destroy(sid: string, fn: () => void) {
+      sharedSessions.delete(sid);
+      return fn();
+    }
+
+    touch(sid: string, sess: unknown, fn: () => void) {
+      return this.set(sid, sess, fn);
+    }
+  }
+  return { default: SharedSessionStore };
+});
+
+type SessionUser = { id: string };
+type SessionRequest = { sessionID: string; session: { user?: SessionUser } };
+type CallResult = { sessionId: string; user: SessionUser | null };
+
+const sessionRequest = (req: express.Request) => req as unknown as SessionRequest;
+
+// Simulate a platform node: the module registry is reset so the session middleware is built again
+// with the given encryption key, exactly as it is on another node or after a restart.
+const loadSessionModule = async (encryptionKey: string = ENCRYPTION_KEY_1) => {
+  vi.resetModules();
+  process.env.APP__ENCRYPTION_KEY = encryptionKey;
+  process.env.APP__SESSION_MANAGER = 'local';
+  return import('../../../src/database/session');
+};
+
+const startNode = async (encryptionKey: string) => {
+  const { getSessionMiddleware } = await loadSessionModule(encryptionKey);
+  const session = await getSessionMiddleware();
+
+  const app = express();
+  app.use(session);
+  app.get('/login', (req, res) => {
+    const { session: userSession, sessionID } = sessionRequest(req);
+    userSession.user = { id: 'user-id' };
+    res.json({ sessionId: sessionID, user: userSession.user });
+  });
+  app.get('/me', (req, res) => {
+    const { session: userSession, sessionID } = sessionRequest(req);
+    res.json({ sessionId: sessionID, user: userSession.user ?? null });
+  });
+
+  const server = http.createServer(app);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+
+  const call = async (path: string, cookie?: string) => {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, { headers: cookie ? { cookie } : {} });
+    const body = await response.json() as CallResult;
+    return { ...body, cookie: response.headers.get('set-cookie')?.split(';')[0] };
+  };
+
+  const stop = async () => {
+    server.close();
+    await once(server, 'close');
+  };
+
+  return { call, stop };
+};
+
+describe('session: signature key derived from the platform encryption key', () => {
+  const nodes: Awaited<ReturnType<typeof startNode>>[] = [];
+  const startTrackedNode = async (encryptionKey: string) => {
+    const node = await startNode(encryptionKey);
+    nodes.push(node);
+    return node;
+  };
+
+  afterEach(async () => {
+    await Promise.all(nodes.splice(0).map((node) => node.stop()));
+    sharedSessions.clear();
+    delete process.env.APP__ENCRYPTION_KEY;
+    delete process.env.APP__SESSION_MANAGER;
+  });
+
+  it('should keep the session on the node that created it', async () => {
+    const node = await startTrackedNode(ENCRYPTION_KEY_1);
+
+    const login = await node.call('/login');
+    expect(login.cookie).toBeDefined();
+
+    const me = await node.call('/me', login.cookie);
+    expect(me.sessionId).toEqual(login.sessionId);
+    expect(me.user).toEqual({ id: 'user-id' });
+  });
+
+  it('should resume the session on another node using the same encryption key', async () => {
+    const firstNode = await startTrackedNode(ENCRYPTION_KEY_1);
+    const secondNode = await startTrackedNode(ENCRYPTION_KEY_1);
+
+    const login = await firstNode.call('/login');
+    const me = await secondNode.call('/me', login.cookie);
+
+    expect(me.sessionId).toEqual(login.sessionId);
+    expect(me.user).toEqual({ id: 'user-id' });
+  });
+
+  it('should reject a session cookie signed with another encryption key', async () => {
+    const firstNode = await startTrackedNode(ENCRYPTION_KEY_1);
+    const secondNode = await startTrackedNode(ENCRYPTION_KEY_2);
+
+    const login = await firstNode.call('/login');
+    const me = await secondNode.call('/me', login.cookie);
+
+    // The signature is rejected, so a brand new session is created and the user has to authenticate again
+    expect(me.sessionId).not.toEqual(login.sessionId);
+    expect(me.user).toBeNull();
+  });
+});
+
+describe('session: user sessions management', () => {
+  const seedSession = (storeSessionId: string, userId: string, creation: string) => {
+    const storedSession = { user: { id: userId, session_creation: creation }, cookie: { originalMaxAge: 1200000 } };
+    sharedSessions.set(storeSessionId, JSON.stringify(storedSession));
+  };
+
+  afterEach(() => {
+    sharedSessions.clear();
+    delete process.env.APP__ENCRYPTION_KEY;
+    delete process.env.APP__SESSION_MANAGER;
+  });
+
+  it('should kill the oldest sessions of a user over the concurrent sessions limit', async () => {
+    const { killUserSessionsOverLimit, findUserSessions } = await loadSessionModule();
+    seedSession('oldest', 'user-1', '2026-01-01T10:00:00.000Z');
+    seedSession('middle', 'user-1', '2026-01-01T11:00:00.000Z');
+    seedSession('newest', 'user-1', '2026-01-01T12:00:00.000Z');
+    seedSession('other-user', 'user-2', '2026-01-01T09:00:00.000Z');
+
+    // one more session is about to be created, so only one of the three existing sessions can be kept
+    expect(await killUserSessionsOverLimit('user-1', 2)).toEqual(2);
+
+    expect((await findUserSessions('user-1')).map((s: { id: string }) => s.id)).toEqual(['sess:newest']);
+    expect(await findUserSessions('user-2')).toHaveLength(1);
+  });
+
+  it('should keep the sessions of a user under the concurrent sessions limit', async () => {
+    const { killUserSessionsOverLimit, findUserSessions } = await loadSessionModule();
+    seedSession('first', 'user-1', '2026-01-01T10:00:00.000Z');
+
+    expect(await killUserSessionsOverLimit('user-1', 3)).toEqual(0);
+    expect(await findUserSessions('user-1')).toHaveLength(1);
+  });
+
+  it('should keep every session when the concurrent sessions limit is disabled', async () => {
+    const { killUserSessionsOverLimit, findUserSessions } = await loadSessionModule();
+    seedSession('first', 'user-1', '2026-01-01T10:00:00.000Z');
+    seedSession('second', 'user-1', '2026-01-01T11:00:00.000Z');
+
+    expect(await killUserSessionsOverLimit('user-1', 0)).toEqual(0);
+    expect(await killUserSessionsOverLimit('user-1', null)).toEqual(0);
+    expect(await findUserSessions('user-1')).toHaveLength(2);
+  });
+
+  it('should kill every session of a user but the current one', async () => {
+    const { killOtherUserSessions, findUserSessions } = await loadSessionModule();
+    seedSession('current', 'user-1', '2026-01-01T10:00:00.000Z');
+    seedSession('another', 'user-1', '2026-01-01T11:00:00.000Z');
+    seedSession('other-user', 'user-2', '2026-01-01T09:00:00.000Z');
+
+    await killOtherUserSessions('user-1', 'current');
+
+    expect((await findUserSessions('user-1')).map((s: { id: string }) => s.id)).toEqual(['sess:current']);
+    expect(await findUserSessions('user-2')).toHaveLength(1);
+  });
+
+  it('should keep every session when the current session is unknown', async () => {
+    const { killOtherUserSessions, findUserSessions } = await loadSessionModule();
+    seedSession('first', 'user-1', '2026-01-01T10:00:00.000Z');
+    seedSession('second', 'user-1', '2026-01-01T11:00:00.000Z');
+
+    await killOtherUserSessions('user-1', undefined);
+
+    expect(await findUserSessions('user-1')).toHaveLength(2);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/user-api-token-security-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/user-api-token-security-test.ts
@@ -42,8 +42,9 @@ vi.mock('../../../src/domain/group', () => ({
 }));
 
 vi.mock('../../../src/database/session', () => ({
-  findUserSessions: vi.fn().mockResolvedValue([]),
-  killSessions: vi.fn().mockResolvedValue({}),
+  killOtherUserSessions: vi.fn().mockResolvedValue([]),
+  killUserSessions: vi.fn().mockResolvedValue([]),
+  killUserSessionsOverLimit: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('passport', () => ({

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/user-cache-reset-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/user-cache-reset-test.ts
@@ -49,9 +49,9 @@ vi.mock('../../../src/database/middleware-loader', () => ({
 }));
 
 vi.mock('../../../src/database/session', () => ({
-  findUserSessions: vi.fn(async () => []),
-  killSessions: vi.fn(),
+  killOtherUserSessions: vi.fn(async () => []),
   killUserSessions: vi.fn(),
+  killUserSessionsOverLimit: vi.fn(async () => []),
 }));
 
 vi.mock('../../../src/database/entity-representative', () => ({

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/platformCrypto-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/platformCrypto-test.ts
@@ -500,6 +500,51 @@ describe('platformCrypto: JWT signing and verification', () => {
   });
 });
 
+describe('platformCrypto: secret derivation', () => {
+  const testSeed = Buffer.from('a'.repeat(64), 'hex');
+
+  it('should derive a deterministic base64 secret of 32 bytes by default', async () => {
+    const factory = createCryptoKeyFactory(testSeed);
+    const secret = await factory.deriveSecret(['test', 'path'], 1);
+    const sameSecret = await createCryptoKeyFactory(testSeed).deriveSecret(['test', 'path'], 1);
+
+    expect(secret).toEqual(sameSecret);
+    expect(Buffer.from(secret, 'base64')).toHaveLength(32);
+  });
+
+  it('should derive a secret of the requested length', async () => {
+    const factory = createCryptoKeyFactory(testSeed);
+    const secret = await factory.deriveSecret(['test', 'path'], 1, 64);
+    expect(Buffer.from(secret, 'base64')).toHaveLength(64);
+  });
+
+  it('should derive different secrets for different seeds, paths and versions', async () => {
+    const factory = createCryptoKeyFactory(testSeed);
+    const secret = await factory.deriveSecret(['test', 'path'], 1);
+
+    const otherSeedSecret = await createCryptoKeyFactory(Buffer.from('b'.repeat(64), 'hex')).deriveSecret(['test', 'path'], 1);
+    const otherPathSecret = await factory.deriveSecret(['test', 'other'], 1);
+    const otherVersionSecret = await factory.deriveSecret(['test', 'path'], 2);
+
+    expect(new Set([secret, otherSeedSecret, otherPathSecret, otherVersionSecret]).size).toEqual(4);
+  });
+
+  it('should not collide with the other derivations of the same path', async () => {
+    const factory = createCryptoKeyFactory(testSeed);
+    const secret = await factory.deriveSecret(['test', 'path'], 1);
+    const { hmac } = await factory.deriveHmac(['test', 'path'], 1);
+
+    expect(secret).not.toEqual(hmac(Buffer.from('')));
+  });
+
+  it('should reject invalid derivation path, version and length', async () => {
+    const factory = createCryptoKeyFactory(testSeed);
+    await expect(factory.deriveSecret(['test:invalid'], 1)).rejects.toThrow(/Invalid derivation path/);
+    await expect(factory.deriveSecret(['test'], 0)).rejects.toThrow(/Version must be positive/);
+    await expect(factory.deriveSecret(['test'], 1, 0)).rejects.toThrow(/Length must be positive/);
+  });
+});
+
 describe('platformCrypto: edge cases and error handling', () => {
   const testSeed = Buffer.from('a'.repeat(64), 'hex');
 


### PR DESCRIPTION
### Proposed changes

#### Session signature key

* The session cookie signature key is now derived from the platform encryption key (`app:encryption_key`), through the `session:signature` derivation path, instead of falling back on the admin password when `app:session_secret` was not set. The derived key has a full 256 bits of entropy, is automatically identical on all the platform nodes, and never has to be configured nor rotated by hand.
* The undocumented `app:session_secret` configuration and the `app:admin:password` fallback are removed. `app:session_secret` was referenced nowhere else in the repository, not even in `config/default.json`.
* `deriveSecret(path, version, length = 32)` is added to the platform crypto key factory, for the third party libraries that require raw secret material — here `express-session`, whose `secret` option is unavoidably a raw string. It is the only derivation that hands out key material, hence the comment restricting its use. Rotation stays possible through the derivation path version, like every other derived key.
* The session middleware is created lazily (`getSessionMiddleware()`), since the key derivation is asynchronous. The session store is therefore built on first use instead of at import time; neither store constructor has side effects.

#### Session module clean-up

Done along the way, in the same module:

* **The store is no longer reachable from outside.** It was exported through `applicationSession.store`, while a single call site actually needed it — the `sessionKill` resolver, only to strip the store key prefix off the session id. That prefix handling moves next to the store, so the resolver is now just `await killSession(id)`. The public API is metadata plus termination; the store, which exposes the full session content and `set()`, stays private.
* **The store is wrapped once, as promisified operations.** `express-session` is callback-only end to end (the `Store` interface, the session object methods, the middleware itself) with no promise API and no `util.promisify.custom` hook, so the conversion happens in one place next to the store creation, and the wrapper states the three store operations the platform actually relies on out of the eight in the interface.
* **The session policies become operations of the module.** The concurrent sessions limit and the "kill every session but the current one" scenario were composed in the user domain from the list and bulk kill primitives, which had to be public for that. They are now `killUserSessionsOverLimit(userId, max)` and `killOtherUserSessions(userId, currentSessionId)`, so the bulk kill stays private. The domain keeps what is its own — reading the setting — and the `enforceSessionLimit` wrapper, reduced to adapting its arguments for a single caller, is dropped.
* **The kill operations return only what their callers use**: a count for the concurrent limit, nothing for the "other sessions" scenario. `killSession` and `killUserSessions` keep returning the killed sessions, which the `sessionKill` and `userSessionsKill` mutations need for their audit action and their GraphQL result.
* **Hand written promise wrappers are replaced by `util.promisify` / `events.once`, and ramda by the standard library** (`Object.groupBy`, `Array.find`). Two incidental fixes come with it: the websocket session parsing never resolved when the store returned an error or no session, and `findSessions` silently returned nothing for object shaped stores — the `Store` interface allows the sessions to be returned either as an array or as an object, so the wrapper normalizes it.

#### Tests

* `tests/01-unit/database/session-test.ts` drives real HTTP nodes against a shared session store, the encryption key being the only difference between them: same key resumes the session, a different key rejects the cookie and yields an empty session. It also covers the two session policies, which had no test at all before — no test in the repository referenced `enforceSessionLimit`, and neither `user-test.ts` nor the password expiry suite mentioned sessions.
* `tests/01-unit/utils/platformCrypto-test.ts` covers `deriveSecret`: determinism, requested length, separation across seeds, paths and versions, no collision with the other derivations of the same path, and input validation.

### Related issues

* closes #15353

### How to test this PR

The key is used by `express-session` to sign (HMAC-SHA256) the session id carried by the `opencti_session` cookie. It authenticates the session id only: the session content lives in the session store. So a node accepts a session when **both** the signature verifies (same encryption key) **and** the session id is found in its store (`app:session_manager: shared` with the same Redis and `redis:namespace`).

1. Nominal: with an `app:encryption_key` configured and no `app:session_secret`, log in and browse. Sessions, subscriptions (websocket) and `Settings > Security > Sessions` session kill behave as before.
2. Restart the platform with the same encryption key: the session cookie stays valid, no new login (derivation is deterministic).
3. Cluster: start two nodes with the same encryption key, `app:session_manager: shared` and the same Redis (same `redis:namespace`), reached on the same host and `app:base_path`. A session created on the first node is accepted by the second one. Without a shared session store, the second node cannot find the session and requires a login — that requirement is pre-existing and unrelated to the signature key.
4. Key change: restart with a different `app:encryption_key`, then reload the UI. The cookie signature no longer verifies, a new empty session is created and the login page is shown. Beware that `APP__ENCRYPTION_KEY` in the environment takes precedence over the JSON configuration files (`nconf.env()` is registered before `nconf.file()`), and that a running process keeps the key it booted with.
5. Concurrent sessions limit: set `platform_session_max_concurrent` in the settings and log in beyond it — the oldest sessions are terminated, and the login event reports how many.
6. Unit tests: `yarn test:ci-unit`.

To check what a given key derives to, without starting the platform:

```
node -e "const c=require('crypto');const k=Buffer.from(process.env.APP__ENCRYPTION_KEY,'base64');c.hkdf('sha256',k,Buffer.alloc(0),Buffer.from('session:signature:secret::v1'),32,(e,b)=>console.log(Buffer.from(b).toString('base64')))"
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

**Upgrade impact.** The session signature key changes, so every existing session cookie becomes invalid and users have to log in again once. Deployments that had explicitly set `app:session_secret` will see it silently ignored, with the same one-time consequence. No new configuration requirement is introduced: `app:encryption_key` is already needed for the platform to start, for API token hashing and credentials encryption.

**Pre-existing behaviours kept as is, worth a separate look:**

* `killOtherUserSessions` kills nothing when there is no current session — the original filter carried a `currentSessionId &&` guard that short circuited for every session. Arguably it should kill them all, since that is exactly the case where a forced password change matters most. Behaviour is preserved here, and the new test pins it, so whoever changes it will see a red test rather than a silent surprise.
* The in memory session store (`app:session_manager` other than `shared`) does not really support session listing and killing: session ids come from `redis_key_id`, and its `destroy` never calls back because `LRUCache.get` is called with a callback.
* `req.session.save()` is called without a callback, so the session write is neither awaited nor checked for errors.
* `domain/user.js` still holds 50 ramda usages over 2397 lines. Converting them would have drowned this change and concentrated regression risk on the most sensitive file of the platform, so it is left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
