### PR TITLE
chore(fds): bump the design-system pin to the library main tip (#17926)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=0ed2581bf1b8a8cec5f5de654d94e4108703920c",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
@@ -1,8 +1,8 @@
 {
   "__generated": "GENERATED FILE — do not edit by hand. Regenerate from the filigran-design-system repo: pnpm generate:mui-bridge --product opencti --write-to-product.",
   "product": "opencti",
-  "themeCssHash": "sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52",
+  "themeCssHash": "sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da",
   "generator": "@filigran/design-system scripts/generate-mui-bridge.ts",
   "tsFile": "fds-tokens.generated.ts",
-  "tsFileSha256": "sha256:040942eadd96468546bc9a1092ca727f5f86ce5a0b73fe3d070083f1abc4c88b"
+  "tsFileSha256": "sha256:5ef4336b2ec8871efc207c9e661e6e039235a2f25196a051ca231e60f15db45e"
 }

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
@@ -6,7 +6,7 @@
  * fields. Wiring: fds-migration/TOKEN-MAPPING.md.
  *
  * Source: @filigran/design-system packages/filigran-design-system/src/tokens/theme.css
- * Theme.css content hash: sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52
+ * Theme.css content hash: sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da
  * Regenerate (from the filigran-design-system repo, not here):
  *   pnpm generate:mui-bridge --product opencti --write-to-product
  *
@@ -18,7 +18,7 @@
 
 export const FDS_META = {
   product: "opencti",
-  themeCssHash: "sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52",
+  themeCssHash: "sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da",
   generator: "@filigran/design-system scripts/generate-mui-bridge.ts",
 } as const;
 

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=0ed2581bf1b8a8cec5f5de654d94e4108703920c":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=0ed2581bf1b8a8cec5f5de654d94e4108703920c"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/27668ed45862a3fe4e601e06638a8478abd03c5f054d38f73a4224ef335d1aa0e91500e475f296c3bba8bc71376ed1a1e7ce95b1fb6674f3eb384b31f1099450
+  checksum: 10c0/0afac06f22d24ae83f4301dbd3713cfdc403f67ff8467b2569b7c13e249b707cb1782289a30661b6fb05b8bdba007363a80f16a520428f74b661118ff3ade955
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=0ed2581bf1b8a8cec5f5de654d94e4108703920c"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
## What

Bumps `@filigran/design-system` from `0ed2581` (the pin #17946 left in the
base) to the library's main tip `1f7c64c`. Two library commits, nothing else
in this change set — **no site consumes the new options yet**, that is the
next PR.

| lib PR | what it lands |
|---|---|
| [#189](https://github.com/XTM-Foundation/filigran-design-system/pull/189) | the disabled field is repainted as an **outline**; the leading edge drops 16px → 12px; `HeaderSearch` (opt-in integrated search) |
| [#190](https://github.com/XTM-Foundation/filigran-design-system/pull/190) | `clearable` on Select, `isTypeNumber` on Input |

## Proof, by bytes in the installed dist

Not from the changelog and not from the types — read out of
`node_modules/@filigran/design-system/packages/filigran-design-system/dist`
after `yarn install` at the new pin.

### The disabled field is an outline now, on all six surfaces

The fill token is **gone** from every one of them — `grep -c bg-input-disabled`
returns `0` on all six files, where each carried it at the old pin:

| surface | new class string, verbatim from the dist |
|---|---|
| `input/Input.mjs` | `disabled:bg-transparent disabled:border-elevation-disabled` |
| `textarea/Textarea.mjs` | `disabled:bg-transparent disabled:border-elevation-disabled` |
| `combobox/Combobox.mjs` | `data-[disabled]:bg-transparent data-[disabled]:border-elevation-disabled` |
| `select/Select.mjs` | `disabled:pointer-events-none disabled:bg-transparent` + `disabled:border-elevation-disabled` |
| `search-field/SearchField.mjs` | `bg-transparent border-elevation-disabled pointer-events-none` |
| `file-select/FileSelect.mjs` | `bg-transparent border-elevation-disabled` |

`Combobox` and `FileSelect`/`SearchField` differ in form for a reason the
library states: their shell is a `<div>`, and `:disabled` only matches form
controls — hence `data-[disabled]:` on the Radix trigger and plain conditional
classes on the two that are composed by hand.

### The 12px leading edge

| surface | dist string | before |
|---|---|---|
| Input | `h-9 w-full rounded-sm pl-3 pr-2` | `pl-4` |
| Input, with a start icon | `true: "pl-8"` | `pl-9` |
| Textarea | `w-full rounded-sm pl-3 pr-4 pt-4 pb-2` | `px-4 pt-4 pb-2` |
| Combobox trigger | `rounded-sm border pl-3 pr-2 py-1` | `pl-4` |

**The Select trigger deliberately keeps `pl-4`** — the dist reads
`h-9 w-fit items-center justify-between gap-1 rounded-sm border pl-4 pr-2`.
So "12px everywhere" is not what shipped; it is 12px on the three surfaces
Sandy re-read on 2026-08-28, and this PR does not paper over the difference.

The delivered stylesheet carries the utilities the classes need —
`grep -c` in `dist/index.css`: `.pl-3` 1, `.pl-8` 1, `.pr-4` 1,
`border-elevation-disabled` 1, `disabled\:bg-transparent` 1,
`group-focus-within\:text-icon-highlight` 1.

### The two new options

- `select/Select.mjs` contains `clearable`, `canClear`, `clearLabel`;
  `index.d.ts` declares `clearable` on 4 surfaces.
- `input/Input.mjs` contains `isTypeNumber`, `"Increase value"`,
  `"Decrease value"`, `stepUp`, `stepDown`; `index.d.ts` declares
  `isTypeNumber?: boolean`.
- `header/Header.mjs` imports `SearchField` and exports `HeaderSearch` —
  the option the TopBar workaround retires against, consumed in the next PR.

## The token bridge is regenerated, not hand-edited

`check-fds-conformity.mjs` went red on `[bridge-freshness]` after the bump.
Cause, read rather than guessed: lib #190 appends an
`@utility appearance-textfield` block to `theme.css` (it suppresses the
browser's own number spinners), which moves the content hash the gate reads.

Regenerated with `pnpm generate:mui-bridge --product opencti --write-to-product`
from the library repo at the new pin, per AGENTS.md rule 1. **Zero token values
changed** — the entire diff of `fds-tokens.generated.ts` is its two hash lines,
which is exactly what an `@utility` should produce: it declares no token.

## Verification

| check | result |
|---|---|
| `yarn check-ts` | clean |
| `yarn test` (vitest) | exit 0 |
| `node fds-migration/scripts/check-fds-conformity.mjs` | 38 checks, 0 issues |
| `node fds-migration/scripts/check-accessible-names.mjs` | clean |

E2E is read live on this PR's runs; any red is fixed test-side unless the
component stops matching the library.
