### PR TITLE
feat(fds): route the SwitchField pivot onto the library Switch (#17926)

### DIFF
--- a/opencti-platform/opencti-front/setup-vitest.ts
+++ b/opencti-platform/opencti-front/setup-vitest.ts
@@ -9,6 +9,23 @@ import '@testing-library/jest-dom/vitest';
 global.jest = vi;
 
 
+// jsdom ships no ResizeObserver. The Radix primitives behind the design-system
+// Switch, Checkbox and Radio measure their control with one (their hidden bubble
+// input calls useSize), so any test rendering one of them throws without this
+// stub. Guarded so a real implementation always wins.
+if (!('ResizeObserver' in globalThis)) {
+  class ResizeObserverStub {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  }
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  globalThis.ResizeObserver = ResizeObserverStub;
+}
+
 expect.extend(matchers);
 
 afterEach(() => {

--- a/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
+++ b/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
@@ -1,29 +1,32 @@
 import React, { useCallback, useEffect } from 'react';
-import MuiSwitch from '@mui/material/Switch';
-import FormControlLabel from '@mui/material/FormControlLabel';
+import { Switch } from '@filigran/design-system';
 import FormGroup from '@mui/material/FormGroup';
 import FormHelperText from '@mui/material/FormHelperText';
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
-import { fieldToSwitch } from 'formik-mui';
 import { useFormatter } from '../i18n';
 
 const SwitchField = (props) => {
   const {
     form: { setFieldValue, setFieldTouched },
-    field: { name },
+    field: { name, value },
     onChange,
     helpertext,
     tooltip,
     initialValue,
+    disabled,
+    required,
+    label,
   } = props;
   const { t_i18n } = useFormatter();
+  // Radix reports the new value directly; MUI reported an event whose
+  // target.checked had to be read. The string form is kept because consumers
+  // of `onChange` receive 'true'/'false', not a boolean.
   const internalOnChange = useCallback(
-    (event) => {
-      const value = event.target.checked ? 'true' : 'false';
-      setFieldValue(name, event.target.checked);
+    (checked) => {
+      setFieldValue(name, checked);
       if (typeof onChange === 'function') {
-        onChange(name, value);
+        onChange(name, checked ? 'true' : 'false');
       }
     },
     [onChange, setFieldValue, name],
@@ -41,37 +44,39 @@ const SwitchField = (props) => {
     }
   }, []);
 
+  const labelNode = tooltip ? (
+    <div style={{ display: 'flex' }}>
+      <span>{label}</span>
+      <Tooltip title={t_i18n(tooltip)}>
+        <InformationOutline
+          fontSize="small"
+          color="primary"
+          style={{ cursor: 'default', margin: '0 0 0 10px' }}
+        />
+      </Tooltip>
+    </div>
+  ) : (
+    label
+  );
+
   return (
     <div style={props.containerstyle}>
+      {/* FormGroup and the fit-content wrapper are kept so the control keeps
+          the row position it had under MUI; the library Switch carries its own
+          label, so FormControlLabel is gone — it clone-injects checked/onChange
+          into its control, which a Radix button would silently ignore. */}
       <FormGroup>
-        <FormControlLabel
-          style={{ width: 'fit-content' }}
-          control={(
-            <MuiSwitch
-              {...fieldToSwitch(props)}
-              onChange={internalOnChange}
-              onBlur={internalOnBlur}
-            />
-          )}
-          label={
-            tooltip ? (
-              <div style={{ display: 'flex' }}>
-                <span>{props.label}</span>
-                <Tooltip
-                  title={t_i18n(tooltip)}
-                >
-                  <InformationOutline
-                    fontSize="small"
-                    color="primary"
-                    style={{ cursor: 'default', margin: '0 0 0 10px' }}
-                  />
-                </Tooltip>
-              </div>
-            ) : (
-              props.label
-            )
-          }
-        />
+        <div style={{ width: 'fit-content' }}>
+          <Switch
+            name={name}
+            checked={value === true}
+            disabled={disabled}
+            required={required}
+            label={labelNode}
+            onCheckedChange={internalOnChange}
+            onBlur={internalOnBlur}
+          />
+        </div>
       </FormGroup>
       <FormHelperText>{helpertext}</FormHelperText>
     </div>

--- a/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
+++ b/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
@@ -8,9 +8,10 @@ import { useFormatter } from '../i18n';
 
 const SwitchField = (props) => {
   const {
-    form: { setFieldValue, setFieldTouched },
+    form: { setFieldValue, setFieldTouched, isSubmitting },
     field: { name, value },
     onChange,
+    onFocus,
     helpertext,
     tooltip,
     initialValue,
@@ -62,18 +63,27 @@ const SwitchField = (props) => {
   return (
     <div style={props.containerstyle}>
       {/* FormGroup and the fit-content wrapper are kept so the control keeps
-          the row position it had under MUI; the library Switch carries its own
-          label, so FormControlLabel is gone — it clone-injects checked/onChange
-          into its control, which a Radix button would silently ignore. */}
+          the row position it had under MUI. FormControlLabel is gone because
+          the library Switch carries its own label — NOT because this file was
+          exposed to the clone-injection trap: the old code put checked and
+          onChange on the MuiSwitch child, so FormControlLabel had nothing to
+          inject. The mechanism is real (it broke the consent checkbox in
+          #17946); it simply was not active here. */}
       <FormGroup>
         <div style={{ width: 'fit-content' }}>
           <Switch
             name={name}
-            checked={value === true}
-            disabled={disabled}
+            // A caller-supplied `checked` wins over the Formik value: three
+            // sites drive the control from their own state, and one of them
+            // (TriggerEditionOverview) keeps its value outside Formik.
+            checked={props.checked ?? value === true}
+            // formik-mui's fieldToSwitch supplied this; without it the 107
+            // switches stayed live during submit.
+            disabled={disabled ?? isSubmitting}
             required={required}
             label={labelNode}
             onCheckedChange={internalOnChange}
+            onFocus={onFocus}
             onBlur={internalOnBlur}
           />
         </div>

--- a/opencti-platform/opencti-front/src/components/fields/SwitchField.test.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/SwitchField.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Contract tests for the SwitchField pivot. It carries 107 <Field> sites, and
+ * before this file nothing covered it — the three regressions these tests pin
+ * were all found by review, not by the suite.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik, Form, Field, useFormikContext } from 'formik';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import SwitchField from './SwitchField';
+import testRender from '../../utils/tests/test-render';
+
+const Submitting = ({ on }: { on: boolean }) => {
+  const { setSubmitting } = useFormikContext();
+  // In an effect, never during render — setting it inline re-renders forever.
+  React.useEffect(() => {
+    if (on) setSubmitting(true);
+  }, [on, setSubmitting]);
+  return null;
+};
+
+const renderField = (props: Record<string, unknown> = {}, initial = false, isSubmitting = false) => testRender(
+  <Formik initialValues={{ flag: initial }} onSubmit={() => {}}>
+    <Form>
+      <Submitting on={isSubmitting} />
+      <Field component={SwitchField} type="checkbox" name="flag" label="Flag" {...props} />
+    </Form>
+  </Formik>,
+);
+
+describe('SwitchField pivot', () => {
+  it('renders a switch, not a checkbox', () => {
+    renderField();
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeInTheDocument();
+  });
+
+  it('reflects the Formik value when no checked prop is given', () => {
+    renderField({}, true);
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeChecked();
+  });
+
+  it('lets a caller-supplied checked win over the Formik value', () => {
+    // TriggerEditionOverview keeps its value outside Formik entirely, so the
+    // override is the only thing that renders it ON.
+    renderField({ checked: true }, false);
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeChecked();
+  });
+
+  it('honours checked={false} against a truthy Formik value', () => {
+    renderField({ checked: false }, true);
+    expect(screen.getByRole('switch', { name: /flag/i })).not.toBeChecked();
+  });
+
+  it('disables while the form is submitting', () => {
+    renderField({}, false, true);
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeDisabled();
+  });
+
+  it('an explicit disabled still wins', () => {
+    renderField({ disabled: true });
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeDisabled();
+  });
+
+  it('writes a boolean into Formik and reports the string form to onChange', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    renderField({ onChange });
+    await user.click(screen.getByRole('switch', { name: /flag/i }));
+    expect(onChange).toHaveBeenCalledWith('flag', 'true');
+    expect(screen.getByRole('switch', { name: /flag/i })).toBeChecked();
+  });
+
+  it('forwards onFocus — three collaborative-editing sites depend on it', async () => {
+    const onFocus = vi.fn();
+    const user = userEvent.setup();
+    renderField({ onFocus });
+    await user.tab();
+    expect(onFocus).toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
@@ -281,7 +281,7 @@ const TriggerEditionOverview: FunctionComponent<TriggerEditionOverviewProps> = (
   const onChangeInstanceTrigger = (
     setFieldValue: (
       key: string,
-      value: { value: string; label: string }[],
+      value: { value: string; label: string }[] | boolean,
     ) => void,
   ) => {
     const newInstanceTriggerValue = !instanceTrigger;
@@ -292,6 +292,10 @@ const TriggerEditionOverview: FunctionComponent<TriggerEditionOverviewProps> = (
 
     helpers.handleClearAllFilters();
     instanceTriggerFiltersHelpers.handleClearAllFilters();
+    // instance_trigger has to live in Formik too: enableReinitialize rebuilds
+    // the form from initialValues after every commitFieldPatch, so a value kept
+    // only in local state is wiped on the next round-trip.
+    setFieldValue('instance_trigger', newInstanceTriggerValue);
     setInstanceTrigger(newInstanceTriggerValue);
 
     commitFieldPatch({
@@ -311,6 +315,7 @@ const TriggerEditionOverview: FunctionComponent<TriggerEditionOverviewProps> = (
 
   const initialValues = {
     name: trigger.name,
+    instance_trigger: trigger.instance_trigger ?? false,
     description: trigger.description,
     event_types: convertEventTypes(trigger),
     notifiers: convertNotifiers(trigger),


### PR DESCRIPTION
Part of #17926. Branch off `design-system/current`; **no pin bump** — Switch already
ships at the base pin `bd076e8f`, so `package.json` is untouched.

## What this does

`components/fields/SwitchField.jsx` — the Formik pivot behind **107**
`<Field component={SwitchField}>` sites — now renders the design-system `Switch`.

## Why FormControlLabel is gone — corrected

An earlier revision of this PR justified the removal by the clone-injection trap.
**That was wrong for this file.** `FormControlLabel` copies `checked`/`name`/`onChange`
onto its `control` child only when the child does not define them, and the old code put
both on the `MuiSwitch`. The trap is real — it broke the consent checkbox in #17946 —
but it was never active here.

The actual reason is simpler: the library Switch carries its own `label`, so the
wrapper is redundant.

## Geometry, stated plainly

MUI's Switch renders a 58×38 box (34×14 track inside 12px padding). The library Switch
is `h-5 w-9` — a 36×20 track with no padding box. **Row height therefore goes 38px → 20px
on all 107 rows.** That is the Figma-intended geometry, not an accident, but it is a
visible change on every form carrying a switch and it is not recoverable with the
utilities at this pin. `FormGroup` and the `fit-content` wrapper are kept so horizontal
position is unchanged.

## Review fixes (second commit)

| Finding | Fix |
| --- | --- |
| **BLOCKING** — `TriggerEditionOverview`: `instance_trigger` lived only in local state, absent from `initialValues`, never `setFieldValue`'d, while `enableReinitialize` rebuilds from `initialValues` after each `commitFieldPatch` | Both sides: seeded in `initialValues`, and written on change. The value no longer depends on the `checked` override to survive a round-trip |
| Pivot ignored an explicit `checked` | `checked={props.checked ?? value === true}` — 3 sites drive the control themselves; 2 worked only by coincidence |
| `disabled` lost `isSubmitting` (supplied by `fieldToSwitch`) | `disabled={disabled ?? isSubmitting}` — the 107 switches disable during submit again |
| `onFocus` not forwarded | Forwarded to the Radix Root; 3 collaborative-editing sites need it |

## Tests

`SwitchField.test.tsx` — the pivot carried 107 sites with **zero** coverage. Eight cases:
switch role, Formik value, `checked` override in both directions, `isSubmitting`
disabling, explicit `disabled` winning, boolean written to Formik with the string form
reported to `onChange`, and `onFocus` forwarding.

Red-before: against the previous pivot **exactly 4 fail** — one per regression above
plus the `checked={false}` direction — and the other 4 pass.

## Caveat — the ResizeObserver stub can mask real breakage

`setup-vitest.ts` gains a guarded `ResizeObserver` stub because jsdom ships none and the
Radix primitive measures its control with one. Without it these suites throw; with it
they run, but the stub reports **no** size, so anything depending on a measured value
passes vacuously rather than correctly. Product tests whose tree can reach a Radix
control, and are therefore exposed:

- `components/PasswordPoliciesAlert.test.tsx`
- `private/components/data/forms/view/FormView.test.tsx`
- `private/components/data/forms/view/FormFieldRenderer.test.tsx`
- `private/components/settings/sub_types/fintel_templates/FintelTemplateForm.test.tsx`
- `private/components/settings/sub_types/workflow/StatusForm.test.tsx`
- `private/components/settings/sub_types/workflow/TransitionForm.test.tsx`

Same stub as #17946, which merges last — expect a trivial identical-content conflict.

## Open — not closed by me

**String vs boolean at the 11 dynamic-name sites.** Statically, all three families
already coerce before Formik: `PlaybookActionValueField` uses
`action.value?.[0]?.value === 'true'`, `StixCyberObservableCreation` seeds
`initialValues[attribute.value] = false`, and the `objectMarking` path in
`useDefaultValues` does `head(attr.defaultValues)?.id === 'true'`. I did **not** confirm
this on a running pilot against a connector contract form, so the review's question
stays open rather than answered by inference.

## Census

| | |
| --- | --- |
| `<Field component={SwitchField}>` carried by this pivot | **107** |
| direct `<Switch>`, outside #17884 | 35 → Switch-2 |
| direct `<Switch>`, inside #17884 | 43 → Switch-2 |
