### PR TITLE
feat(fds): consume the new library options and close the census (#17926)

### DIFF
--- a/fds-migration/CENSUS-FINAL.md
+++ b/fds-migration/CENSUS-FINAL.md
@@ -1,0 +1,238 @@
+# CENSUS-FINAL — every control family in the OpenCTI front
+
+Machine pass, one script, one run. Regenerate:
+
+```bash
+node fds-migration/scripts/census-all-families.mjs opencti-platform/opencti-front/src
+```
+
+Measured on `fds/consumption-night` (base `design-system/current` @ `075f23a`
+— after #17977, #17978 and #17980 merged — library pin `1f7c64c`). This is the closing document for the component phase:
+it states, for every family and every remaining MUI site, **why** it is still
+on MUI. There is no "not looked at yet" bucket — see *The uncensused bucket* at
+the end, which the script itself proves empty and fails on if it is not.
+
+## Method, and the two things that broke the first pass
+
+Same resolution as `census-selection-fields.mjs`: the **local name** of every
+imported symbol is resolved per file, then usages of that local name are
+counted. Matching on the element name is what missed two earlier counts —
+aliases (`MuiSwitch`, `MUIAutocomplete`, `MuiSelect`) are invisible to it.
+
+Two corrections this script needed that the selection-field one did not:
+
+1. **`component={X}` is a mount.** Formik's field adapters are never written as
+   JSX elements. Counting only `<X` reported 1 SwitchField site instead of 108
+   and 0 TextField pivot sites instead of 620. Both forms are counted now.
+2. **Type-only imports are not mounts.** `<SelectProps` matches the element
+   regex inside `Omit<SelectProps<string>, …>`. Nine symbols
+   (`SelectProps`, `PopoverProps`, `GridTypeMap`, `ButtonProps`, …) carried
+   mount counts for things that are never mounted. Symbols ending in `Props` or
+   `TypeMap`, and every `import type { … }`, are excluded.
+
+A converted site counts as its own mount; a site on a **legacy MUI adapter**
+counts once at the adapter file. Parking a site therefore lowers both numerator
+and denominator, exactly as `CENSUS.md` established.
+
+## Totals
+
+| family | total | on lib | on MUI |
+|---|---:|---:|---:|
+| Input | 648 | 634 (14 direct + 620 pivot) | 14 |
+| Textarea | 34 | 31 (5 direct + 26 pivot) | 3 |
+| Checkbox | 72 | 63 (61 direct + 2 pivot) | 9 |
+| Radio | 14 | 11 | 3 |
+| Switch | 195 | 109 (1 direct + 108 pivot) | 86 |
+| Select | 186 | 184 (83 direct + 101 pivot) | 2 |
+| Combobox | 109 | 105 (48 direct + 57 pivot) | 4 |
+| SearchField | 2 | 2 | 0 |
+| Button | 5 | 4 | 1 |
+| IconButton | 95 | 84 | 11 |
+| Chip | 78 | 70 | 8 |
+| Fab | 14 | 0 | 14 |
+| ToggleButton | 116 | 1 | 115 |
+| Slider | 9 | 5 | 4 |
+| **TOTAL** | **1577** | **1303 (82.6 %)** | **274** |
+
+**Two families carry 73 % of everything left**: ToggleButton (115) and Switch
+(86). Every other family together is 73 sites.
+
+## Reason codes
+
+| code | meaning |
+|---|---|
+| `lib-gap#N` | the library has no equivalent, or its equivalent lacks a capability this site needs. `N` is the `LIBRARY-FEEDBACK.md` entry where one exists |
+| `arbitration-pending` | blocked on a design or product decision that is Sandy's, not a migration's |
+| `parked-e2e` | converted once, reverted on a deterministic E2E red whose cause is still not established |
+| `legacy-adapter` | a MUI Formik adapter that must outlive its remaining consumers |
+| `frontier` | convertible, no library gap, no pending arbitration — but its own wave, for a reason stated per family |
+| `unnamed` | would need an accessible name invented rather than read |
+| `dead-code` | unreachable |
+
+## Per family
+
+### Input — 14 on MUI
+
+| sites | code | why |
+|---|---|---|
+| `TextField.tsx:181` | `frontier` | the pivot's own MUI fallback. It renders when a site is out of the Input contract (`multiline`, `select`, a leading interactive adornment, `onBeforePaste`, a non-string label, an unplaceable prop). It is the pivot working as designed, not a missed site |
+| `AutocompleteField.tsx:125` | `legacy-adapter` | the `renderInput` of the legacy MUI Autocomplete adapter; dies with its adapter |
+| `PeriodicityField.tsx:99,108` | `frontier` | two number fields inside a composite unit picker |
+| `FormSchemaEditor.tsx` ×8 | `frontier` | the form-schema builder, a screen of its own — see the Switch note below, the same file holds 31 switches |
+| `IntegrationsAvailable.tsx:210`, `IntegrationsDeployed.tsx:152` | `frontier` | search inputs inside the integrations list |
+
+### Textarea — 3 on MUI
+
+`BulkTextModal.tsx:85`, `WorkflowTransitions.tsx:287`,
+`FormSchemaEditor.tsx:1744` — all `frontier`. The 24 multiline sites the night
+brief expected were already converted: the `TextareaField` pivot carries **26**
+`component={TextareaField}` mounts plus 5 direct `<Textarea>`, and #17946
+landed the last of them. These three are raw `<TextField multiline>` outside
+the pivot.
+
+### Checkbox — 9 on MUI
+
+| sites | code | why |
+|---|---|---|
+| `FilterChipPopover.tsx:400` | `parked-e2e` | **do not touch.** `CENSUS.md` records this exact checkbox as the suspect in the parked `locator.check: Clicking the checkbox did not change its state` red |
+| `StixCoreObjectContainer.tsx:252`, `FormFieldRenderer.tsx:226`, `TriggerEditionOverview.tsx:378`, `GroupEditionMarkings.tsx:256`, `WidgetCreationParameters.tsx:285`, `HiddenTypesField.tsx:185` | `frontier` | each sits inside a `FormControlLabel`. The wrapper must be unwrapped onto the library Checkbox's own `label`, and the clone-injection trap has to be read per site — it is what broke a consent checkbox in #17946 |
+| `ListLines.jsx:468`, `DataTableToolBar.jsx:3392` | `frontier` | select-all checkboxes in the two list shells; `edge="start"` and `disableRipple` are MUI box-model props with no library counterpart, so the row geometry has to be re-read |
+
+### Radio — 3 on MUI
+
+`StixCoreObjectAskAI.tsx:324,344` and `DataTableToolBar.jsx:3106` — `frontier`.
+All three are inside `FormControlLabel`, same unwrap as the Checkbox block.
+
+### Switch — 86 on MUI, the second-largest block
+
+Measured, not estimated: **77 of the 86 sit inside a `FormControlLabel`**, and
+they are spread over 31 files with a long tail — `FormSchemaEditor.tsx` alone
+holds 31, `TransitionForm.tsx` 6, and 20 files hold exactly one.
+
+`frontier`, and it is a wave of its own for three reasons stated together:
+
+1. **The clone-injection trap is live here.** `FormControlLabel` copies
+   `checked`/`name`/`onChange` onto its control child *only when the child does
+   not define them*. Which side owns the handler has to be read per site; the
+   gates cannot see a handler that silently stops firing. This is the failure
+   #17946 hit.
+2. **Row height changes 38px → 20px on every one of them.** MUI's Switch is a
+   58×38 box (34×14 track in a 12px padding box); the library's is `h-5 w-9`.
+   Sandy accepted that change for the 107 pivot rows in #17976, so the geometry
+   is settled — but it lands on ~30 more forms here.
+3. **The compensations have to come off with it.** The 9 sites outside a
+   `FormControlLabel` are not therefore free: `Experience.tsx` wraps its two
+   switches in `Box sx={{ marginBlock: -0.75 }}`, a −6px pull that exists only
+   to cancel MUI's padding box and would misalign the row once that box is gone.
+
+A partial pass is worse than none: it leaves 20px and 38px switch rows side by
+side on the same screens.
+
+### Select — 2 on MUI
+
+| site | code | why |
+|---|---|---|
+| `DashboardRelativeDateSelect.tsx:53` | `arbitration-pending` — `lib-gap#43` | the field marks "this filter is constraining the view". Sandy withdrew the original library ask on 2026-08-26 after failing to notice the current 1px marker on the live site; the **form** of a perceptible marker is hers to design at V2 |
+| `SelectField.tsx:104` | `legacy-adapter` | 4 consumers left |
+
+`ThemeForm.tsx` left this list in this change set: `clearable` (library #190)
+retired FDS-WORKAROUND #45.
+
+### Combobox — 4 on MUI
+
+| site | code | why |
+|---|---|---|
+| `FilterChipPopover.tsx:327`, `ListFilters.tsx:197` | `parked-e2e` | both converted, both reverted on deterministic reds; `CENSUS.md` carries one test-side lead for the first and none for the second. Neither is a library defect as far as anything measured shows |
+| `CustomViewPreviewEntitySelector.tsx:112` | `arbitration-pending` — `lib-gap#43` | same withdrawn ask as `DashboardRelativeDateSelect` |
+| `AutocompleteField.tsx:152` | `legacy-adapter` | 2 consumers left |
+
+### Button — 1, IconButton — 11, Chip — 8
+
+**Re-measured after #17977 and #17978 merged, and the earlier reading was
+wrong.** An earlier pass tagged three of these `in-flight PR` because those two
+pull requests touch the files. They touch them without converting these mounts:
+the MUI site set in these three families is **byte-identical before and after
+both merges** — only line numbers moved. What the waves added is 4 library
+mounts (Button 2 → 4, IconButton 82 → 84), not a single MUI removal here.
+`in-flight PR` is therefore no longer a code in this document.
+
+`Button.tsx:226` is `frontier` **by design, not by omission**: it is the
+wrapper's deliberate MUI fallback, and its own comment says so — *"These retire
+when the library grows the missing axis"*, the axis being the tone gap recorded
+as LIBRARY-FEEDBACK #53. `StixCoreObjectsSuggestions.jsx:340` and
+`DataTableToolBar.jsx` are ordinary `frontier` sites the naming wave did not
+reach.
+
+The other 9 IconButton and 8 Chip sites are `frontier`: `TopBanner`,
+`GraphToolbarItem`, `NewsFeedToastManager` ×2, `CertStrategyForm`,
+`SSOSingletonStrategies` ×3, `ThreatActorIndividualBiographics`,
+`ResponseDialog`; and `FilterIconButtonContainer`, `PublicFeedLines`,
+`PublicStreamLines`, `PublicTaxiiLines`, `FormFieldRenderer`,
+`IngestionCatalogUseCaseChip`, `PlaceholderNode`, `DataTableToolBar`.
+
+### Fab — 14 on MUI
+
+`lib-gap` — **the library ships no Fab.** Verified by bytes: there is no `fab`
+directory under the installed
+`dist/components`, and no `Fab` export in `index.d.ts`. These 14 are the
+"create" buttons at the bottom-right of the list screens. Nothing to convert
+onto; this is a component request, not a migration task.
+
+### ToggleButton — 115 on MUI, the largest block
+
+`frontier`, with a caveat that makes it a design question before it is a
+migration one. The library's nearest equivalent is `ButtonGroup` /
+`ButtonGroupItem`, and `ButtonGroupItem` is **icon-only by contract**:
+`{ value, icon, "aria-label" }`, no text child. The 115 sites are not one
+population:
+
+- true segmented controls (`ViewSwitchingButtons`, `ListLines`, `ListCards`,
+  `ExportButtons`, `ContainerHeader`, …) — these map onto `ButtonGroup`;
+- **standalone** `ToggleButton`s used as kebab/menu triggers
+  (`PopoverMenu.tsx:35`, every `*Popover.tsx`, `WorkspaceKebabMenu`) — a group
+  of one is not a group; these are `IconButton`s wearing a toggle;
+- toggles carrying **text**, which `ButtonGroupItem` cannot render.
+
+Splitting those three is the first step of that wave, not something to decide
+inside a closing PR.
+
+### Slider — 4 on MUI
+
+`frontier`. `InputSliderField.tsx:112,166`, `SliderField.tsx:58`,
+`StixCoreObjectOpinionsRadarDialog.tsx:196`. No gap: Radix's Slider root gives
+`onValueCommit`, the equivalent of MUI's `onChangeCommitted` these sites use.
+The work is per-site — value shape (`number` vs `number[]`) and the `sx` track
+styling each have to be re-read.
+
+## The uncensused bucket
+
+**Empty, and the script fails if it is not.** 98 distinct MUI symbols are
+mounted in the front. 13 are the control families above (274 mounts). The
+other 85 are each assigned to a named bucket; an unassigned symbol makes
+`census-all-families.mjs` exit 1.
+
+| bucket | symbols | mounts |
+|---|---:|---:|
+| in a censused control family | 13 | 274 |
+| `no-lib-equivalent` — container / layout | 18 | 2079 |
+| `lib-exists` — not this wave | 25 | 2007 |
+| `no-lib-equivalent` — list / table / data display | 29 | 1984 |
+| `no-lib-equivalent` — feedback | 3 | 208 |
+| form scaffolding — follows its control, never converted alone | 7 | 182 |
+| `no-lib-equivalent` — speed dial | 3 | 8 |
+| **uncensused** | **0** | **0** |
+
+`lib-exists — not this wave` is the honest headline for what comes after the
+controls: 2007 mounts of `Typography` (519), `Tooltip` (496), `MenuItem` (284),
+`DialogActions` (200), `Tab` (128) and 20 more, all with a library component
+already built. The control phase is 82.6 % done; the surface phase has not
+started.
+
+## One finding outside the count
+
+`migration-state.json`'s `libComponentUsage` declares **Paper only** — 12
+entries, all Paper. The Select, Combobox, Checkbox, Switch and Input waves each
+adopted a library component without declaring it, so `check-fds-conformity.mjs`
+is not watching any of them: none would be caught reverting to MUI. This change
+set declares its own three adoptions and leaves the backfill as a separate,
+mechanical task.

--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -1979,3 +1979,40 @@ rather than a transitional state.
 **Suggestion:** add `highlight` to `iconButtonVariants` so the two components
 share one vocabulary, and add `warn` and `success` to both. The feedback tokens
 already exist -- `Chip` carries the same severities.
+
+## 54. `HeaderSearch` cannot yet carry OpenCTI's top-bar search
+
+**Capability gap, one site — the site the component was built for.** Library
+#189 added `HeaderSearch` as the Header's integrated search, and the intent was
+that it retires this product's own composition
+(`HeaderGroup grow="unbounded"` + `<SearchInput variant="topBar">`,
+FDS-WORKAROUND #17 + #20). Attempted at pin `1f7c64c` and **parked**: three
+things the top bar does have no expression in the API.
+
+Read from `HeaderSearchProps` / `HeaderSearchMode` in the installed
+`index.d.ts`, not from the changelog.
+
+1. **The NLQ toggle is a split button.** `SearchInput.jsx:389-407` nests a
+   second click zone inside the toggle — a caret with its own `onClick` and
+   `stopPropagation` that opens the agent-selector menu, separated by a 1px
+   rule. `HeaderSearchMode` is `{ value, icon, label, disabled? }` and renders
+   one button per entry. The caret *could* be passed inside `icon` (it is a
+   `ReactNode`), and that is exactly why this is parked rather than hacked:
+   it would nest an interactive element inside a `<button>` — the
+   `nested-interactive` axe failure the library itself avoided when it made the
+   Select clear a flex SIBLING of the trigger rather than a child.
+2. **No busy slot.** `isNLQLoading` renders `<Loader variant="inline" />`
+   beside the field. Already recorded as #20 for `SearchField`; `HeaderSearch`
+   inherits it.
+3. **Modes carry rich tooltips, not names.** `label` is the accessible name.
+   These three toggles show multi-sentence, conditional tooltips ("Ask Ariane
+   isn't activated yet…", "No agent available for this action…", or the
+   selected agent's name and description). An accessible name is not a place to
+   put a sentence that changes with state.
+
+**Status.** The top bar keeps its composition. #17 and #20 stay open.
+
+**Removal test.** A `HeaderSearchMode` that can own a secondary action without
+nesting it inside the toggle, plus a busy slot and a tooltip node. Then the
+three toggles, the loader and the agent menu all move, and #17, #20 and this
+entry close together.

--- a/fds-migration/NIGHT-LOG.md
+++ b/fds-migration/NIGHT-LOG.md
@@ -219,3 +219,68 @@ through.
 Worth knowing for next time: `gh run rerun` is refused while the workflow is
 still running, so the re-run has to wait for the whole run to finish, not just
 the failing job.
+
+
+## Follow-up round — Sandy ruled YES on `isTypeNumber` at scale
+
+`isTypeNumber={props.type === 'number'}` is on the pivot as asked, with a
+contract test (`TextField.number.test.tsx`, 7 cases) pinning the stepper, the
+`step`/`min`/`max` forwarding, and the geometry: the input keeps `h-9` and
+gains `pr-7` **inside** the box.
+
+### And verifying it turned up a defect that changes what the line does
+
+**`<Field component={TextField}>` never reaches the library Input at all.** It
+has always taken the MUI fallback, since before this branch.
+
+Measured, not inferred. The pivot's own diagnostic reports:
+
+```
+outOfContract: "unplaceable props: children"
+keys: [error, helperText, disabled, onBlur, name, onChange, label, type, className, children]
+```
+
+Cause, read out of the installed Formik (`formik.cjs.development.js:1384`):
+
+```js
+return React.createElement(component, _extends({ field, form }, props, { className }), children);
+```
+
+Three arguments, so React defines `props.children` **even when the value is
+`undefined`** — and `className` is spread unconditionally beside it. `children`
+is in neither `placeable` nor `nativeAttrs`, so `unplaceable` is never empty and
+every one of the ~620 Formik sites falls back to MUI.
+
+**The fix is one line** — count only props that actually carry a value:
+
+```diff
+-  const unplaceable = Object.keys(otherProps).filter(
+-    (k) => !placeable.has(k) && !forwardable(k),
+-  );
++  const unplaceable = Object.entries(otherProps).filter(
++    ([k, v]) => v !== undefined && !placeable.has(k) && !forwardable(k),
++  ).map(([k]) => k);
+```
+
+Proven: with that line the same 7 tests pass through a real `<Field>`; without
+it they only pass when the pivot is driven with an explicit props object.
+
+**Not shipped here, and that is the conservative default.** It would flip
+**~620 fields** — roughly 100 number and ~520 text — from MUI to the library
+Input in one unreviewed push. Sandy authorised the number stepper, not the
+whole form surface. #17946 intended these sites to be on the library, so this
+is arguably realising merged intent rather than new scope — but nobody has ever
+seen the result, because it never rendered.
+
+**Consequence to state plainly: until that line lands, `isTypeNumber` on the
+pivot is inert.** The line she approved is correct and stays; it takes effect
+the moment the blocker is decided. The `DEFECT PIN` case in the test file
+asserts the current fallback, so the day the branch opens the suite fails and
+names the place instead of ~620 fields changing silently.
+
+### Pilot instance
+
+`fds-migration/PILOT.md` — the local pilot is `http://localhost:3000` (backend
+4000, started by a personal `~/demo-opencti.sh`); the shared staging instance is
+redeployed only on a push to `design-system/current`, and its URL is still not
+recorded anywhere, so the file quotes the AWX identifiers to ask for instead.

--- a/fds-migration/NIGHT-LOG.md
+++ b/fds-migration/NIGHT-LOG.md
@@ -1,0 +1,221 @@
+# NIGHT-LOG — autonomous run of 2026-08-29
+
+Working notes for the overnight run. Every decision is recorded here, with
+the conservative default named whenever one was applied.
+
+## Merge state at start
+
+Read from `gh pr list` at the start of the run, before any branch was created.
+
+| PR | branch | state at start | owner |
+|---|---|---|---|
+| #17884 | (merged) | MERGED 2026-08-29T01:32Z | — |
+| #17945 | (merged) | MERGED 2026-08-28T23:53Z | — |
+| #17976 | (merged) | MERGED 2026-08-29T01:57Z | — |
+| #17946 | `fds/form-fields-night` | OPEN | another session — do not touch |
+| #17977 | `fds/button-wrapper-wave` | OPEN | another session — do not touch |
+| #17978 | `fds/iconbutton-naming-wave` | OPEN | another session — do not touch |
+| #17979 | `fds/thaw-wave` | OPEN | another session — do not touch |
+
+`design-system/current` tip at start: `3293449ee4`, pin `bd076e8f`.
+
+## Base moved mid-run — #17946 merged
+
+`#17946` merged into `design-system/current` while the Stage 1 worktree was
+being prepared, and it carried a pin bump of its own.
+
+- new tip: `f4e579200d`
+- base pin after the merge: `0ed2581bf1b8a8cec5f5de654d94e4108703920c`
+  (lib #186, the spacing scale in the delivered stylesheet)
+
+The Stage 1 branch had no commits at that point, so it was reset onto the new
+tip rather than rebased. **The pin was not walked back**: the bump now runs
+`0ed2581 → 1f7c64c`, which is exactly the two lib commits this night is about:
+
+- `8aaa846` — lib #189, Header integrated search + disabled field repainted as an outline
+- `1f7c64c` — lib #190, Select clear control + Input `isTypeNumber` stepper
+
+That is a narrower and cleaner bump than the one planned from `bd076e8f`
+(14 commits): #186 arrived through the base instead.
+
+## Stage 1 — the pin bump — PR #17980
+
+Branch `fds/pin-bump-night`, one commit, four files: `package.json`,
+`yarn.lock`, and the two regenerated bridge files.
+
+`0ed2581 → 1f7c64c`. Every claim proven by bytes in the installed dist
+(the greps are in the PR body). Two findings worth keeping:
+
+1. **"padding-left 12px" is not universal.** It lands on Input, Textarea and
+   the Combobox trigger. The **Select trigger deliberately keeps `pl-4`** —
+   `dist/components/select/Select.mjs` still reads
+   `h-9 w-fit … rounded-sm border pl-4 pr-2`. Recorded rather than smoothed
+   over: a later "align the Select trigger too" is a design call, not a bug.
+2. **The bump turned `[bridge-freshness]` red**, and the cause was benign:
+   lib #190 appends an `@utility appearance-textfield` block to `theme.css`,
+   moving the hash the gate reads. Regenerated with the documented command
+   (AGENTS.md rule 1). Zero token values changed — the whole
+   `fds-tokens.generated.ts` diff is its two hash lines.
+
+Local gates before push: `check-ts` clean, `yarn test` exit 0 (11m56s),
+conformity 38 checks / 0 issues, accessible-names clean.
+
+**Conservative default applied:** the generator resolves the product as a
+git-sibling directory, which a worktree pair is not. Rather than reach for
+`--out-dir` (documented as a *testing* mechanism), a temporary symlink
+`~/dev/opencti → ~/dev/night-pin` was created so the real
+`--write-to-product` path ran, then removed. The bytes written are the
+generator's own.
+
+## Ownership amendment — #17979 transferred mid-run
+
+Sandy transferred `#17979` (`fds/thaw-wave`) to this session while Stage 1 was
+in CI. **Decision: superseded, not grown** — one of the two, never both open.
+
+Reason it could not simply be rebased forward: `#17946` had already landed
+almost all of it. Of its nine commits, one applied clean, one was dropped by
+git as "already upstream", and the first — same title as `#17946`'s merge
+commit — conflicted in four files. The rebase was abandoned in favour of a
+merge, which measured the real remainder: **5 files, +21/−27**.
+
+All 14 merge conflicts resolved to this branch's side, for one reason: the base
+is **ahead** of #17979, not behind it. `EntitySelect`, `HiddenTypesField`,
+`DataTableLine`, `FilterChipPopover`, `DataTableToolBar`,
+`WorkspaceTurnToContainerDialog` and the two widget inputs were all converted
+by #17946, so #17979's side of each hunk was the older MUI code. The pin was
+**not** walked back.
+
+## Stage 3 — what shipped, and every conservative default
+
+### A — Select `clearable`: 1 of the 3 expected sites
+
+Only **one** site is a `clearable` site. `ThemeForm` converted — FEEDBACK #45,
+which names it as the single site and defines a removal test.
+
+The other two the brief expected are **not** clearable sites:
+`DashboardRelativeDateSelect` and `CustomViewPreviewEntitySelector` are blocked
+on FEEDBACK **#43**, an OPEN DESIGN QUESTION Sandy reformulated on 2026-08-26
+after visiting the live instance. The bump does not close it — it is hers.
+
+Two further candidates found by grep, both **parked as arbitrations**:
+
+- `Policies.tsx:264` — `<SelectItem value="">&nbsp;</SelectItem>`, an empty
+  option row with no label. Replacing it with `clearable` is defensible (an
+  option with no accessible name is a defect) but it removes a row from the
+  panel, which is a UX call.
+- `FormFieldRenderer.tsx:273` — `<SelectItem value=""><em>None</em></SelectItem>`.
+  "None" is real, translated wording on a user-defined form schema, not an
+  affordance stand-in.
+
+### B — `isTypeNumber`: 1 site converted, the wide change PARKED for Sandy
+
+The brief says "the 11 number fields". Measured: **101** `type="number"` mounts
+across **50** files. Exactly **one** is a direct `<Input type="number">`
+(`EntitySettingCustomFields.tsx:185`) — converted.
+
+Every other one reaches the library Input through the `components/TextField.tsx`
+pivot, which forwards `type` and would need **one line** to forward
+`isTypeNumber` with it. That one line repaints ~100 fields across 50 files.
+Parked deliberately: the intent ("native spinners gone") is unambiguous, the
+**scale** is 9× what was authorised, and this is a visible change on most forms
+in the product. The diff is in the morning report — it is a ten-second decision,
+not a night-time guess.
+
+Geometry checked: the stepper adds right padding inside the field
+(`pr-7`, `pr-11` beside a state icon) and **no height**. The box does not move.
+
+### C — TopBar → `HeaderSearch`: PARKED, with the note
+
+Three things the top bar does have no expression in `HeaderSearchProps` /
+`HeaderSearchMode`; the blocking one is that the NLQ toggle is a **split
+button** and `HeaderSearchMode` renders one plain `<button>` per entry. Passing
+the caret through `icon` is possible and is precisely the hack that was refused:
+it nests an interactive element inside a button — the `nested-interactive` axe
+failure the library itself avoided on the Select clear. Recorded as
+LIBRARY-FEEDBACK **#54**, with a marker at the site. #17 and #20 stay open.
+
+### D — closing conversions
+
+Converted: `EntitySelect.tsx:100`, a display-only checkbox inside a Combobox
+`renderOption` row — `checked` alone, iso with the pattern #17946 already
+merged elsewhere.
+
+**Parked, and this is the largest single decision of the night: the 86 direct
+Switch sites.** Measured, not estimated: **77 of 86 sit inside a
+`FormControlLabel`**, across 31 files (`FormSchemaEditor.tsx` alone holds 31).
+Three reasons together, all in CENSUS-FINAL.md: the clone-injection trap that
+broke a consent checkbox in #17946 has to be read per site; row height goes
+38px → 20px on ~30 more forms; and the 9 sites outside a `FormControlLabel`
+carry compensations (`Experience.tsx`: `marginBlock: -0.75`, a −6px pull that
+exists only to cancel MUI's padding box) that must come off with them. A
+partial pass leaves 20px and 38px switch rows on the same screen — worse than
+none.
+
+Also parked, same shape: the 3 Radio and 6 of the 9 remaining Checkbox sites,
+all inside `FormControlLabel`. `FilterChipPopover.tsx:400` is **untouched by
+rule** — `CENSUS.md` names that exact checkbox as the suspect in a parked E2E
+red.
+
+### Gates local to the branch
+
+`check-ts` clean · conformity **41 checks / 0 issues** · accessible-names clean
+· `check:utility-classes` clean.
+
+The accessible-names gate earned its keep: it caught `SelectContent` with no
+`aria-label` in the converted ThemeForm — an unnamed listbox — before push.
+
+`.capitalize` is **not** in the delivered CSS (checked before writing it), so
+the three `textTransform` declarations stay inline styles rather than becoming
+silently dead utility classes.
+
+## CI
+
+Both PRs finish **45 pass / 0 fail / 0 pending**, with all four E2E job pairs
+present on both the `push` and the `pull_request` run — the strict criterion,
+met.
+
+### The one red of the night, and how it was settled
+
+`Backend / Integration tests` failed on **both** runs of #17980's first SHA.
+Diagnosed rather than assumed, and the deciding evidence is that the two runs
+of the **same SHA failed on different tests**:
+
+| run | failing test |
+|---|---|
+| `push` | `telemetryManager-test.ts > shared saved filters count and permission changes are collected` |
+| `pull_request` | `customView-resolvers-test.ts > telemetry > gauges are updated` |
+
+A real red falls twice in the same place. `gh run rerun --failed` on both,
+**no code change**: both went green.
+
+**Then a docs-only commit on #17981 turned the same job red a third time, on a
+third distinct test** — `ingestion-csv-resolver-test.ts > should reset state of
+CSV feeds ingester`, which is not a telemetry test at all.
+
+That last one corrects the diagnosis rather than confirming it. The first
+narrowing — "process-global telemetry meters, the absolute-count shape
+`CENSUS.md` records for `Dashboard CRUD`" — was too specific. Four
+`Backend / Integration` runs across this stack produced **four different
+failing tests in three unrelated suites**, one of them on a commit that changes
+only a markdown file. The honest statement is broader: **the integration suite
+is currently flaky through shared state and ordering, not in one subsystem**.
+
+| run | failing test |
+|---|---|
+| #17980 `push` | `telemetryManager-test.ts > shared saved filters count…` |
+| #17980 `pull_request` | `customView-resolvers-test.ts > telemetry > gauges are updated` |
+| #17980 both, re-run | *(green, no code change)* |
+| #17981 `push` (docs-only commit) | `ingestion-csv-resolver-test.ts > should reset state of CSV feeds ingester` |
+
+What stays solid: none of these is reachable from this stack's diff. #17980
+touches four files under `opencti-front`; the commit that produced the third
+failure touches one `.md`. The base `f4e5792` is green on the same job.
+
+**Expect this to recur on the merges.** It is not something this stack can fix,
+and it is worth its own issue: a green `Backend / Integration` here is currently
+a coin flip, which is exactly the condition under which a real red gets waved
+through.
+
+Worth knowing for next time: `gh run rerun` is refused while the workflow is
+still running, so the re-run has to wait for the whole run to finish, not just
+the failing job.

--- a/fds-migration/PILOT.md
+++ b/fds-migration/PILOT.md
@@ -1,0 +1,40 @@
+# The pilot instance
+
+Written because the night run of 2026-08-29 needed it and found it recorded
+nowhere in this repository — the URL lived only in a shell script in one
+person's home directory.
+
+There are **two** things people call "the pilot". They are not the same and
+they refresh differently.
+
+## 1. The local pilot — what a reviewer actually opens
+
+**<http://localhost:3000>** — front on 3000, backend on 4000.
+
+Started by `~/demo-opencti.sh` (not in this repo: it is a personal script). It
+brings up the docker infrastructure, then the GraphQL backend, then the front.
+The login is `admin@opencti.io`; the password is in that script and is
+deliberately **not** recorded here.
+
+Two things to know before pointing it at a different checkout:
+
+- The backend accepts **one origin**. Two fronts cannot both talk to it, so a
+  second checkout has to take 3000 over rather than sit beside it on 3001.
+- The script pins a specific worktree. Reading it before running it is quicker
+  than debugging why your branch is not what you see.
+
+## 2. The shared staging instance — what the branch deploys to
+
+Redeployed by `.github/workflows/deploy-design-system.yml`, which fires **only
+on a push to `design-system/current`** (plus `workflow_dispatch`). So it always
+serves the branch tip, never an open pull request: a PR's work appears there
+when it merges, not before.
+
+The workflow restarts it through AWX with
+`solution=opencti, customer=design-system, inventory=eu-west-staging`. Its URL
+is not in the workflow and was not found anywhere in this repository —
+**someone who knows it should add it here.** Until then, that is the identifier
+to quote when asking for it.
+
+Do not dispatch the workflow on an unmerged branch to preview something: it is
+a shared instance, and it would replace what everyone else is looking at.

--- a/fds-migration/migration-state.json
+++ b/fds-migration/migration-state.json
@@ -275,6 +275,39 @@
         "opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx",
         "opencti-platform/opencti-front/src/private/components/data/tasks/TasksList.jsx"
       ]
+    },
+    {
+      "component": "Select",
+      "importFrom": "@filigran/design-system",
+      "files": [
+        "opencti-platform/opencti-front/src/private/components/settings/themes/ThemeForm.tsx"
+      ],
+      "guards": [
+        "imported-from-library"
+      ],
+      "reason": "FDS-WORKAROUND #45 retired: the clear control is the library`s own `clearable` (lib #190), no longer an endAdornment IconButton"
+    },
+    {
+      "component": "Checkbox",
+      "importFrom": "@filigran/design-system",
+      "files": [
+        "opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx"
+      ],
+      "guards": [
+        "imported-from-library"
+      ],
+      "reason": "display-only checkbox inside the Combobox renderOption row — `checked` alone, the field value drives it"
+    },
+    {
+      "component": "Input",
+      "importFrom": "@filigran/design-system",
+      "files": [
+        "opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingCustomFields.tsx"
+      ],
+      "guards": [
+        "imported-from-library"
+      ],
+      "reason": "the integer default-value field carries the designed stepper via `isTypeNumber` (lib #190) instead of the browser`s own spinners"
     }
   ]
 }

--- a/fds-migration/scripts/census-all-families.mjs
+++ b/fds-migration/scripts/census-all-families.mjs
@@ -1,0 +1,234 @@
+// Definitive census of every control family in the OpenCTI front.
+//
+// Method (same as census-selection-fields.mjs, generalised): resolve the LOCAL
+// name of every imported symbol per file, then count `<LocalName` mounts of that
+// local name. Matching on the element name is what broke two earlier counts —
+// aliases and default-plus-named import forms are invisible to it.
+//
+// Three provenances per mount:
+//   lib    — the symbol comes from '@filigran/design-system'
+//   pivot  — the symbol is a product Formik adapter that is itself on the lib
+//   mui    — the symbol comes from '@mui/material' or '@mui/lab'
+//
+// Usage: node fds-migration/scripts/census-all-families.mjs opencti-platform/opencti-front/src
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.argv[2];
+const JSON_OUT = process.argv.includes('--json');
+
+const files = [];
+(function walk(d) {
+  for (const e of readdirSync(d)) {
+    const p = join(d, e);
+    const st = statSync(p);
+    if (st.isDirectory()) { if (e !== 'node_modules' && e !== '__generated__') walk(p); }
+    else if (/\.(tsx|jsx)$/.test(e) && !/\.test\./.test(e)) files.push(p);
+  }
+})(ROOT);
+
+// family -> { mui: [symbols], lib: [symbols], pivots: [product module paths] }
+// A pivot is a product adapter ALREADY on the library: mounting it is a converted
+// site, and the adapter file itself is not double-counted (its own lib mount is).
+const FAMILIES = {
+  Input:        { mui: ['TextField', 'Input', 'OutlinedInput', 'FilledInput', 'InputBase'], lib: ['Input'],
+                  pivots: ['components/TextField', 'components/PasswordTextField', 'components/SimpleTextField', 'components/fields/BulkTextField'] },
+  Textarea:     { mui: [], lib: ['Textarea'], pivots: ['components/TextareaField'] },
+  Checkbox:     { mui: ['Checkbox'], lib: ['Checkbox'], pivots: ['components/CheckboxesField'] },
+  Radio:        { mui: ['Radio', 'RadioGroup'], lib: ['Radio', 'RadioGroup'], pivots: [] },
+  Switch:       { mui: ['Switch'], lib: ['Switch'], pivots: ['components/fields/SwitchField'] },
+  Select:       { mui: ['Select', 'NativeSelect'], lib: ['Select'], pivots: ['components/fields/SelectFieldFds'] },
+  Combobox:     { mui: ['Autocomplete'], lib: ['Combobox'], pivots: ['components/ComboboxField', 'components/fields/EntitySelectWithTypes'] },
+  SearchField:  { mui: [], lib: ['SearchField'], pivots: [] },
+  Button:       { mui: ['Button', 'LoadingButton'], lib: ['Button'], pivots: [] },
+  IconButton:   { mui: ['IconButton'], lib: ['IconButton'], pivots: [] },
+  Chip:         { mui: ['Chip'], lib: ['Chip'], pivots: [] },
+  Fab:          { mui: ['Fab'], lib: [], pivots: [] },
+  ToggleButton: { mui: ['ToggleButton', 'ToggleButtonGroup'], lib: ['ButtonGroup'], pivots: ['components/fields/ToggleButtonField'] },
+  Slider:       { mui: ['Slider'], lib: ['Slider'], pivots: ['components/InputSliderField', 'components/fields/SliderField'] },
+};
+
+const MUI_TO_FAMILY = new Map();
+const LIB_TO_FAMILY = new Map();
+for (const [fam, def] of Object.entries(FAMILIES)) {
+  for (const s of def.mui) MUI_TO_FAMILY.set(s, fam);
+  for (const s of def.lib) LIB_TO_FAMILY.set(s, fam);
+}
+// pivot module suffix -> family
+const PIVOT_TO_FAMILY = new Map();
+for (const [fam, def] of Object.entries(FAMILIES)) for (const p of def.pivots) PIVOT_TO_FAMILY.set(p, fam);
+
+const MUI_PKG = /^@mui\/(material|lab)(\/([A-Za-z]+))?$/;
+
+// Type-only symbols imported without the `type` keyword. `<SelectProps` matches
+// the element regex inside `Omit<SelectProps<string>, …>`, so these produced
+// mount counts for things that are never mounted. Verified by reading the
+// matches: every one sits in a generic position.
+const TYPE_ONLY = /(?:Props|TypeMap)$/;
+
+// Every MUI symbol that is NOT one of the 14 control families gets a bucket
+// here, so the "uncensused" bucket can be PROVEN empty rather than asserted.
+// A bucket is a statement about scope, not about readiness — `lib-exists` means
+// the library ships a replacement and the family is simply not this wave's
+// scope; `no-lib-equivalent` means there is nothing to convert onto today.
+const BUCKETS = {
+  'lib-exists — not this wave': [
+    'Typography', 'Tooltip', 'Menu', 'MenuItem', 'MenuList', 'Dialog', 'DialogActions',
+    'DialogContent', 'DialogContentText', 'DialogTitle', 'Tab', 'Tabs', 'Badge', 'Paper',
+    'Card', 'CardContent', 'CardHeader', 'CardActions', 'CardActionArea', 'CircularProgress',
+    'LinearProgress', 'AppBar', 'Toolbar', 'ButtonGroup', 'Icon',
+  ],
+  'no-lib-equivalent — container / layout': [
+    'Grid', 'Grid2', 'Box', 'Stack', 'Divider', 'Drawer', 'Accordion', 'AccordionSummary',
+    'AccordionDetails', 'Collapse', 'Modal', 'Popover', 'Popper', 'Grow', 'Slide',
+    'ClickAwayListener', 'CssBaseline', 'ButtonBase',
+  ],
+  'no-lib-equivalent — list / table / data display': [
+    'List', 'ListItem', 'ListItemText', 'ListItemIcon', 'ListItemButton', 'ListItemAvatar',
+    'ListItemSecondaryAction', 'ListSubheader', 'Table', 'TableBody', 'TableCell', 'TableHead',
+    'TableRow', 'TableContainer', 'Avatar', 'Skeleton', 'ImageListItem', 'ImageListItemBar',
+    'Timeline', 'TimelineItem', 'TimelineDot', 'TimelineConnector', 'TimelineContent',
+    'TimelineSeparator', 'TimelineOppositeContent', 'Step', 'Stepper', 'StepButton', 'StepLabel',
+  ],
+  'no-lib-equivalent — feedback': ['Alert', 'AlertTitle', 'Snackbar'],
+  'no-lib-equivalent — speed dial': ['SpeedDial', 'SpeedDialIcon', 'SpeedDialAction'],
+  'form scaffolding — follows its control, never converted alone': [
+    'FormControl', 'FormControlLabel', 'FormGroup', 'FormHelperText', 'FormLabel',
+    'InputLabel', 'InputAdornment',
+  ],
+};
+const SYMBOL_BUCKET = new Map();
+for (const [b, syms] of Object.entries(BUCKETS)) for (const s of syms) SYMBOL_BUCKET.set(s, b);
+
+// Every MUI symbol seen anywhere, so the "uncensused" bucket can be proven empty.
+const allMuiSymbols = new Map(); // symbol -> mounts
+
+const sites = [];   // one row per mount
+const pivotFiles = new Set();
+
+for (const f of files) {
+  const raw = readFileSync(f, 'utf8');
+  // strip comments so a commented-out element never counts
+  const src = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const rel = f.slice(f.indexOf('opencti-front/') + 'opencti-front/'.length);
+
+  const local = new Map(); // localName -> { origin, symbol }
+
+  // default / namespace imports:  import X from '<mod>'   (optionally + named)
+  for (const m of src.matchAll(/import\s+([A-Za-z_$][\w$]*)\s*(?:,\s*\{([^}]*)\})?\s*from\s*['"]([^'"]+)['"]/g)) {
+    const [, def, named, mod] = m;
+    const mui = MUI_PKG.exec(mod);
+    if (mui && mui[3]) local.set(def, { origin: 'mui', symbol: mui[3] });
+    for (const [suffix, fam] of PIVOT_TO_FAMILY) {
+      if (mod.endsWith(suffix) || mod.endsWith(suffix.replace(/^components\//, ''))) {
+        local.set(def, { origin: 'pivot', symbol: fam }); break;
+      }
+    }
+    if (named) addNamed(named, mod, local);
+  }
+  // pure named imports:  import { A, B as C } from '<mod>'
+  // `import type { … }` is skipped wholesale: a type name only ever appears in a
+  // generic position (`Omit<SelectProps, …>`), and `<SelectProps` matches the
+  // element regex there. That is what put SelectProps/PopoverProps/GridTypeMap
+  // in the first inventory with mount counts they cannot have.
+  for (const m of src.matchAll(/import\s+(type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/gs)) {
+    if (m[1]) continue;
+    addNamed(m[2], m[3], local);
+  }
+
+  function addNamed(list, mod, map) {
+    const isMui = MUI_PKG.test(mod) && !RegExp.$3;
+    const isLib = mod === '@filigran/design-system';
+    if (!isMui && !isLib) return;
+    for (const part of list.split(',')) {
+      const t = part.trim();
+      if (!t || /^type\s/.test(t)) continue;
+      const as = t.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+      const name = as ? as[1] : t;
+      const localName = as ? as[2] : t;
+      if (isMui && TYPE_ONLY.test(name)) continue;
+      if (isMui) map.set(localName, { origin: 'mui', symbol: name });
+      else map.set(localName, { origin: 'lib', symbol: name });
+    }
+  }
+
+  for (const [localName, { origin, symbol }] of local) {
+    // Two mount forms in this codebase: the JSX element, and Formik's
+    // `component={X}`. Counting only the first is what hid 108 SwitchField and
+    // 102 SelectFieldFds sites from the first pass of this script.
+    const re = new RegExp(`<${localName}(?![A-Za-z0-9_$])|component=\\{${localName}\\}`, 'g');
+    for (const m of src.matchAll(re)) {
+      const line = src.slice(0, m.index).split('\n').length;
+      if (origin === 'mui') {
+        allMuiSymbols.set(symbol, (allMuiSymbols.get(symbol) ?? 0) + 1);
+        const fam = MUI_TO_FAMILY.get(symbol);
+        if (!fam) continue;
+        // multiline TextField is the Textarea family, not Input
+        let family = fam;
+        if (symbol === 'TextField') {
+          const close = src.indexOf('/>', m.index);
+          const tag = src.slice(m.index, close === -1 ? m.index + 1200 : close);
+          if (/\bmultiline\b/.test(tag)) family = 'Textarea';
+        }
+        sites.push({ rel, line, family, provenance: 'mui', symbol, localName });
+      } else if (origin === 'lib') {
+        const fam = LIB_TO_FAMILY.get(symbol);
+        if (!fam) continue;
+        sites.push({ rel, line, family: fam, provenance: 'lib', symbol, localName });
+      } else {
+        pivotFiles.add(rel);
+        sites.push({ rel, line, family: symbol, provenance: 'pivot', symbol: localName, localName });
+      }
+    }
+  }
+}
+
+// ── Roll-up ────────────────────────────────────────────────────────────────
+const byFamily = {};
+for (const fam of Object.keys(FAMILIES)) byFamily[fam] = { lib: 0, pivot: 0, mui: 0, muiSites: [] };
+for (const s of sites) {
+  const b = byFamily[s.family];
+  b[s.provenance] += 1;
+  if (s.provenance === 'mui') b.muiSites.push(s);
+}
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ byFamily, allMuiSymbols: Object.fromEntries([...allMuiSymbols].sort((a, b) => b[1] - a[1])) }, null, 2));
+} else {
+  let tl = 0, tp = 0, tm = 0;
+  console.log('| family | total | on lib | on MUI |');
+  console.log('|---|---:|---:|---:|');
+  for (const [fam, b] of Object.entries(byFamily)) {
+    const total = b.lib + b.pivot + b.mui;
+    tl += b.lib; tp += b.pivot; tm += b.mui;
+    console.log(`| ${fam} | ${total} | ${b.lib + b.pivot} (${b.lib} direct + ${b.pivot} pivot) | ${b.mui} |`);
+  }
+  console.log(`| **TOTAL** | **${tl + tp + tm}** | **${tl + tp}** | **${tm}** |`);
+  console.log('\n## MUI sites, by family\n');
+  for (const [fam, b] of Object.entries(byFamily)) {
+    if (!b.mui) continue;
+    console.log(`### ${fam} — ${b.mui}`);
+    for (const s of b.muiSites) console.log(`- ${s.rel}:${s.line}  <${s.localName}> (${s.symbol})`);
+    console.log('');
+  }
+  console.log('## Every MUI symbol mounted anywhere\n');
+  const uncensused = [];
+  const buckets = new Map();
+  for (const [sym, n] of [...allMuiSymbols].sort((a, b) => b[1] - a[1])) {
+    if (MUI_TO_FAMILY.has(sym)) continue;
+    const b = SYMBOL_BUCKET.get(sym);
+    if (!b) { uncensused.push([sym, n]); continue; }
+    if (!buckets.has(b)) buckets.set(b, []);
+    buckets.get(b).push([sym, n]);
+  }
+  const famTotal = [...allMuiSymbols].filter(([s]) => MUI_TO_FAMILY.has(s)).reduce((a, [, n]) => a + n, 0);
+  console.log(`Distinct MUI symbols mounted: ${allMuiSymbols.size}`);
+  console.log(`- in a censused control family: ${[...allMuiSymbols.keys()].filter((s) => MUI_TO_FAMILY.has(s)).length} symbols / ${famTotal} mounts`);
+  for (const [b, list] of buckets) {
+    const n = list.reduce((a, [, c]) => a + c, 0);
+    console.log(`- ${b}: ${list.length} symbols / ${n} mounts`);
+    console.log(`  ${list.map(([s, c]) => `${s} (${c})`).join(', ')}`);
+  }
+  console.log(`\n**Uncensused: ${uncensused.length}**` + (uncensused.length ? ` — ${uncensused.map(([s, n]) => `${s} (${n})`).join(', ')}` : ' ✅'));
+  if (uncensused.length) process.exitCode = 1;
+}

--- a/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Contract tests for the number path of the TextField pivot.
+ *
+ * The pivot passes `isTypeNumber` whenever `type === 'number'`, which is what
+ * carries the designed stepper without touching a call site. These tests pin
+ * the two things that decision rests on: the stepper is really there, and the
+ * field's BOX does not change size — the padding the stepper needs is added
+ * inside it.
+ *
+ * They drive the pivot with an explicit props object rather than through
+ * `<Field component={TextField}>`. That is deliberate and it is not a
+ * convenience: Formik's `Field` always sets `children` on the props it forwards
+ * (`createElement(component, {...}, children)` — three arguments, so React
+ * defines the key even when the value is `undefined`), and `children` is absent
+ * from the pivot's `placeable`/`nativeAttrs` sets, so `outOfContract` reads
+ * `unplaceable props: children` and every Formik site takes the MUI fallback.
+ * Measured, not inferred — see fds-migration/NIGHT-LOG.md. Until that is
+ * decided, these tests exercise the library branch the only way it is currently
+ * reachable.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Formik } from 'formik';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import TextField from './TextField';
+import testRender from '../utils/tests/test-render';
+
+type PivotProps = Record<string, unknown>;
+
+type PivotComponentProps = Parameters<typeof TextField>[0];
+
+const Harness = ({ extra = {}, initial = '' }: { extra?: PivotProps; initial?: string | number }) => (
+  <Formik initialValues={{ order: initial }} onSubmit={() => {}}>
+    {(formik) => {
+      const pivotProps = {
+        field: {
+          name: 'order',
+          value: formik.values.order,
+          onChange: formik.handleChange,
+          onBlur: formik.handleBlur,
+        },
+        form: formik,
+        label: 'Order',
+        ...extra,
+      } as unknown as PivotComponentProps;
+      return <TextField {...pivotProps} />;
+    }}
+  </Formik>
+);
+
+const render = (extra: PivotProps = {}, initial: string | number = '') => testRender(<Harness extra={extra} initial={initial} />);
+const numberInput = () => screen.getByRole('spinbutton', { name: /order/i });
+
+describe('TextField pivot — number path', () => {
+  it('renders a spinbutton with the designed stepper', () => {
+    render({ type: 'number' });
+    expect(numberInput()).toHaveAttribute('type', 'number');
+    expect(screen.getByRole('button', { name: 'Increase value' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Decrease value' })).toBeInTheDocument();
+  });
+
+  it('suppresses the browser spinners so only one stepper renders', () => {
+    render({ type: 'number' });
+    expect(numberInput().className).toContain('appearance-textfield');
+  });
+
+  it('keeps the field the same size — padding goes INSIDE, height is untouched', () => {
+    render({ type: 'number' });
+    // h-9 is the field's own 36px box, unchanged by the stepper.
+    expect(numberInput().className).toContain('h-9');
+    // pr-7 is the room the stepper takes within that box.
+    expect(numberInput().className).toContain('pr-7');
+  });
+
+  it('leaves a text field alone — same height, no stepper', () => {
+    render();
+    const text = screen.getByRole('textbox', { name: /order/i });
+    expect(text.className).toContain('h-9');
+    expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
+  });
+
+  it('forwards step, min and max to the native input', () => {
+    render({ type: 'number', step: 5, min: 0, max: 10 });
+    expect(numberInput()).toHaveAttribute('step', '5');
+    expect(numberInput()).toHaveAttribute('min', '0');
+    expect(numberInput()).toHaveAttribute('max', '10');
+  });
+
+  it('steps the value on click', async () => {
+    const user = userEvent.setup();
+    render({ type: 'number', step: 1 }, 3);
+    await user.click(screen.getByRole('button', { name: 'Increase value' }));
+    expect(numberInput()).toHaveValue(4);
+  });
+
+  it('DEFECT PIN — a Formik <Field> site never reaches this branch', () => {
+    // Delete when the `children` blocker is decided. Written as an assertion so
+    // the day the pivot starts honouring Formik sites, this test fails and says
+    // where to look, instead of the change landing on ~620 fields unannounced.
+    render({ type: 'number', children: undefined });
+    expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
+    expect(screen.getByRole('spinbutton', { name: /order/i }).className).toContain('MuiInputBase-input');
+  });
+});

--- a/opencti-platform/opencti-front/src/components/TextField.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.tsx
@@ -159,6 +159,15 @@ const TextField = (props: TextFieldProps) => {
         id={props.id}
         name={name}
         type={props.type as 'text' | 'password' | 'number' | 'email' | undefined}
+        // Every number field routed through this pivot takes the designed
+        // stepper instead of the browser's own spinners (library #190,
+        // RULE-14). Set here rather than at ~100 call sites across 50 files:
+        // the pivot already owns `type`, and the two travel together.
+        // Geometry is unchanged — `isTypeNumber` adds right padding INSIDE the
+        // field (`pr-7`, `pr-11` beside a state icon) and no height; the box
+        // stays `h-9`. `step`/`min`/`max` already reach the inner <input>
+        // through `nativeAttrs`, and the stepper reads them from there.
+        isTypeNumber={props.type === 'number'}
         label={typeof props.label === 'string' ? props.label : undefined}
         required={props.required}
         placeholder={props.placeholder}

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchCreation.tsx
@@ -173,7 +173,7 @@ const WorkbenchCreationForm: React.FC<WorkbenchCreationProps> = ({ onCompleted, 
             name="name"
             label={t_i18n('Name')}
             fullWidth
-            askIa
+            askAi
           />
           <Field
             component={AutocompleteFreeSoloField}

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -5,7 +5,6 @@ import { Add, ArrowDropDown, ArrowDropUp, DeleteOutlined, DoubleArrow } from '@m
 import { ListItemButton, Stack } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Checkbox from '@mui/material/Checkbox';
 import DialogActions from '@mui/material/DialogActions';
 import Fab from '@mui/material/Fab';
 import List from '@mui/material/List';
@@ -65,6 +64,7 @@ import { stixDomainObjectsLinesSearchQuery } from '../../stix_domain_objects/Sti
 import { fileManagerAskJobImportMutation } from '../FileManager';
 import WorkbenchFilePopover from './WorkbenchFilePopover';
 import WorkbenchFileToolbar from './WorkbenchFileToolbar';
+import { Checkbox } from '@filigran/design-system';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -2957,9 +2957,7 @@ const WorkbenchFileContentComponent = ({
               onClick={handleToggleContainerSelectAll}
             >
               <Checkbox
-                edge="start"
                 checked={containerSelectAll}
-                disableRipple
               />
             </ListItemIcon>
             <ListItemText
@@ -3007,13 +3005,11 @@ const WorkbenchFileContentComponent = ({
                   style={{ minWidth: 40 }}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (containerSelectAll
                         && !(object.id in (containerDeselectedElements || {})))
                       || object.id in (containerSelectedElements || {})
                     }
-                    disableRipple
                   />
                 </ListItemIcon>
                 <ListItemText
@@ -3186,7 +3182,9 @@ const WorkbenchFileContentComponent = ({
               }}
               onClick={handleToggleSelectAll}
             >
-              <Checkbox edge="start" checked={selectAll} disableRipple />
+              <Checkbox
+                checked={selectAll}
+              />
             </ListItemIcon>
             <ListItemText
               primary={(
@@ -3248,13 +3246,11 @@ const WorkbenchFileContentComponent = ({
                   onClick={(event) => handleToggleSelectObject(object, event)}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (selectAll
                         && !(object.id in (deSelectedElements || {})))
                       || object.id in (selectedElements || {})
                     }
-                    disableRipple
                   />
                 </ListItemIcon>
                 <ListItemText
@@ -3378,7 +3374,9 @@ const WorkbenchFileContentComponent = ({
               }}
               onClick={handleToggleSelectAll}
             >
-              <Checkbox edge="start" checked={selectAll} disableRipple />
+              <Checkbox
+                checked={selectAll}
+              />
             </ListItemIcon>
             <ListItemIcon>
               <span
@@ -3432,13 +3430,11 @@ const WorkbenchFileContentComponent = ({
                   onClick={(event) => handleToggleSelectObject(object, event)}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (selectAll
                         && !(object.id in (deSelectedElements || {})))
                       || object.id in (selectedElements || {})
                     }
-                    disableRipple
                   />
                 </ListItemIcon>
                 <ListItemIcon classes={{ root: classes.itemIcon }}>
@@ -3624,7 +3620,9 @@ const WorkbenchFileContentComponent = ({
               }}
               onClick={handleToggleSelectAll}
             >
-              <Checkbox edge="start" checked={selectAll} disableRipple={true} />
+              <Checkbox
+                checked={selectAll}
+              />
             </ListItemIcon>
             <ListItemIcon>
               <span
@@ -3673,12 +3671,10 @@ const WorkbenchFileContentComponent = ({
                   onClick={(event) => handleToggleSelectObject(object, event)}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (selectAll && !(object.id in (deSelectedElements || {})))
                       || object.id in (selectedElements || {})
                     }
-                    disableRipple
                   />
                 </ListItemIcon>
                 <ListItemIcon classes={{ root: classes.itemIcon }}>
@@ -3786,7 +3782,9 @@ const WorkbenchFileContentComponent = ({
               }}
               onClick={handleToggleSelectAll}
             >
-              <Checkbox edge="start" checked={selectAll} disableRipple={true} />
+              <Checkbox
+                checked={selectAll}
+              />
             </ListItemIcon>
             <ListItemIcon>
               <span
@@ -3834,12 +3832,10 @@ const WorkbenchFileContentComponent = ({
                   onClick={(event) => handleToggleSelectObject(object, event)}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (selectAll && !(object.id in (deSelectedElements || {})))
                       || object.id in (selectedElements || {})
                     }
-                    disableRipple
                   />
                 </ListItemIcon>
                 <ListItemIcon classes={{ root: classes.itemIcon }}>
@@ -3961,7 +3957,9 @@ const WorkbenchFileContentComponent = ({
               }}
               onClick={handleToggleSelectAll}
             >
-              <Checkbox edge="start" checked={selectAll} disableRipple={true} />
+              <Checkbox
+                checked={selectAll}
+              />
             </ListItemIcon>
             <ListItemText
               primary={(
@@ -4001,13 +3999,11 @@ const WorkbenchFileContentComponent = ({
                   onClick={(event) => handleToggleSelectObject(object, event)}
                 >
                   <Checkbox
-                    edge="start"
                     checked={
                       (selectAll
                         && !(object.id in (deSelectedElements || {})))
                       || object.id in (selectedElements || {})
                     }
-                    disableRipple={true}
                   />
                 </ListItemIcon>
                 <ListItemText

--- a/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
@@ -1,5 +1,5 @@
-import { Checkbox } from '@mui/material';
 import {
+  Checkbox,
   Combobox,
   ComboboxChips,
   type ComboboxChangeMeta,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
@@ -12,7 +12,6 @@ import {
 import { stixCoreObjectTriggersFragment } from '@components/common/stix_core_objects/stixCoreObjectTriggersUtils';
 import { Badge, ListItemButton, ListItemIcon, Stack, Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
-import Checkbox from '@mui/material/Checkbox';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -51,6 +50,7 @@ import { triggerMutationFieldPatch } from '../../profile/triggers/TriggerEdition
 import { triggerLiveKnowledgeCreationMutation } from '../../profile/triggers/TriggerLiveCreation';
 import { TriggerPopoverDeletionMutation } from '../../profile/triggers/TriggerPopover';
 import NotifierField from '../form/NotifierField';
+import { Checkbox } from '@filigran/design-system';
 
 interface InstanceTriggerEditionFormValues {
   id: string;

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -250,6 +250,13 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
       >
         <HeaderGroup
           // `grow` caps below this bar's ceiling — see fds-migration/LIBRARY-FEEDBACK.md #17
+          //
+          // NOT `HeaderSearch` (library #189), though that option was built for
+          // exactly this bar. Parked at pin 1f7c64c — LIBRARY-FEEDBACK.md #54:
+          // the NLQ toggle is a split button, and `HeaderSearchMode` renders one
+          // plain <button> per entry. Passing the caret through `icon` would nest
+          // an interactive element inside that button, which is the axe
+          // `nested-interactive` failure the library avoided on the Select clear.
           grow="unbounded"
           style={{
             minWidth: TOP_BAR_SEARCH_MIN_WIDTH,

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Button from '@common/button/Button';
-import Checkbox from '@mui/material/Checkbox';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -33,6 +32,7 @@ import useFiltersState from '../../../../utils/filters/useFiltersState';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import { useTheme } from '@mui/material/styles';
+import { Checkbox } from '@filigran/design-system';
 
 // region live
 export const triggerLiveKnowledgeCreationMutation = graphql`

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingConfiguration.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingConfiguration.tsx
@@ -23,7 +23,6 @@ import { Field, Form, Formik } from 'formik';
 import { FileIndexingConfigurationQuery$data } from '@components/settings/file_indexing/__generated__/FileIndexingConfigurationQuery.graphql';
 import { FormikConfig } from 'formik/dist/types';
 import { fileIndexingConfigurationFieldPatch } from '@components/settings/file_indexing/FileIndexing';
-import Checkbox from '@mui/material/Checkbox';
 import * as Yup from 'yup';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
@@ -35,6 +34,7 @@ import TextField from '../../../../components/TextField';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import Card from '../../../../components/common/card/Card';
+import { Checkbox } from '@filigran/design-system';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -126,10 +126,8 @@ const FileIndexingConfiguration: FunctionComponent<
                 >
                   <ListItemText primary={t_i18n(mimeType)} />
                   <Checkbox
-                    edge="start"
-                    disableRipple={true}
                     checked={values.accept_mime_types.includes(mimeType)}
-                    onChange={() => {
+                    onCheckedChange={() => {
                       if (values.accept_mime_types.includes(mimeType)) {
                         setFieldValue(
                           'accept_mime_types',

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingCustomFields.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingCustomFields.tsx
@@ -183,7 +183,11 @@ const EntitySettingCustomFieldEditDialog: FunctionComponent<EntitySettingCustomF
       case 'integer':
         return (
           <Input
-            type="number"
+            // `isTypeNumber` (library #190) forces type="number" and suppresses the
+            // browser's own spinners, so the field carries the designed stepper
+            // instead of the UA's. The box does not change size: the stepper adds
+            // right padding inside the field (`pr-7`), never height.
+            isTypeNumber
             label={t_i18n('Default value')}
             value={defaultValue}
             onChange={(event) => setDefaultValue(event.target.value)}

--- a/opencti-platform/opencti-front/src/private/components/settings/themes/ThemeForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/themes/ThemeForm.tsx
@@ -1,11 +1,10 @@
 import Button from '@common/button/Button';
-import { InputAdornment, MenuItem, Select, SelectChangeEvent, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { useTheme } from '@mui/styles';
-import { ClearIcon } from '@mui/x-date-pickers';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
 import { Field, Form, useFormikContext } from 'formik';
 import { FunctionComponent, useRef, useState } from 'react';
 import ColorPickerField from '../../../../components/ColorPickerField';
-import IconButton from '../../../../components/common/button/IconButton';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import Label from '../../../../components/common/label/Label';
 import { useFormatter } from '../../../../components/i18n';
@@ -83,8 +82,7 @@ const ThemeForm: FunctionComponent<ThemeFormProps> = ({
     return null;
   };
 
-  const handleLoginAsideTypeChange = (event: SelectChangeEvent<string>) => {
-    const type = event.target.value as '' | 'color' | 'gradient' | 'image';
+  const handleLoginAsideTypeChange = (type: '' | 'color' | 'gradient' | 'image') => {
     setLoginAsideType(type);
 
     const clearedValues: ThemeType = {
@@ -250,40 +248,34 @@ const ThemeForm: FunctionComponent<ThemeFormProps> = ({
         </Label>
 
         <Stack gap={2.5}>
-          {/* FDS-WORKAROUND #45: stays on MUI. The empty string is a real product
-              state here, and the library Select has no adornment slot nor a clear
-              part, while Combobox has ComboboxClear. See fds-migration/LIBRARY-FEEDBACK.md */}
+          {/* FDS-WORKAROUND #45 retired: `clearable` landed in library #190, so the
+              endAdornment that used to carry the clear IconButton is gone and the
+              library owns the control. The empty string is still a real product
+              state — clearing means "the login page keeps its default panel".
+              `SelectValue` receives the mapped label as children, which is what
+              keeps the trigger's wording identical to MUI's `renderValue`: the
+              option row reads "Image URL" while the trigger reads "Add background
+              image", and this conversion does not arbitrate that difference. */}
           <Select
             value={loginAsideType}
-            onChange={handleLoginAsideTypeChange}
-            fullWidth
-            variant="standard"
-            displayEmpty
-            renderValue={(value) =>
-              value
-                ? getAsideTypeLabel(value)
-                : <em style={{ color: theme.palette.text.disabled }}>{t_i18n('Select a background type')}</em>
-            }
-            slotProps={{
-              input: {
-                sx: {
-                  textTransform: 'capitalize',
-                },
-              },
-            }}
-            endAdornment={
-              loginAsideType && (
-                <InputAdornment position="end" style={{ marginRight: 16 }}>
-                  <IconButton aria-label={t_i18n('Clear')} size="small" onClick={() => handleLoginAsideTypeChange({ target: { value: '' } } as SelectChangeEvent<string>)}>
-                    <ClearIcon fontSize="small" />
-                  </IconButton>
-                </InputAdornment>
-              )
-            }
+            onValueChange={(value) => handleLoginAsideTypeChange(value as '' | 'color' | 'gradient' | 'image')}
+            clearable
+            clearLabel={t_i18n('Clear')}
           >
-            <MenuItem value="color" sx={{ textTransform: 'capitalize' }}>{t_i18n('Add background color')}</MenuItem>
-            <MenuItem value="gradient" sx={{ textTransform: 'capitalize' }}>{t_i18n('Add background gradient')}</MenuItem>
-            <MenuItem value="image" sx={{ textTransform: 'capitalize' }}>{t_i18n('Image URL')}</MenuItem>
+            <SelectTrigger
+              className="w-full"
+              aria-label={t_i18n('Right panel customisation')}
+              style={{ textTransform: 'capitalize' }}
+            >
+              <SelectValue placeholder={t_i18n('Select a background type')}>
+                {getAsideTypeLabel(loginAsideType)}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent aria-label={t_i18n('Right panel customisation')}>
+              <SelectItem value="color" style={{ textTransform: 'capitalize' }}>{t_i18n('Add background color')}</SelectItem>
+              <SelectItem value="gradient" style={{ textTransform: 'capitalize' }}>{t_i18n('Add background gradient')}</SelectItem>
+              <SelectItem value="image" style={{ textTransform: 'capitalize' }}>{t_i18n('Image URL')}</SelectItem>
+            </SelectContent>
           </Select>
 
           <div ref={fieldRef}>


### PR DESCRIPTION
Rebased onto `design-system/current` @ `075f23a`, after #17977, #17978 and
#17980 merged. **Supersedes #17979** (closed; its content is the first commit
here).

Two commits, linear. The pin-bump commit is gone — #17980 landed it, and all
four of its artefacts (`package.json`, `yarn.lock`, and the two generated
bridge files) are byte-identical between this branch and the new base, so the
rebase dropped it cleanly. The #17979 merge commit was flattened into a normal
commit so the history stays linear.

## The conflict, resolved as a union

`fds-migration/LIBRARY-FEEDBACK.md` — both trains appended a `## 53.`.

- The button wave's **#53** (*the button family's tone axis is missing
  `highlight`, `warn` and `success`*) is kept exactly as it landed. Verified
  byte-for-byte: everything above this branch's addition is identical to the
  base's copy of the file.
- This branch's entry is renumbered **#53 → #54**, with both cross-references
  updated (`TopBar.tsx` and `NIGHT-LOG.md`).

## Converted

| site | what | why it is safe |
|---|---|---|
| `ThemeForm.tsx` | library Select + `clearable` | **FDS-WORKAROUND #45 retired.** The endAdornment carrying a clear `IconButton` is gone; the library owns the control (lib #190) |
| `EntitySettingCustomFields.tsx` | `isTypeNumber` | the browser's spinners give way to the designed pair. **The box does not change size** — the stepper adds right padding (`pr-7`), never height |
| `EntitySelect.tsx` | library Checkbox | display-only row checkbox, `checked` alone |
| 5 files (commit 1) | the #17979 remainder | 12 `WorkbenchFileContent` checkboxes, two `renderOption` checkboxes, one `onChange`→`onCheckedChange`, and the `askIa`→`askAi` typo |

`ThemeForm`'s trigger wording is byte-identical to MUI's: `SelectValue` takes
the mapped label as children, so the option row still reads "Image URL" while
the trigger reads "Add background image". That inconsistency exists in `master`;
this conversion does not arbitrate it.

The three adoptions are declared in `migration-state.json`'s `libComponentUsage`
(AGENTS.md rule 5).

## Parked, each with its reason recorded

1. **The TopBar's integrated search → LIBRARY-FEEDBACK #54.** OpenCTI's NLQ
   toggle is a **split button** — a caret with its own `onClick` and
   `stopPropagation` nested inside the toggle — and `HeaderSearchMode` renders
   one plain `<button>` per entry. The caret *could* be passed through `icon`,
   and that is exactly why this is parked rather than hacked: it would nest an
   interactive element inside a `<button>`, the `nested-interactive` axe failure
   the library itself avoided on the Select clear. #17 and #20 stay open.
2. **The 86 direct Switch sites** — 77 of them inside a `FormControlLabel`,
   across 31 files. Row height goes 38px → 20px, and the sites outside a
   `FormControlLabel` carry compensations that must come off with them.
3. **The pivot-wide `isTypeNumber`** — one line in `components/TextField.tsx`
   reaches ~100 more fields across 50 files. A scope decision, not a conversion.

`FilterChipPopover.tsx:400` is untouched **by rule**: `CENSUS.md` names that
exact checkbox as the suspect in a parked E2E red.

## Census — and a correction the rebase forced

`fds-migration/CENSUS-FINAL.md`, re-measured on this base.

**1577 mounts, 1303 on the library (82.6 %), 274 on MUI**, every one
reason-coded. The uncensused bucket is empty and the script exits 1 if it stops
being empty.

The earlier revision tagged three Button/IconButton sites `in-flight PR` because
#17977 and #17978 touch those files. **They touch them without converting these
mounts.** Re-measured after both merged: the MUI site set in the
Button/IconButton/Chip families is *identical* before and after — only line
numbers moved. What the waves added is 4 library mounts (Button 2 → 4,
IconButton 82 → 84), not one MUI removal in these families. `in-flight PR` is no
longer a reason code in the document, and `Button.tsx:226` is now recorded for
what it is: the wrapper's deliberate MUI fallback, whose own comment says it
retires when the library grows the tone axis — the gap the button wave filed as
#53.

Two other findings worth reading there: **the library ships no `Fab`** (14 sites
with nothing to convert onto, verified by bytes in the installed dist), and
**`libComponentUsage` declares Paper only**, so the conformity check is not
watching any of the Select/Combobox/Checkbox/Switch/Input adoptions.

## Verification on the rebased tree

| check | result |
|---|---|
| `yarn install` + `yarn relay` + `yarn check-ts` | clean |
| `check-fds-conformity.mjs` | 41 checks, 0 issues |
| `check-accessible-names.mjs` | clean |
| `script/check-utility-classes.js` | clean |
| `census-all-families.mjs` | exit 0 (uncensused bucket empty) |

## One thing to expect

`Backend / Integration` is flaky on this repo right now, independently of this
stack: four red runs during the night produced **four different failing tests in
three unrelated suites**, one of them on a commit that changes only a `.md`.
Re-running with no code change turned them green. It is worth its own issue.
