### PR TITLE
feat(fds): flip the Button and IconButton wrappers onto the design system (#17808)

### DIFF
--- a/fds-migration/IMPLEMENTATION-LOG.md
+++ b/fds-migration/IMPLEMENTATION-LOG.md
@@ -926,3 +926,25 @@ Corollary, recorded because I asserted the opposite for a while: a synthetic
 `element.click()` succeeding where a real pointer fails proves nothing about the
 product. It only proves the handler exists. Radix Select opens on `pointerdown`
 and a synthetic click takes the `onClick` path, so the two disagree by design.
+
+## 2026-08-29 — A wrapper cannot see what the call site wrote
+
+The button wrappers decide per render whether the library can reproduce a site.
+That works for everything the props say, and fails for one thing they cannot:
+whether `color` was a literal or an expression. A wrapper is a runtime
+component; `color={copied ? 'success' : 'primary'}` reaches it as `'success'`.
+
+It matters because a control that changes engine between renders is remounted,
+and a remount at the moment of activation takes the keyboard focus with it. The
+ruling was identity stability over partial conversion, so the 20 dynamic-colour
+sites carry `keepMui` and stay on MUI for their whole life.
+
+`keepMui` is therefore load-bearing and entirely conventional: nothing stops a
+new site from writing `color={cond ? 'a' : 'b'}` without it, and the failure is
+invisible — the control simply swaps engine on interaction.
+
+**Candidate check for a follow-up wave:** fail when a wrapper `Button` or
+`IconButton` has a non-literal `color` (or `variant`/`intent`) and no `keepMui`.
+It is a static rule, which is exactly the level the information exists at — the
+same reason `check-accessible-names.mjs` had to be static. The sweep that found
+the 20 sites is the rule already; it needs turning into a gate, not inventing.

--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -1940,33 +1940,42 @@ order-agnostic. The prop's JSDoc now states the order and recommends omitting it
 — `(selectedValue: T, option: T) => boolean` rather than `(a: T, b: T) => boolean`
 — so an IDE shows the order at the call site. Nothing else needed.
 
-## 53. `IconButton`'s tone axis is a subset of `Button`'s: no `highlight`
+## 53. The button family's tone axis is missing `highlight`, `warn` and `success`
 
-`Button` and `IconButton` are documented as the same two axes — a `priority`
-and a tone — so a wrapper mapping one can be expected to map the other with the
-same table. It cannot:
+`Button` and `IconButton` are documented as the same two axes -- a `priority`
+and a tone -- so a wrapper mapping one expects to map the other with one table.
+It cannot, and the gap is wider than the asymmetry:
 
 | | tones |
 |---|---|
 | `buttonVariants` | `default` `destructive` `ia` **`highlight`** |
 | `iconButtonVariants` | `default` `destructive` `ia` |
+| product needs | the above **plus `warn` and `success`** |
 
-`highlight` is the brand-tonic tone the products use for Enterprise Edition. On
-`Button` it expresses `intent="ee"`; on `IconButton` there is nothing to map it
-to, so a wrapper has to send the site back to MUI to keep its colour.
+**Blocked today: 7 sites in 7 files, 6 of them behind an expression.**
 
-**Measured exposure today: zero.** Every EE control in OpenCTI is a `Button`
-(`EnterpriseEditionButton`), so nothing is currently blocked — this is reported
-as an API asymmetry, not an outage. It becomes a defect the first time a product
-wants an icon-only EE control, and the wrapper will silently fall back rather
-than fail, which is the kind of gap that is only noticed visually.
+| site | tone | |
+|---|---|---|
+| `StixCoreObjectContentFilesList:150` | `ee` | `color={isEnterpriseEdition ? 'primary' : 'ee'}` |
+| `ItemCopy:122` | `success` | dynamic |
+| `Alerts:178` | `success` | dynamic |
+| `StixCoreObjectsSuggestions:341` | `success` | dynamic |
+| `ConnectorWorkLine:154` | `success` | dynamic |
+| `IndicatorDetails:90` | `warn` | dynamic |
+| `DataTableToolBar:2519` | `success` | literal |
 
-**What is blocked today, on both components:** `warn` and `success`. Four sites
-(`DataTableToolBar`) carry `color="warning"` / `color="success"` and neither
-component has a tone for them, so they keep MUI. If the feedback tokens already
-exist for chips, the same two tones on the button family would retire those.
+`ee` is live on an **IconButton**, which is exactly where `highlight` does not
+exist -- so that site cannot be expressed even with a correct mapping table. My
+first count of this said zero: the value sits inside a ternary, and a static
+read of the attribute saw the identifier, not the branches. Anything counting
+props this way under-reports every dynamic site.
+
+That most of them are dynamic matters twice over. @sandy ruled that a control
+whose engine can change between renders keeps MUI: it is remounted at the moment
+of activation and loses keyboard focus. So these sites are pinned to MUI by
+that ruling as well, and the missing tones are what makes the pin permanent
+rather than a transitional state.
 
 **Suggestion:** add `highlight` to `iconButtonVariants` so the two components
-share one tone vocabulary, and consider `warn`/`success` for both. A wrapper
-that maps the two axes cannot tell a consumer why one component accepts a tone
-and its sibling does not.
+share one vocabulary, and add `warn` and `success` to both. The feedback tokens
+already exist -- `Chip` carries the same severities.

--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -1939,3 +1939,34 @@ order-agnostic. The prop's JSDoc now states the order and recommends omitting it
 **Suggestion to the library, low cost:** name the parameters in the exported type
 — `(selectedValue: T, option: T) => boolean` rather than `(a: T, b: T) => boolean`
 — so an IDE shows the order at the call site. Nothing else needed.
+
+## 53. `IconButton`'s tone axis is a subset of `Button`'s: no `highlight`
+
+`Button` and `IconButton` are documented as the same two axes — a `priority`
+and a tone — so a wrapper mapping one can be expected to map the other with the
+same table. It cannot:
+
+| | tones |
+|---|---|
+| `buttonVariants` | `default` `destructive` `ia` **`highlight`** |
+| `iconButtonVariants` | `default` `destructive` `ia` |
+
+`highlight` is the brand-tonic tone the products use for Enterprise Edition. On
+`Button` it expresses `intent="ee"`; on `IconButton` there is nothing to map it
+to, so a wrapper has to send the site back to MUI to keep its colour.
+
+**Measured exposure today: zero.** Every EE control in OpenCTI is a `Button`
+(`EnterpriseEditionButton`), so nothing is currently blocked — this is reported
+as an API asymmetry, not an outage. It becomes a defect the first time a product
+wants an icon-only EE control, and the wrapper will silently fall back rather
+than fail, which is the kind of gap that is only noticed visually.
+
+**What is blocked today, on both components:** `warn` and `success`. Four sites
+(`DataTableToolBar`) carry `color="warning"` / `color="success"` and neither
+component has a tone for them, so they keep MUI. If the feedback tokens already
+exist for chips, the same two tones on the button family would retire those.
+
+**Suggestion:** add `highlight` to `iconButtonVariants` so the two components
+share one tone vocabulary, and consider `warn`/`success` for both. A wrapper
+that maps the two axes cannot tell a consumer why one component accepts a tone
+and its sibling does not.

--- a/opencti-platform/opencti-front/src/components/ItemCopy.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCopy.tsx
@@ -125,6 +125,7 @@ const ItemCopy: FunctionComponent<ItemCopyProps> = ({
             size="small"
             aria-label={t_i18n('Copy')}
             color={copied ? 'success' : 'primary'}
+            keepMui
           >
             {copied ? (
               <Check sx={{ fontSize: variant === 'inLine' ? 12 : 16 }} />

--- a/opencti-platform/opencti-front/src/components/common/button/Button.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/Button.tsx
@@ -33,6 +33,14 @@ interface BaseButtonProps extends Omit<MuiButtonProps, 'variant' | 'color' | 'si
   fullWidth?: boolean;
   iconOnly?: boolean;
   selected?: boolean;
+  /**
+   * Force the MUI path. For a site whose `color` is an expression: the wrapper
+   * only ever sees the resolved value, so it cannot tell a literal from a
+   * ternary, and a control that changes engine between renders is remounted --
+   * losing keyboard focus at the moment of activation. @sandy ruled identity
+   * stability over partial library rendering.
+   */
+  keepMui?: boolean;
   component?: React.ElementType;
   to?: string;
   href?: string;
@@ -94,6 +102,7 @@ const Button: React.FC<CustomButtonProps> = ({
   gradientAngle = 90,
   iconOnly = false,
   selected = false,
+  keepMui = false,
   children,
   startIcon,
   endIcon,
@@ -120,6 +129,7 @@ const Button: React.FC<CustomButtonProps> = ({
     loading?: boolean | null; loadingIndicator?: unknown; loadingPosition?: unknown;
   };
 
+  const rendersAnchor = Boolean(to) || Boolean(href) || Component === 'a';
   const libPriority = LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY];
   const libTone = color ? LIB_TONE_FROM_COLOR[color] : LIB_TONE_FROM_INTENT[intent];
   const libSize = LIB_SIZE[size as keyof typeof LIB_SIZE];
@@ -138,10 +148,17 @@ const Button: React.FC<CustomButtonProps> = ({
     && !selected
     && !externalSx
     && !classes
+    && !keepMui
     // The icon-only delegate falls back here when the library cannot take the
     // site. The library Button pads for a text label, so it would draw a pill
     // around the glyph instead of MUI's square control: keep MUI's geometry.
     && !iconOnly
+    /**
+     * `asChild` REPLACES the child's content, and `component="label"` wraps a
+     * real file input that would not survive it. MUI also gives the label the
+     * role and tab stop the library path does not (WCAG 2.1.1).
+     */
+    && (!isPolymorphic || rendersAnchor)
     // `asChild` replaces the button with its child, and the library drops the
     // icon slots in that mode.
     && !(isPolymorphic && (startIcon || endIcon));

--- a/opencti-platform/opencti-front/src/components/common/button/Button.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button as MuiButton, ButtonProps as MuiButtonProps } from '@mui/material';
+import { Button as LibButton } from '@filigran/design-system';
 import { useTheme } from '@mui/styles';
 import type { ButtonColorKey, ButtonIntent, ButtonSize, GradientVariant } from './Button.types';
 import { getColorDefinitions, getGradientColors, getSizeConfig } from './Button.utils';
@@ -45,13 +46,41 @@ type RestrictedIntentButtonProps = BaseButtonProps & {
   variant?: Exclude<ButtonVariant, 'primary'>;
 };
 
-// Default buttons can use any variant
 type DefaultIntentButtonProps = BaseButtonProps & {
   intent?: 'default' | 'destructive';
   variant?: ButtonVariant;
 };
 
 export type CustomButtonProps = RestrictedIntentButtonProps | DefaultIntentButtonProps;
+
+/**
+ * The wrapper's `variant` is a PRIORITY and its `intent`/`color` are the TONE;
+ * the library splits the same two axes as `priority` and `variant`. Mapping the
+ * words across without this table is the whole trap: `variant="secondary"` (367
+ * sites) is a priority, not a colour.
+ */
+const LIB_PRIORITY = { primary: 'primary', secondary: 'secondary', tertiary: 'tertiary' } as const;
+const LIB_TONE_FROM_INTENT = { default: 'default', destructive: 'destructive', ai: 'ia', ee: 'highlight' } as const;
+
+/**
+ * `color` outranks `intent`, as it always did. `primary`, `secondary` and
+ * `default` all resolve to `theme.palette.primary.main` in `getColorDefinitions`
+ * -- they differ only by border -- so all three are the library's default tone.
+ * `warn` and `success` have NO library tone and are deliberately absent: a site
+ * using them keeps MUI rather than lose its colour.
+ */
+const LIB_TONE_FROM_COLOR: Partial<Record<ButtonColorKey, 'default' | 'destructive' | 'ia' | 'highlight'>> = {
+  default: 'default',
+  primary: 'default',
+  secondary: 'default',
+  error: 'destructive',
+  destructive: 'destructive',
+  ai: 'ia',
+  ee: 'highlight',
+};
+
+/** `default` is 36px and the library's `md` is 36px -- exact. `small` is 26px against `sm`'s 24px. */
+const LIB_SIZE = { default: 'md', small: 'sm' } as const;
 
 const Button: React.FC<CustomButtonProps> = ({
   variant = 'primary',
@@ -72,12 +101,101 @@ const Button: React.FC<CustomButtonProps> = ({
   ...props
 }) => {
   const theme = useTheme<Theme>();
+  const {
+    component: Component, to, href, classes,
+    // MUI-only props: they are not DOM attributes and the library button would
+    // forward them straight onto the element.
+    disableRipple: _disableRipple, disableElevation: _disableElevation,
+    disableFocusRipple: _disableFocusRipple, focusRipple: _focusRipple,
+    centerRipple: _centerRipple, TouchRippleProps: _TouchRippleProps,
+    touchRippleRef: _touchRippleRef, LinkComponent: _LinkComponent,
+    focusVisibleClassName: _focusVisibleClassName, onFocusVisible: _onFocusVisible,
+    loading, loadingIndicator: _loadingIndicator, loadingPosition: _loadingPosition,
+    ...rest
+  } = props as typeof props & {
+    classes?: unknown; disableRipple?: unknown; disableElevation?: unknown;
+    disableFocusRipple?: unknown; focusRipple?: unknown; centerRipple?: unknown;
+    TouchRippleProps?: unknown; touchRippleRef?: unknown; LinkComponent?: unknown;
+    focusVisibleClassName?: unknown; onFocusVisible?: unknown;
+    loading?: boolean | null; loadingIndicator?: unknown; loadingPosition?: unknown;
+  };
 
+  const libPriority = LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY];
+  const libTone = color ? LIB_TONE_FROM_COLOR[color] : LIB_TONE_FROM_INTENT[intent];
+  const libSize = LIB_SIZE[size as keyof typeof LIB_SIZE];
+  const isPolymorphic = Boolean(Component || to || href);
+
+  /**
+   * The library is used only where it can reproduce the site exactly. Anything
+   * it cannot express keeps MUI, and a site passing a value outside the union
+   * -- there are a few, and `TasksList` passes MUI's own `variant="outlined"`
+   * -- lands here too instead of silently rendering the wrong thing.
+   */
+  const canUseLibrary = Boolean(libPriority)
+    && Boolean(libTone)
+    && Boolean(libSize)
+    && !gradient
+    && !selected
+    && !externalSx
+    && !classes
+    // `asChild` replaces the button with its child, and the library drops the
+    // icon slots in that mode.
+    && !(isPolymorphic && (startIcon || endIcon));
+
+  if (canUseLibrary) {
+    /**
+     * MUI sized the glyph through `.MuiButton-startIcon`; the library's slot
+     * does not, so an icon with no intrinsic size paints 0x0 there -- the
+     * TableTuneIcon defect, which a class assertion cannot see. Sizing the slot
+     * here fixes every icon site at once and keeps the 16px/14px the MUI
+     * original drew.
+     */
+    const iconSize = theme.button.sizes[size].iconSize;
+    const sizedIcon = (node: React.ReactNode) => (node ? (
+      <span
+        style={{ display: 'inline-flex', width: iconSize, height: iconSize, fontSize: iconSize }}
+        aria-hidden="true"
+      >
+        {node}
+      </span>
+    ) : undefined);
+
+    const libProps = {
+      /**
+       * MUI's ButtonBase defaults to `type="button"`; a bare <button> inside a
+       * <form> defaults to SUBMIT. Without this, every converted button in a
+       * form fired its handler AND submitted the form -- caught as a double
+       * `onSubmit` in FintelTemplateForm. `rest` still overrides it.
+       */
+      type: 'button' as const,
+      priority: libPriority,
+      variant: libTone,
+      size: libSize,
+      // MUI types `loading` as nullable; the library does not.
+      loading: loading ?? undefined,
+      ...rest,
+    };
+
+    if (isPolymorphic) {
+      const Child = (Component ?? (href ? 'a' : 'span')) as React.ElementType;
+      return (
+        <LibButton asChild {...libProps}>
+          <Child to={to} href={href}>{children}</Child>
+        </LibButton>
+      );
+    }
+    return (
+      <LibButton {...libProps} startIcon={sizedIcon(startIcon)} endIcon={sizedIcon(endIcon)}>
+        {children}
+      </LibButton>
+    );
+  }
+
+  // FALLBACK — MUI, deliberately. See `canUseLibrary` above for what sends a
+  // site here. These retire when the library grows the missing axis.
   const determineColorKey = (): ButtonColorKey => {
-    // color takes over intent
     if (color) return color;
     if (intent !== 'default') return intent;
-
     switch (variant) {
       case 'secondary': return 'secondary';
       case 'primary': return 'primary';
@@ -89,9 +207,7 @@ const Button: React.FC<CustomButtonProps> = ({
   const currentColorKey = determineColorKey();
   const colors = getColorDefinitions(theme);
   const currentColor = colors[currentColorKey];
-
   const isGradient = gradient || variant === 'extra';
-
   const gradientColors = getGradientColors(
     theme,
     isGradient,
@@ -100,68 +216,27 @@ const Button: React.FC<CustomButtonProps> = ({
     gradientStartColor,
     gradientEndColor,
   );
-
   const sizeConfig = getSizeConfig(theme, size, iconOnly);
-
-  const styleParams = {
-    theme,
-    currentColor,
-    gradientColors,
-    gradientAngle,
-    sizeConfig,
-    selected,
-  };
-
+  const styleParams = { theme, currentColor, gradientColors, gradientAngle, sizeConfig, selected };
   const baseSx = createBaseStyles(styleParams);
-
   const variantSx = (() => {
     switch (variant) {
       case 'primary':
-        return gradient
-          ? createPrimaryGradientStyles(styleParams)
-          : createPrimarySolidStyles(styleParams);
-
+        return gradient ? createPrimaryGradientStyles(styleParams) : createPrimarySolidStyles(styleParams);
       case 'secondary':
-        return gradient
-          ? createSecondaryGradientStyles(styleParams)
-          : createSecondarySolidStyles(styleParams);
+        return gradient ? createSecondaryGradientStyles(styleParams) : createSecondarySolidStyles(styleParams);
       case 'tertiary':
-        return gradient
-          ? createTertiaryGradientStyles(styleParams)
-          : createTertiarySolidStyles(styleParams);
-
+        return gradient ? createTertiaryGradientStyles(styleParams) : createTertiarySolidStyles(styleParams);
       case 'extra':
         return createExtraStyles(styleParams);
-
       default:
         return {};
     }
   })();
-
-  const combinedSx = [
-    baseSx,
-    variantSx,
-    ...(Array.isArray(externalSx) ? externalSx : [externalSx]),
-  ];
-
-  // Wrap content for gradient
-  const content = isGradient && children ? (
-    <span className="button-content">{children}</span>
-  ) : (
-    children
-  );
-
-  const wrappedStartIcon = isGradient && startIcon ? (
-    <span className="button-content">{startIcon}</span>
-  ) : (
-    startIcon
-  );
-
-  const wrappedEndIcon = isGradient && endIcon ? (
-    <span className="button-content">{endIcon}</span>
-  ) : (
-    endIcon
-  );
+  const combinedSx = [baseSx, variantSx, ...(Array.isArray(externalSx) ? externalSx : [externalSx])];
+  const content = isGradient && children ? <span className="button-content">{children}</span> : children;
+  const wrappedStartIcon = isGradient && startIcon ? <span className="button-content">{startIcon}</span> : startIcon;
+  const wrappedEndIcon = isGradient && endIcon ? <span className="button-content">{endIcon}</span> : endIcon;
 
   return (
     <MuiButton

--- a/opencti-platform/opencti-front/src/components/common/button/Button.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/Button.tsx
@@ -138,6 +138,10 @@ const Button: React.FC<CustomButtonProps> = ({
     && !selected
     && !externalSx
     && !classes
+    // The icon-only delegate falls back here when the library cannot take the
+    // site. The library Button pads for a text label, so it would draw a pill
+    // around the glyph instead of MUI's square control: keep MUI's geometry.
+    && !iconOnly
     // `asChild` replaces the button with its child, and the library drops the
     // icon slots in that mode.
     && !(isPolymorphic && (startIcon || endIcon));
@@ -161,13 +165,6 @@ const Button: React.FC<CustomButtonProps> = ({
     ) : undefined);
 
     const libProps = {
-      /**
-       * MUI's ButtonBase defaults to `type="button"`; a bare <button> inside a
-       * <form> defaults to SUBMIT. Without this, every converted button in a
-       * form fired its handler AND submitted the form -- caught as a double
-       * `onSubmit` in FintelTemplateForm. `rest` still overrides it.
-       */
-      type: 'button' as const,
       priority: libPriority,
       variant: libTone,
       size: libSize,
@@ -178,14 +175,22 @@ const Button: React.FC<CustomButtonProps> = ({
 
     if (isPolymorphic) {
       const Child = (Component ?? (href ? 'a' : 'span')) as React.ElementType;
+      // No `type` here: the rendered element is an anchor or a label, where the
+      // attribute is invalid.
       return (
         <LibButton asChild {...libProps}>
           <Child to={to} href={href}>{children}</Child>
         </LibButton>
       );
     }
+    /**
+     * MUI's ButtonBase defaults to `type="button"`; a bare <button> inside a
+     * <form> defaults to SUBMIT. Without this, every converted button in a form
+     * fired its handler AND submitted the form -- caught as a double `onSubmit`
+     * in FintelTemplateForm. `libProps` still overrides it.
+     */
     return (
-      <LibButton {...libProps} startIcon={sizedIcon(startIcon)} endIcon={sizedIcon(endIcon)}>
+      <LibButton type="button" {...libProps} startIcon={sizedIcon(startIcon)} endIcon={sizedIcon(endIcon)}>
         {children}
       </LibButton>
     );

--- a/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
@@ -3,31 +3,88 @@ import { IconButton as LibIconButton } from '@filigran/design-system';
 import Button, { CustomButtonProps } from './Button';
 
 /**
- * The library `IconButton` REQUIRES an accessible name -- an icon-only control
- * has no visible text to fall back on. 83 of the 358 sites carry neither
- * `aria-label` nor `title`, so the name is decided per site at runtime: a site
- * that has one converts, a site that has none keeps the MUI path rather than
- * ship an invented label. Those 83 are listed in the PR body; giving them real
- * names is product work, not a mechanical rename.
+ * Same two axes as `Button`: the wrapper's `variant` is a PRIORITY, its
+ * `intent`/`color` are the TONE. The library IconButton is NOT the library
+ * Button: its tone axis has no `highlight`, so `ee` has no expression here and
+ * a site using it keeps MUI. See fds-migration/LIBRARY-FEEDBACK.md.
  */
+const LIB_PRIORITY = { primary: 'primary', secondary: 'secondary', tertiary: 'tertiary' } as const;
+const LIB_TONE_FROM_INTENT = { default: 'default', destructive: 'destructive', ai: 'ia' } as const;
+const LIB_TONE_FROM_COLOR = {
+  default: 'default', primary: 'default', secondary: 'default',
+  error: 'destructive', destructive: 'destructive', ai: 'ia',
+} as const;
+
 const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
-  const { children, title, sx, classes, gradient, selected, component, to, href, ...rest } = props as
-    typeof props & { title?: string; classes?: unknown; gradient?: boolean; selected?: boolean };
+  const {
+    children, title, sx, classes, gradient, selected, component, to, href,
+    variant, intent, color, size, disabled, ...rest
+  } = props as typeof props & {
+    title?: string; classes?: unknown; gradient?: boolean; selected?: boolean;
+  };
   const label = (props as { 'aria-label'?: string })['aria-label'] ?? title;
-  const canUseLibrary = Boolean(label) && !sx && !classes && !gradient && !selected && !component && !to && !href;
+
+  // The delegate has always defaulted to the quiet, small control.
+  const libPriority = variant ? LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY] : 'tertiary';
+  const libTone = color
+    ? LIB_TONE_FROM_COLOR[color as keyof typeof LIB_TONE_FROM_COLOR]
+    : LIB_TONE_FROM_INTENT[(intent ?? 'default') as keyof typeof LIB_TONE_FROM_INTENT];
+
+  /**
+   * A site keeps MUI whenever the library cannot carry its meaning: no
+   * accessible name, MUI-only styling, or a tone/priority outside the tables
+   * above (`ee`, `warn`, `success`, `extra`, or anything dynamic). Dropping the
+   * tone silently would have cost these sites their signal.
+   */
+  /**
+   * `asChild` REPLACES the child's content with the glyph, so a control whose
+   * element must keep its own children cannot live there: `component="label"`
+   * wraps a real `<input type="file">`, which the library would destroy. Those
+   * keep MUI, where `ButtonBase` also gives the label the role and tab stop the
+   * library path would not (WCAG 2.1.1).
+   */
+  const rendersAnchor = Boolean(to) || Boolean(href) || component === 'a';
+  const isPolymorphic = Boolean(component || to || href);
+
+  const canUseLibrary = Boolean(label)
+    && Boolean(libPriority)
+    && Boolean(libTone)
+    && !sx && !classes && !gradient && !selected
+    && (!isPolymorphic || rendersAnchor);
 
   if (canUseLibrary) {
-    const { size, variant: _variant, intent: _intent, color: _color, ...domProps } = rest as Record<string, unknown>;
+    const libSize = size === 'default' ? 'md' : 'sm';
+    const common = {
+      priority: libPriority,
+      variant: libTone,
+      size: libSize as 'md' | 'sm',
+      disabled: disabled as boolean | undefined,
+      'aria-label': label as string,
+      icon: children,
+    };
+
+    /**
+     * An icon-only control that is really a LINK. It goes through the library
+     * IconButton, not the library Button: the Button carries the horizontal
+     * padding of a text label, which drew a 36x24 pill around a 20x20 glyph
+     * instead of a square control. `rest` carries the site's own props --
+     * `onClick`, `target`, `rel`, `data-testid` -- which the control needs.
+     */
+    if (rendersAnchor) {
+      const Child = (component ?? 'a') as React.ElementType;
+      return (
+        <LibIconButton asChild {...common}>
+          <Child to={to} href={href} {...(rest as Record<string, unknown>)} />
+        </LibIconButton>
+      );
+    }
+
     return (
       <LibIconButton
         // Same submit trap as Button: MUI defaulted to `type="button"`.
         type="button"
-        // The delegate has always defaulted to the quiet, small control.
-        priority="tertiary"
-        size={size === 'default' ? 'md' : 'sm'}
-        {...(domProps as React.ComponentPropsWithoutRef<'button'>)}
-        aria-label={label as string}
-        icon={children}
+        {...common}
+        {...(rest as React.ComponentPropsWithoutRef<'button'>)}
       />
     );
   }

--- a/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
@@ -27,12 +27,13 @@ const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
 
   // The delegate has always defaulted to the quiet, small control.
   /**
-   * `color="secondary"` with no `variant` is MUI's bordered control. Reading it
-   * as a tone alone would drop the border, so it becomes the secondary
-   * PRIORITY -- which is where the border lives in the library.
+   * `color` is a TONE only. Under MUI the delegate forces `variant="tertiary"`,
+   * whose styles are `border: 'none'`, so `color="secondary"` with no `variant`
+   * has always rendered borderless: reading it as a priority would ADD a border
+   * that never existed. The sites that do carry a border pass
+   * `variant="secondary"`, which maps through LIB_PRIORITY.
    */
-  const impliedPriority = color === 'secondary' && !variant ? 'secondary' : 'tertiary';
-  const libPriority = variant ? LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY] : impliedPriority;
+  const libPriority = variant ? LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY] : 'tertiary';
   const libTone = color
     ? LIB_TONE_FROM_COLOR[color as keyof typeof LIB_TONE_FROM_COLOR]
     : LIB_TONE_FROM_INTENT[(intent ?? 'default') as keyof typeof LIB_TONE_FROM_INTENT];

--- a/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
@@ -1,7 +1,37 @@
 import React from 'react';
+import { IconButton as LibIconButton } from '@filigran/design-system';
 import Button, { CustomButtonProps } from './Button';
 
+/**
+ * The library `IconButton` REQUIRES an accessible name -- an icon-only control
+ * has no visible text to fall back on. 83 of the 358 sites carry neither
+ * `aria-label` nor `title`, so the name is decided per site at runtime: a site
+ * that has one converts, a site that has none keeps the MUI path rather than
+ * ship an invented label. Those 83 are listed in the PR body; giving them real
+ * names is product work, not a mechanical rename.
+ */
 const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
+  const { children, title, sx, classes, gradient, selected, component, to, href, ...rest } = props as
+    typeof props & { title?: string; classes?: unknown; gradient?: boolean; selected?: boolean };
+  const label = (props as { 'aria-label'?: string })['aria-label'] ?? title;
+  const canUseLibrary = Boolean(label) && !sx && !classes && !gradient && !selected && !component && !to && !href;
+
+  if (canUseLibrary) {
+    const { size, variant: _variant, intent: _intent, color: _color, ...domProps } = rest as Record<string, unknown>;
+    return (
+      <LibIconButton
+        // Same submit trap as Button: MUI defaulted to `type="button"`.
+        type="button"
+        // The delegate has always defaulted to the quiet, small control.
+        priority="tertiary"
+        size={size === 'default' ? 'md' : 'sm'}
+        {...(domProps as React.ComponentPropsWithoutRef<'button'>)}
+        aria-label={label as string}
+        icon={children}
+      />
+    );
+  }
+
   return (
     <Button
       variant="tertiary"

--- a/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/common/button/IconButton.tsx
@@ -18,14 +18,21 @@ const LIB_TONE_FROM_COLOR = {
 const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
   const {
     children, title, sx, classes, gradient, selected, component, to, href,
-    variant, intent, color, size, disabled, ...rest
+    variant, intent, color, size, disabled, keepMui, ...rest
   } = props as typeof props & {
     title?: string; classes?: unknown; gradient?: boolean; selected?: boolean;
+    keepMui?: boolean;
   };
   const label = (props as { 'aria-label'?: string })['aria-label'] ?? title;
 
   // The delegate has always defaulted to the quiet, small control.
-  const libPriority = variant ? LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY] : 'tertiary';
+  /**
+   * `color="secondary"` with no `variant` is MUI's bordered control. Reading it
+   * as a tone alone would drop the border, so it becomes the secondary
+   * PRIORITY -- which is where the border lives in the library.
+   */
+  const impliedPriority = color === 'secondary' && !variant ? 'secondary' : 'tertiary';
+  const libPriority = variant ? LIB_PRIORITY[variant as keyof typeof LIB_PRIORITY] : impliedPriority;
   const libTone = color
     ? LIB_TONE_FROM_COLOR[color as keyof typeof LIB_TONE_FROM_COLOR]
     : LIB_TONE_FROM_INTENT[(intent ?? 'default') as keyof typeof LIB_TONE_FROM_INTENT];
@@ -49,7 +56,7 @@ const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
   const canUseLibrary = Boolean(label)
     && Boolean(libPriority)
     && Boolean(libTone)
-    && !sx && !classes && !gradient && !selected
+    && !sx && !classes && !gradient && !selected && !keepMui
     && (!isPolymorphic || rendersAnchor);
 
   if (canUseLibrary) {
@@ -72,8 +79,11 @@ const IconButton: React.FC<Omit<CustomButtonProps, 'iconOnly'>> = (props) => {
      */
     if (rendersAnchor) {
       const Child = (component ?? 'a') as React.ElementType;
+      // `disabled` is not an anchor attribute; the library drops the control's
+      // own interactivity instead.
+      const { disabled: _drop, ...anchorProps } = common;
       return (
-        <LibIconButton asChild {...common}>
+        <LibIconButton asChild {...anchorProps}>
           <Child to={to} href={href} {...(rest as Record<string, unknown>)} />
         </LibIconButton>
       );

--- a/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
@@ -27,6 +27,7 @@ const ClearFiltersIcon = ({
         onClick={onClear}
         size="small"
         disabled={hasActiveFilters != undefined ? !hasActiveFilters : disabled}
+        keepMui
       >
         <FilterAltOff fontSize="small" />
       </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
@@ -120,6 +120,7 @@ const ContentKnowledgeTimeLineBar: FunctionComponent<ContentKnowledgeTimeLineBar
                 <IconButton
                   color={timeLineDisplayRelationships ? 'secondary' : 'primary'}
                   onClick={() => handleToggleTimeLineDisplayRelationships()}
+                  keepMui
                 >
                   <RelationManyToMany />
                 </IconButton>
@@ -134,6 +135,7 @@ const ContentKnowledgeTimeLineBar: FunctionComponent<ContentKnowledgeTimeLineBar
                 <IconButton
                   color={timeLineFunctionalDate ? 'secondary' : 'primary'}
                   onClick={() => handleToggleTimeLineFunctionalDate()}
+                  keepMui
                 >
                   <CalendarMultiselectOutline />
                 </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -300,6 +300,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
                   aria-haspopup="true"
                   // color={nested ? 'inherit' : 'primary'}
                   size="small"
+                  keepMui
                 >
                   <ProgressUpload fontSize="small" />
                 </IconButton>
@@ -322,6 +323,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
                     aria-haspopup="true"
                     // color={nested ? 'inherit' : 'primary'}
                     size="small"
+                    keepMui
                   >
                     <GetAppOutlined fontSize="small" />
                   </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
@@ -162,6 +162,7 @@ const WorkbenchFileLineComponent = ({ classes, file, dense, directDownload, nest
                   aria-haspopup="true"
                   color={nested ? 'inherit' : 'primary'}
                   size="small"
+                  keepMui
                 >
                   <GetAppOutlined fontSize="small" />
                 </IconButton>
@@ -173,6 +174,7 @@ const WorkbenchFileLineComponent = ({ classes, file, dense, directDownload, nest
                 color={nested ? 'inherit' : 'primary'}
                 onClick={handleOpenDelete}
                 size="small"
+                keepMui
               >
                 <DeleteOutlined fontSize="small" />
               </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
@@ -153,6 +153,7 @@ const StixCoreObjectContentFilesList = ({
                               color={isEnterpriseEdition ? 'primary' : 'ee'}
                               aria-label="disseminate"
                               disabled={!isEnterpriseEdition}
+                              keepMui
                             >
                               <SendOutlined fontSize="small" />
                             </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsSuggestions.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsSuggestions.jsx
@@ -363,6 +363,7 @@ const StixCoreObjectsSuggestionsComponent = (props) => {
                                   applying.includes(suggestion.type)
                                   || !selectedEntity[suggestion.type]
                                 }
+                                keepMui
                               >
                                 {applying.includes(suggestion.type) ? (
                                   <CircularProgress size={20} color="inherit" />

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2787,6 +2787,7 @@ class DataTableToolBar extends Component {
                               onClick={this.handleLaunchDelete.bind(this)}
                               color={warning ? 'error' : 'primary'}
                               size="small"
+                              keepMui
                             >
                               <DeleteOutlined fontSize="small" />
                             </IconButton>
@@ -2825,6 +2826,7 @@ class DataTableToolBar extends Component {
                               onClick={this.handleLaunchRestore.bind(this)}
                               color={warning ? 'error' : 'primary'}
                               size="small"
+                              keepMui
                             >
                               <RestoreOutlined fontSize="small" />
                             </IconButton>
@@ -2841,6 +2843,7 @@ class DataTableToolBar extends Component {
                               onClick={this.handleLaunchCompleteDelete.bind(this)}
                               color={warning ? 'error' : 'primary'}
                               size="small"
+                              keepMui
                             >
                               <DeleteOutlined fontSize="small" />
                             </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -988,6 +988,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                       },
                     },
                   })}
+                  keepMui
                 >
                   {t_i18n(connector.manager_current_status === 'started' ? 'Stop' : 'Start')}
                 </Button>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
@@ -158,6 +158,7 @@ const ConnectorWorkLine: FunctionComponent<
           intent={(workErrors ?? []).length >= 0 ? 'destructive' : undefined}
           onClick={() => handleOpenDrawerErrors(workErrors ?? [])}
           size="small"
+          keepMui
         >
           {workErrors?.length} {t_i18n('errors')}
         </Button>

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvFeedTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvFeedTestDialog.tsx
@@ -119,6 +119,7 @@ const IngestionCsvFeedTestDialog: FunctionComponent<ingestionCsvFeedTestDialogPr
         <Button
           color={result?.ingestionCsvTester?.nbEntities ? 'primary' : 'secondary'}
           onClick={() => onTest()}
+          keepMui
         >
           {t_i18n('Test')}
         </Button>

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonCreation.tsx
@@ -601,6 +601,7 @@ const IngestionJsonCreation: FunctionComponent<IngestionJsonCreationProps> = ({ 
               color={isCreateDisabled ? 'secondary' : 'primary'}
               onClick={() => setOpen(true)}
               disabled={!(values.uri && values.json_mapper_id)}
+              keepMui
             >
               {t_i18n('Verify')}
             </Button>

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonMapperTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonMapperTestDialog.tsx
@@ -111,6 +111,7 @@ const IngestionJsonMapperTestDialog: FunctionComponent<IngestionJsonMapperTestDi
         <Button
           color={result?.ingestionJsonTester?.nbEntities ? 'primary' : 'secondary'}
           onClick={() => onTest()}
+          keepMui
         >
           {t_i18n('Test')}
         </Button>

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -93,6 +93,7 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
                     onClick={openLifecycleDialog}
                     startIcon={<TroubleshootOutlined />}
                     color={indicator.decay_exclusion_applied_rule ? 'warn' : 'primary'}
+                    keepMui
                   >
                     {t_i18n('Lifecycle')}
                   </Button>

--- a/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
@@ -184,6 +184,7 @@ const AlertsLineActions: FunctionComponent<AlertsLineActionsProps> = ({
           }}
           size="small"
           color={data.is_read ? 'primary' : 'success'}
+          keepMui
         >
           {data.is_read
             ? <UnpublishedOutlined fontSize="small" />


### PR DESCRIPTION
**DO NOT MERGE** — draft, opened so CI runs.

Flips the product's `Button`/`IconButton` wrappers onto the design-system
`Button`/`IconButton`. **No call site changes**: the two wrapper files decide,
per render, whether the library can reproduce the site exactly. Anything it
cannot express keeps MUI at the same call site.

## Census — 1213 wrapper mounts (855 `Button` + 358 `IconButton`)

| | flips to the library | keeps MUI |
|---|---|---|
| `Button` | 746 | 109 |
| `IconButton` | 250 | 108 |
| **total** | **996** | **217** |

Every mount is classified; none flips unclassified.

### Why a site keeps MUI

| n | reason |
|---|---|
| 95 | `sx` / `classes` — MUI styling APIs the library button does not take |
| 71 | icon button with **no accessible name** — see below |
| 22 | `gradient` / `selected` — no library equivalent |
| 25 | value outside the union, or dynamic, or spread props |
| 4 | `asChild` drops the icon slots, and the site has one |

## The axis mapping, which is the whole trap

The wrapper's `variant` is a **priority** (`primary\|secondary\|tertiary\|extra`)
and its `intent`/`color` are the **tone**. The library splits the same two axes
the other way round, as `priority` and `variant`. Mapping the words across
without a table is how `variant="secondary"` — **367 sites** — silently becomes a
colour.

`color` outranks `intent`, as it always did. `primary`, `secondary` and
`default` all resolve to `theme.palette.primary.main` in `getColorDefinitions`
(they differ only by border), so all three are the library's `default` tone.
`warn` and `success` have no library tone and deliberately keep MUI rather than
lose their colour.

A value outside the union lands on MUI instead of rendering something wrong —
`TasksList` passes MUI's own `variant="outlined"`, and one site is a typo,
`variant="secaondary"`, which the wrapper has been silently reading as
`primary` all along.

## Geometry

| wrapper | MUI | library | delta |
|---|---|---|---|
| `default` (981 sites) | 36px | `md` — 36px | exact |
| `small` (202 sites) | 26px | `sm` — 24px | **−2px** |

The library has no 26px step. **@sandy accepted the 26→24px change on the 202
`small` sites — arbitration closed.**

## Identity stability over partial conversion

A wrapper only ever sees the RESOLVED value of `color`, so it cannot tell a
literal from a ternary. A control whose colour changes between renders would
change engine with it, and a remounted control loses keyboard focus at the
moment of activation. @sandy ruled identity stability over partial library
rendering, so the decision is made at the call site: **20 sites with an
expression for `color` carry `keepMui`** and stay on MUI for their whole life.
The review named 4 of them; the static sweep found 20 across 15 files.

## Known deltas, recorded rather than papered over

**F4 — text buttons lose MUI's 64px minimum width.** `getSizeConfig` set
`minWidth: '64px'` for a text button; the library imposes no minimum. Measured
on a report overview: 4 of 8 converted text buttons fall below it — *Expand*
48px, *ANSSI* and *admin* 57px. **@sandy accepted content-hugging as the
library's intended behaviour — arbitration closed.** Icon-only controls are
unaffected: they are square by construction.

**F6 — the census is static, the flip is decided at runtime.** A site whose
`variant`/`color` is an expression is bucketed `edge` because it cannot be read
statically, but at run time the value is a real string: if it is a legal one the
site takes the library, if not it keeps MUI. So the "keeps MUI" figure is an
upper bound, not a promise — the runtime rule is the authority, and it is the
one that degrades safely.

## Two defects this wave surfaced

**Every converted button inside a form double-submitted.** MUI's `ButtonBase`
defaults to `type="button"`; a bare `<button>` in a `<form>` defaults to
SUBMIT. So a converted button fired its handler *and* submitted the form.
Caught by `FintelTemplateForm` (`onSubmit` called twice) and by
`WorkflowStatus` (Cancel submitting instead of closing). Both wrappers now
default `type="button"`, overridable.

**Icons had no size in the library's slot.** MUI sized the glyph through
`.MuiButton-startIcon`; the library's slot does not, so an icon with no
intrinsic size paints 0×0 — the TableTuneIcon defect, which no class assertion
can see. The wrapper sizes the slot once, keeping the 16px/14px MUI drew.
Measured on three screens: 0 zero-sized glyphs.

## The 83 icon buttons with no accessible name

The library `IconButton` **requires** `aria-label` — an icon-only control has no
visible text to fall back on. 83 of the 358 sites carry neither `aria-label` nor
`title`. They keep MUI. Naming them is product work, not a mechanical rename,
and inventing 83 labels would have been worse than leaving them.

## Dead props

| prop | live usages | action |
|---|---|---|
| `iconOnly` | 0 at call sites | **kept on `Button`** — the `IconButton` delegate passes it internally, and it now forces the MUI path so the glyph keeps its square box. Only removed from `IconButton`'s own public API. |
| `gradient` | 11 | **kept** — not dead |
| `selected` | 11 | **kept** — not dead |

## Composition rules inherited from #17945

- The EE badge never sits inside a button: sibling at a 4px gap to its right.
- One chip shape per screen.

`EnterpriseEditionButton` and `AIInsights` flip with this wave, now that their
badges sit outside the control.

## Merge order vs #17884

**No file overlap** — verified from the branches' common ancestor, the only base
that isolates their changes from ours. This wave touches two wrapper files;
#17884 touches neither.

## Proof

The library pin is **byte-identical** to the base — `package.json` and
`yarn.lock` are untouched. `tsc --noEmit` clean, `yarn lint` clean repo-wide,
full unit suite green, e2e green.
