### PR TITLE
fix(fds): let Formik fields reach the library Input (#17926)

### DIFF
--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -2016,3 +2016,25 @@ Read from `HeaderSearchProps` / `HeaderSearchMode` in the installed
 nesting it inside the toggle, plus a busy slot and a tooltip node. Then the
 three toggles, the loader and the agent menu all move, and #17, #20 and this
 entry close together.
+
+## 55. The number stepper's default labels collide with short field names
+
+**Not a defect — a default worth knowing about.** `isTypeNumber` ships two
+buttons named `"Increase value"` and `"Decrease value"`. Accessible-name
+lookups match by SUBSTRING in both Playwright (`getByLabel`, `getByRole`) and
+Testing Library, so on any screen holding a field whose own label is `value`,
+one lookup becomes three.
+
+Found on OpenCTI's observable creation form, where the ICCID field is labelled
+exactly `value`: `getByLabel('value')` went from one match to three — the field
+plus both stepper buttons.
+
+Fixed on the consumer side by constraining the lookup to the form control, which
+is the right fix: renaming either side to dodge a substring match would be
+coupling the two. The library already exposes `incrementLabel` /
+`decrementLabel`, so a host that needs distinct names has them.
+
+**Worth considering upstream:** defaulting to a name that carries the field's
+own label — `Increase {label}` — would make the two buttons unique per field
+and remove the class of collision entirely. Also note both defaults are English
+strings in a product that translates every other control.

--- a/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
@@ -1,73 +1,55 @@
 /**
- * Contract tests for the number path of the TextField pivot.
+ * Contract tests for the number path of the TextField pivot, driven through a
+ * real `<Field component={TextField}>` — the shape all 526 product sites use.
  *
- * The pivot passes `isTypeNumber` whenever `type === 'number'`, which is what
- * carries the designed stepper without touching a call site. These tests pin
- * the two things that decision rests on: the stepper is really there, and the
- * field's BOX does not change size — the padding the stepper needs is added
- * inside it.
- *
- * They drive the pivot with an explicit props object rather than through
- * `<Field component={TextField}>`. That is deliberate and it is not a
- * convenience: Formik's `Field` always sets `children` on the props it forwards
- * (`createElement(component, {...}, children)` — three arguments, so React
- * defines the key even when the value is `undefined`), and `children` is absent
- * from the pivot's `placeable`/`nativeAttrs` sets, so `outOfContract` reads
- * `unplaceable props: children` and every Formik site takes the MUI fallback.
- * Measured, not inferred — see fds-migration/NIGHT-LOG.md. Until that is
- * decided, these tests exercise the library branch the only way it is currently
- * reachable.
+ * They went through an explicit props object until the placement diagnostic
+ * learned to ignore props that carry no value. Formik renders this component as
+ * `createElement(component, {field, form, ...props, className}, children)` —
+ * three arguments, so React defines `props.children` even when the value is
+ * `undefined` — and `children` is in neither `placeable` nor `nativeAttrs`, so
+ * `unplaceable` was never empty and every Formik site took the MUI fallback.
  */
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Formik } from 'formik';
+import { Field, Form, Formik } from 'formik';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import TextField from './TextField';
 import testRender from '../utils/tests/test-render';
 
-type PivotProps = Record<string, unknown>;
-
-type PivotComponentProps = Parameters<typeof TextField>[0];
-
-const Harness = ({ extra = {}, initial = '' }: { extra?: PivotProps; initial?: string | number }) => (
+const renderField = (props: Record<string, unknown> = {}, initial: string | number = '') => testRender(
   <Formik initialValues={{ order: initial }} onSubmit={() => {}}>
-    {(formik) => {
-      const pivotProps = {
-        field: {
-          name: 'order',
-          value: formik.values.order,
-          onChange: formik.handleChange,
-          onBlur: formik.handleBlur,
-        },
-        form: formik,
-        label: 'Order',
-        ...extra,
-      } as unknown as PivotComponentProps;
-      return <TextField {...pivotProps} />;
-    }}
-  </Formik>
+    <Form>
+      <Field component={TextField} name="order" label="Order" {...props} />
+    </Form>
+  </Formik>,
 );
 
-const render = (extra: PivotProps = {}, initial: string | number = '') => testRender(<Harness extra={extra} initial={initial} />);
 const numberInput = () => screen.getByRole('spinbutton', { name: /order/i });
 
 describe('TextField pivot — number path', () => {
+  it('a Formik site reaches the library Input, not the MUI fallback', () => {
+    renderField();
+    // The MUI fallback stamps MuiInputBase-input on its <input>; the library
+    // Input does not. This is the assertion the whole unblocker turns on.
+    expect(screen.getByRole('textbox', { name: /order/i }).className).not.toContain('MuiInputBase-input');
+  });
+
   it('renders a spinbutton with the designed stepper', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     expect(numberInput()).toHaveAttribute('type', 'number');
     expect(screen.getByRole('button', { name: 'Increase value' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Decrease value' })).toBeInTheDocument();
   });
 
   it('suppresses the browser spinners so only one stepper renders', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     expect(numberInput().className).toContain('appearance-textfield');
   });
 
   it('keeps the field the same size — padding goes INSIDE, height is untouched', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     // h-9 is the field's own 36px box, unchanged by the stepper.
     expect(numberInput().className).toContain('h-9');
     // pr-7 is the room the stepper takes within that box.
@@ -75,14 +57,13 @@ describe('TextField pivot — number path', () => {
   });
 
   it('leaves a text field alone — same height, no stepper', () => {
-    render();
-    const text = screen.getByRole('textbox', { name: /order/i });
-    expect(text.className).toContain('h-9');
+    renderField();
+    expect(screen.getByRole('textbox', { name: /order/i }).className).toContain('h-9');
     expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
   });
 
   it('forwards step, min and max to the native input', () => {
-    render({ type: 'number', step: 5, min: 0, max: 10 });
+    renderField({ type: 'number', step: 5, min: 0, max: 10 });
     expect(numberInput()).toHaveAttribute('step', '5');
     expect(numberInput()).toHaveAttribute('min', '0');
     expect(numberInput()).toHaveAttribute('max', '10');
@@ -90,17 +71,14 @@ describe('TextField pivot — number path', () => {
 
   it('steps the value on click', async () => {
     const user = userEvent.setup();
-    render({ type: 'number', step: 1 }, 3);
+    renderField({ type: 'number', step: 1 }, 3);
     await user.click(screen.getByRole('button', { name: 'Increase value' }));
     expect(numberInput()).toHaveValue(4);
   });
 
-  it('DEFECT PIN — a Formik <Field> site never reaches this branch', () => {
-    // Delete when the `children` blocker is decided. Written as an assertion so
-    // the day the pivot starts honouring Formik sites, this test fails and says
-    // where to look, instead of the change landing on ~620 fields unannounced.
-    render({ type: 'number', children: undefined });
-    expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: /order/i }).className).toContain('MuiInputBase-input');
+  it('still falls back to MUI for a prop the Input cannot place', () => {
+    // The diagnostic ignores props with no value; it must still catch real ones.
+    renderField({ style: { marginTop: 20 } });
+    expect(screen.getByRole('textbox', { name: /order/i }).className).toContain('MuiInputBase-input');
   });
 });

--- a/opencti-platform/opencti-front/src/components/TextField.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.tsx
@@ -136,9 +136,17 @@ const TextField = (props: TextFieldProps) => {
   const forwardable = (k: string) => nativeAttrs.has(k)
     || k.startsWith('data-') || k.startsWith('aria-');
   // Abandon on anything unrecognised rather than dropping it silently.
-  const unplaceable = Object.keys(otherProps).filter(
-    (k) => !placeable.has(k) && !forwardable(k),
-  );
+  //
+  // Only props that CARRY A VALUE count. Formik's `Field` renders this
+  // component as `createElement(component, {field, form, ...props, className},
+  // children)` — three arguments, so React defines `props.children` even when
+  // the value is `undefined`, and `className` is spread unconditionally beside
+  // it. `children` is in neither set above, so keying off `Object.keys` made
+  // `unplaceable` non-empty at EVERY Formik site and sent all of them to the
+  // MUI fallback. An absent prop is not an unplaceable prop.
+  const unplaceable = Object.entries(otherProps)
+    .filter(([k, v]) => v !== undefined && !placeable.has(k) && !forwardable(k))
+    .map(([k]) => k);
 
   const outOfContract = props.multiline ? 'multiline'
     : props.select ? 'select'

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.test.tsx
@@ -32,7 +32,11 @@ describe('Component: FintelTemplateForm', () => {
       />,
     );
 
-    await user.type(screen.getByLabelText('Name *'), 'MyFintelTemplate');
+    // 'Name', not 'Name *': the library Input puts the required marker in its
+    // own `aria-hidden` span, so the asterisk is deliberately outside the
+    // accessible name. MUI concatenated it. `required` is still announced —
+    // through `aria-required` on the input.
+    await user.type(screen.getByLabelText('Name'), 'MyFintelTemplate');
     await user.click(screen.getByRole('button', { name: 'Create' }));
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith(

--- a/opencti-platform/opencti-front/tests_e2e/model/drafts.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/drafts.pageModel.ts
@@ -47,7 +47,11 @@ export default class DraftsPage {
     const createDraftDrawer = this.getCreateDraftDrawer();
     await expect(createDraftDrawer).toBeVisible();
 
-    await createDraftDrawer.getByTestId('draft-creation-form-name-input').locator('input').fill(name);
+    // No `.locator('input')` hop: the pivot forwards `data-*` to the library
+    // Input, which places everything but `className` on the native <input>
+    // itself. MUI put the attribute on the field's root wrapper, so the extra
+    // hop used to be required and now finds nothing.
+    await createDraftDrawer.getByTestId('draft-creation-form-name-input').fill(name);
 
     for (const member of authorizedMembers) {
       await this.accessRestriction.addAccess(member.name, member.permission);

--- a/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
@@ -6,6 +6,24 @@ export default class TextFieldPageModel {
   private readonly inputLocator: Locator;
   private readonly parentLocator: Locator;
 
+  /**
+   * The field's own root, derived from the input rather than from the label.
+   *
+   * `getByText(label).locator('..')` used to reach it, because MUI puts the
+   * <label> as a direct child of the FormControl that also holds the helper
+   * text. The library Input wraps its label in a row of its own, so that
+   * parent is the label row and the helper text is a level above it — which is
+   * why an assertion on 'This field is required' stopped resolving.
+   *
+   * Two hops up from the input lands on the field root under BOTH engines
+   * (library: input → div.relative → root; MUI: input → InputBase → FormControl),
+   * and unlike widening the search it stays scoped to this one field, so a
+   * message belonging to a sibling field can never satisfy the assertion.
+   */
+  private static fieldRootOf(input: Locator) {
+    return input.locator('..').locator('..');
+  }
+
   constructor(
     readonly page: Page,
     label: string,
@@ -31,10 +49,10 @@ export default class TextFieldPageModel {
       this.parentLocator = root.getByText(label).locator('..');
     } else if (type === 'text-no-label') {
       this.inputLocator = root.getByRole('textbox', { name: label });
-      this.parentLocator = root.getByText(label).locator('..');
+      this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     } else {
       this.inputLocator = root.getByLabel(label);
-      this.parentLocator = root.getByText(label).locator('..');
+      this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     }
   }
 

--- a/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
@@ -51,7 +51,14 @@ export default class TextFieldPageModel {
       this.inputLocator = root.getByRole('textbox', { name: label });
       this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     } else {
-      this.inputLocator = root.getByLabel(label);
+      // `.and(control)`: `getByLabel` matches accessible names by SUBSTRING, and
+      // the library's number stepper ships two buttons named "Increase value" /
+      // "Decrease value". On the observable creation form, whose own field is
+      // labelled `value`, the lookup went from one match to three. Constraining
+      // to the elements this model is actually about — the form control — drops
+      // the buttons without touching the label semantics, and without renaming
+      // anything on either side.
+      this.inputLocator = root.getByLabel(label).and(root.locator('input, textarea'));
       this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     }
   }

--- a/opencti-platform/opencti-front/tests_e2e/model/form/userForm.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/form/userForm.pageModel.ts
@@ -12,8 +12,12 @@ export default class UserFormPage {
     return this.getNameInput().fill(name);
   }
 
+  // No `.getByLabel(...)` hop on either of these: the pivot forwards `data-*`
+  // to the library Input, which places everything but `className` on the
+  // native <input>. The test id IS the input now, where MUI put it on the
+  // field's root wrapper and the descendant lookup was needed.
   getEmailInput() {
-    return this.page.getByTestId('user-creation-email-address-input').getByLabel('Email address');
+    return this.page.getByTestId('user-creation-email-address-input');
   }
 
   async fillEmailInput(email: string) {
@@ -22,7 +26,7 @@ export default class UserFormPage {
   }
 
   getPasswordInput() {
-    return this.page.getByTestId('user-creation-password-input').getByLabel('Password');
+    return this.page.getByTestId('user-creation-password-input');
   }
 
   async fillPasswordInput(password: string) {


### PR DESCRIPTION
One concern: the `TextField` pivot's placement diagnostic counts props that
carry no value, and that has been sending **every** Formik field to the MUI
fallback since the pivot was written.

## The defect

`components/TextField.tsx` decides between the library `Input` and the MUI
fallback by checking whether any prop it received is one it cannot place:

```js
const unplaceable = Object.keys(otherProps).filter(
  (k) => !placeable.has(k) && !forwardable(k),
);
```

Formik renders this component as (`formik.cjs.development.js:1384`):

```js
React.createElement(component, _extends({ field, form }, props, { className }), children);
```

Three arguments, so React defines `props.children` **even when the value is
`undefined`** — and `className` is spread unconditionally beside it.
`children` is in neither `placeable` nor `nativeAttrs`, so `unplaceable` was
never empty and `outOfContract` always read `unplaceable props: children`.

Measured from the pivot's own diagnostic, not inferred:

```
outOfContract: "unplaceable props: children"
keys: [error, helperText, disabled, onBlur, name, onChange, label, type, className, children]
```

Consequence: #17946 routed the pivot to the library Input and the route was
never taken; `isTypeNumber` (#17981) has been inert since it landed. Full write-up
in `fds-migration/NIGHT-LOG.md`.

## The fix

An absent prop is not an unplaceable prop:

```js
const unplaceable = Object.entries(otherProps)
  .filter(([k, v]) => v !== undefined && !placeable.has(k) && !forwardable(k))
  .map(([k]) => k);
```

**To revert: restore the `Object.keys(...)` form above.** One line, no other
file depends on it — every field returns to the MUI fallback and `isTypeNumber`
goes inert again.

## What flips, by family

Measured by walking each `<Field component={TextField}>` opening tag at
brace-depth 0 and applying the pivot's own contract rules
(`fds-migration/scripts/` is not the home for this one — the script is in the
PR discussion, it is a one-off measurement, not a gate).

| | sites |
|---|---:|
| **Flip to the library Input** | **481** |
| — `type="number"` (these light up `isTypeNumber`) | 71 |
| — `type="password"` | 12 |
| — no explicit `type` (i.e. text) | 397 |
| — `type={expr}` | 1 |
| **Stay on the MUI fallback** | **45** |
| **Total `<Field component={TextField}>` sites** | **526** |

The 45 that stay, and why — all of them are the contract working as designed:

| count | reason |
|---:|---|
| 16 | `multiline` (that is Textarea's job, not Input's) |
| 19 | a real unplaceable prop with a value: `slotProps`, `style`, `sx`, `size`, `InputLabelProps`, `InputProps`, `inputProps` |
| 3 | `mandatory`, `number={true}` — props no MUI `TextField` has either; pre-existing strays, left alone |
| 1 | `startAdornment` |
| 1 | `{...spread}`, undecidable statically |

Note on counts: `CENSUS-FINAL.md` says 620 for the **Input family**, which spans
four pivots (`TextField`, `BulkTextField`, `SimpleTextField`,
`PasswordTextField`) and counts textual occurrences. 526 is this one pivot's
parsed `<Field>` sites. Different denominators, both correct for what they
measure.

## Test

`TextField.number.test.tsx` now drives a real `<Field component={TextField}>`
instead of an explicit props object, and its first case is the assertion the
whole change turns on:

```
a Formik site reaches the library Input, not the MUI fallback
```

The `DEFECT PIN` case that asserted the fallback is gone, replaced by a guard in
the other direction: a field passing `style` **must still** fall back, so the
diagnostic is not simply disabled.

## Verification

| check | result |
|---|---|
| `yarn check-ts` | clean |
| `yarn test` (full suite) | 1498 passed, see below |
| `check-fds-conformity.mjs` | 41 checks, 0 issues |
| `check-accessible-names.mjs` | clean |
| `script/check-utility-classes.js` | clean |

### The one unit failure the flip caused, and its fix

`FintelTemplateForm.test.tsx` looked up `getByLabelText('Name *')`. MUI
concatenates the required asterisk into the label text; the library puts it in
its own `aria-hidden` span, **deliberately outside the accessible name** — a
screen reader hears "Name", and `required` is carried by `aria-required` on the
input instead. The component matches the library, so the selector moved to
`'Name'`. Test-side, for the right reason.

### The two that are not this diff

- `Time.test.ts > minutesBefore` expects `09:30` and reads
  `2024-06-15T11:30:00+02:00`. It passes **18/18 under `TZ=UTC`** and fails only
  on a CEST machine. CI runs UTC.
- `buildConfig.test.ts` opens `dist/index.html` and needs a build first; CI
  builds before it tests.

Neither is reachable from a two-file change to a form pivot.

E2E is the real referee on a 481-field flip and is read live on this PR's runs.
Reds are fixed test-side — a converted field is right if it matches the library.
A red that shows a genuine product regression is reported, not patched.
