### PR TITLE
chore(fds): bump the design-system pin to 47baf69 — Select 12px, depth rename, light hover (#17926)

### DIFF
--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -2016,3 +2016,25 @@ Read from `HeaderSearchProps` / `HeaderSearchMode` in the installed
 nesting it inside the toggle, plus a busy slot and a tooltip node. Then the
 three toggles, the loader and the agent menu all move, and #17, #20 and this
 entry close together.
+
+## 55. The number stepper's default labels collide with short field names
+
+**Not a defect — a default worth knowing about.** `isTypeNumber` ships two
+buttons named `"Increase value"` and `"Decrease value"`. Accessible-name
+lookups match by SUBSTRING in both Playwright (`getByLabel`, `getByRole`) and
+Testing Library, so on any screen holding a field whose own label is `value`,
+one lookup becomes three.
+
+Found on OpenCTI's observable creation form, where the ICCID field is labelled
+exactly `value`: `getByLabel('value')` went from one match to three — the field
+plus both stepper buttons.
+
+Fixed on the consumer side by constraining the lookup to the form control, which
+is the right fix: renaming either side to dodge a substring match would be
+coupling the two. The library already exposes `incrementLabel` /
+`decrementLabel`, so a host that needs distinct names has them.
+
+**Worth considering upstream:** defaulting to a name that carries the field's
+own label — `Increase {label}` — would make the two buttons unique per field
+and remove the class of collision entirely. Also note both defaults are English
+strings in a product that translates every other control.

--- a/fds-migration/PILOT.md
+++ b/fds-migration/PILOT.md
@@ -38,3 +38,48 @@ to quote when asking for it.
 
 Do not dispatch the workflow on an unmerged branch to preview something: it is
 a shared instance, and it would replace what everyone else is looking at.
+
+## 3. The stacked preview — built from an unmerged stack, for a visual pass
+
+Not a permanent instance: a static server for the built front, put up so the
+complete state can be SEEN before anything merges. Recreate it with
+
+```
+cd opencti-platform/opencti-front && yarn build
+node <scratch>/serve-stack.mjs <path>/opencti-front/dist 3000 <backend-port>
+```
+
+**<http://localhost:3000>**
+
+Two things it has to do that a plain static server does not:
+
+- **Substitute the index.html placeholders.** The built `index.html` ships
+  `%APP_TITLE%`, `%BASE_PATH%`, `%APP_FAVICON%`, `%APP_DESCRIPTION%` and
+  `%APP_SCRIPT_SNIPPET%`; the BACKEND normally replaces them when it serves the
+  front (`opencti-graphql/src/http/httpPlatform.js`). Serve the raw file and the
+  app never boots — the same substitution has to happen in the server.
+- **Proxy the API.** `/graphql`, `/auth`, `/stream`, `/storage`, `/logout`,
+  `/schema`, `/taxii2`, `/feeds`, `/chatbot` and `/*/embedded/*` go to the
+  backend. Port 3000 for the front is deliberate: the backend accepts one
+  origin.
+
+### Choosing the backend to proxy to — check the schema first
+
+A front built from a branch will fail against a backend whose schema predates
+it, and it fails on the screens rather than at build time. Compare before
+picking:
+
+```
+diff <backend-worktree>/opencti-graphql/config/schema/opencti.graphql \
+     ./opencti-platform/opencti-graphql/config/schema/opencti.graphql
+```
+
+Measured 2026-08-29 while putting this up: the backend on **:4000** differs by
+11 lines — `x_opencti_score` is missing from `Malware`, `IntrusionSet` and
+`ThreatActorGroup`, which the front queries in 33 generated artifacts and which
+is itself one of the stepper fields on `ThreatActorGroupCreation`. Those three
+entity families would have failed. The backends on **:4030** and **:4011**
+matched exactly (0 differing lines), so the preview proxies :4030.
+
+Credentials are per backend and are not recorded here — this repository is
+public. The local demo instance's login lives in `~/demo-opencti.sh`.

--- a/fds-migration/PILOT.md
+++ b/fds-migration/PILOT.md
@@ -79,7 +79,20 @@ Measured 2026-08-29 while putting this up: the backend on **:4000** differs by
 `ThreatActorGroup`, which the front queries in 33 generated artifacts and which
 is itself one of the stepper fields on `ThreatActorGroupCreation`. Those three
 entity families would have failed. The backends on **:4030** and **:4011**
-matched exactly (0 differing lines), so the preview proxies :4030.
+matched exactly (0 differing lines).
+
+**A matching schema is not enough — check the data too.** The first attempt
+proxied :4030 on the schema check alone. Its index prefix is `opencti-cbx`,
+which holds **0 documents**: the platform logs in and shows an empty instance,
+which is useless for a visual pass. Count before choosing:
+
+```
+curl -s "http://localhost:9200/_cat/indices/<prefix>*?h=index,docs.count"
+```
+
+Measured the same day: `opencti*` 3617 docs (the :4000 instance),
+`papercti*` 2484 docs (:4011), `opencti-cbx*` 0. The preview therefore proxies
+**:4011** — the only backend that is both schema-matching and populated.
 
 Credentials are per backend and are not recorded here — this repository is
 public. The local demo instance's login lives in `~/demo-opencti.sh`.

--- a/fds-migration/scripts/serve-stack.mjs
+++ b/fds-migration/scripts/serve-stack.mjs
@@ -1,0 +1,50 @@
+// Serves the built OpenCTI front (dist/) on :3000 and proxies the API to the
+// dev backend on :4000. Port 3000 deliberately: the backend accepts one origin
+// and that is the one it is configured for.
+import http from 'node:http';
+import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
+import { join, extname, normalize } from 'node:path';
+
+const DIST = process.argv[2];
+const PORT = Number(process.argv[3] ?? 3000);
+const BACK = Number(process.argv[4] ?? 4000);
+const API = ['/graphql', '/auth', '/stream', '/storage', '/logout', '/schema', '/taxii2', '/feeds', '/chatbot', '/static'];
+const MIME = { '.html':'text/html', '.js':'text/javascript', '.mjs':'text/javascript', '.css':'text/css',
+  '.json':'application/json', '.svg':'image/svg+xml', '.png':'image/png', '.jpg':'image/jpeg',
+  '.woff':'font/woff', '.woff2':'font/woff2', '.ttf':'font/ttf', '.ico':'image/x-icon', '.map':'application/json' };
+
+http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const isApi = API.some((p) => url.pathname === p || url.pathname.startsWith(`${p}/`))
+    || /\/embedded\//.test(url.pathname);
+  if (isApi) {
+    const proxy = http.request({ hostname: 'localhost', port: BACK, path: req.url, method: req.method,
+      headers: { ...req.headers, host: `localhost:${BACK}` } }, (up) => {
+      res.writeHead(up.statusCode ?? 502, up.headers); up.pipe(res);
+    });
+    proxy.on('error', (e) => { res.writeHead(502); res.end(`proxy: ${e.message}`); });
+    req.pipe(proxy);
+    return;
+  }
+  // static, with SPA fallback
+  const rel = normalize(decodeURIComponent(url.pathname)).replace(/^(\.\.[/\\])+/, '');
+  let file = join(DIST, rel);
+  if (!existsSync(file) || statSync(file).isDirectory()) file = join(DIST, 'index.html');
+  // index.html ships with placeholders the BACKEND normally substitutes when it
+  // serves the front (opencti-graphql/src/http/httpPlatform.js). Serving the raw
+  // file leaves `%APP_TITLE%` and friends in place and the app never boots — so
+  // do the same substitution here, with the same defaults.
+  if (file.endsWith('index.html')) {
+    const html = readFileSync(file, 'utf8')
+      .replace(/%BASE_PATH%/g, '')
+      .replace(/%APP_SCRIPT_SNIPPET%/g, '')
+      .replace(/%APP_TITLE%/g, 'OpenCTI - Cyber Threat Intelligence Platform')
+      .replace(/%APP_DESCRIPTION%/g, 'OpenCTI is an open source platform allowing organizations to manage their cyber threat intelligence knowledge and observables.')
+      .replace(/%APP_FAVICON%/g, './assets/static/favicon.png');
+    res.writeHead(200, { 'content-type': 'text/html', 'cache-control': 'no-store' });
+    res.end(html);
+    return;
+  }
+  res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+  createReadStream(file).pipe(res);
+}).listen(PORT, () => console.log(`stack served on http://localhost:${PORT} (api -> :${BACK})`));

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.number.test.tsx
@@ -1,73 +1,55 @@
 /**
- * Contract tests for the number path of the TextField pivot.
+ * Contract tests for the number path of the TextField pivot, driven through a
+ * real `<Field component={TextField}>` — the shape all 526 product sites use.
  *
- * The pivot passes `isTypeNumber` whenever `type === 'number'`, which is what
- * carries the designed stepper without touching a call site. These tests pin
- * the two things that decision rests on: the stepper is really there, and the
- * field's BOX does not change size — the padding the stepper needs is added
- * inside it.
- *
- * They drive the pivot with an explicit props object rather than through
- * `<Field component={TextField}>`. That is deliberate and it is not a
- * convenience: Formik's `Field` always sets `children` on the props it forwards
- * (`createElement(component, {...}, children)` — three arguments, so React
- * defines the key even when the value is `undefined`), and `children` is absent
- * from the pivot's `placeable`/`nativeAttrs` sets, so `outOfContract` reads
- * `unplaceable props: children` and every Formik site takes the MUI fallback.
- * Measured, not inferred — see fds-migration/NIGHT-LOG.md. Until that is
- * decided, these tests exercise the library branch the only way it is currently
- * reachable.
+ * They went through an explicit props object until the placement diagnostic
+ * learned to ignore props that carry no value. Formik renders this component as
+ * `createElement(component, {field, form, ...props, className}, children)` —
+ * three arguments, so React defines `props.children` even when the value is
+ * `undefined` — and `children` is in neither `placeable` nor `nativeAttrs`, so
+ * `unplaceable` was never empty and every Formik site took the MUI fallback.
  */
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Formik } from 'formik';
+import { Field, Form, Formik } from 'formik';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import TextField from './TextField';
 import testRender from '../utils/tests/test-render';
 
-type PivotProps = Record<string, unknown>;
-
-type PivotComponentProps = Parameters<typeof TextField>[0];
-
-const Harness = ({ extra = {}, initial = '' }: { extra?: PivotProps; initial?: string | number }) => (
+const renderField = (props: Record<string, unknown> = {}, initial: string | number = '') => testRender(
   <Formik initialValues={{ order: initial }} onSubmit={() => {}}>
-    {(formik) => {
-      const pivotProps = {
-        field: {
-          name: 'order',
-          value: formik.values.order,
-          onChange: formik.handleChange,
-          onBlur: formik.handleBlur,
-        },
-        form: formik,
-        label: 'Order',
-        ...extra,
-      } as unknown as PivotComponentProps;
-      return <TextField {...pivotProps} />;
-    }}
-  </Formik>
+    <Form>
+      <Field component={TextField} name="order" label="Order" {...props} />
+    </Form>
+  </Formik>,
 );
 
-const render = (extra: PivotProps = {}, initial: string | number = '') => testRender(<Harness extra={extra} initial={initial} />);
 const numberInput = () => screen.getByRole('spinbutton', { name: /order/i });
 
 describe('TextField pivot — number path', () => {
+  it('a Formik site reaches the library Input, not the MUI fallback', () => {
+    renderField();
+    // The MUI fallback stamps MuiInputBase-input on its <input>; the library
+    // Input does not. This is the assertion the whole unblocker turns on.
+    expect(screen.getByRole('textbox', { name: /order/i }).className).not.toContain('MuiInputBase-input');
+  });
+
   it('renders a spinbutton with the designed stepper', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     expect(numberInput()).toHaveAttribute('type', 'number');
     expect(screen.getByRole('button', { name: 'Increase value' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Decrease value' })).toBeInTheDocument();
   });
 
   it('suppresses the browser spinners so only one stepper renders', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     expect(numberInput().className).toContain('appearance-textfield');
   });
 
   it('keeps the field the same size — padding goes INSIDE, height is untouched', () => {
-    render({ type: 'number' });
+    renderField({ type: 'number' });
     // h-9 is the field's own 36px box, unchanged by the stepper.
     expect(numberInput().className).toContain('h-9');
     // pr-7 is the room the stepper takes within that box.
@@ -75,14 +57,13 @@ describe('TextField pivot — number path', () => {
   });
 
   it('leaves a text field alone — same height, no stepper', () => {
-    render();
-    const text = screen.getByRole('textbox', { name: /order/i });
-    expect(text.className).toContain('h-9');
+    renderField();
+    expect(screen.getByRole('textbox', { name: /order/i }).className).toContain('h-9');
     expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
   });
 
   it('forwards step, min and max to the native input', () => {
-    render({ type: 'number', step: 5, min: 0, max: 10 });
+    renderField({ type: 'number', step: 5, min: 0, max: 10 });
     expect(numberInput()).toHaveAttribute('step', '5');
     expect(numberInput()).toHaveAttribute('min', '0');
     expect(numberInput()).toHaveAttribute('max', '10');
@@ -90,17 +71,14 @@ describe('TextField pivot — number path', () => {
 
   it('steps the value on click', async () => {
     const user = userEvent.setup();
-    render({ type: 'number', step: 1 }, 3);
+    renderField({ type: 'number', step: 1 }, 3);
     await user.click(screen.getByRole('button', { name: 'Increase value' }));
     expect(numberInput()).toHaveValue(4);
   });
 
-  it('DEFECT PIN — a Formik <Field> site never reaches this branch', () => {
-    // Delete when the `children` blocker is decided. Written as an assertion so
-    // the day the pivot starts honouring Formik sites, this test fails and says
-    // where to look, instead of the change landing on ~620 fields unannounced.
-    render({ type: 'number', children: undefined });
-    expect(screen.queryByRole('button', { name: 'Increase value' })).not.toBeInTheDocument();
-    expect(screen.getByRole('spinbutton', { name: /order/i }).className).toContain('MuiInputBase-input');
+  it('still falls back to MUI for a prop the Input cannot place', () => {
+    // The diagnostic ignores props with no value; it must still catch real ones.
+    renderField({ style: { marginTop: 20 } });
+    expect(screen.getByRole('textbox', { name: /order/i }).className).toContain('MuiInputBase-input');
   });
 });

--- a/opencti-platform/opencti-front/src/components/TextField.tsx
+++ b/opencti-platform/opencti-front/src/components/TextField.tsx
@@ -136,9 +136,17 @@ const TextField = (props: TextFieldProps) => {
   const forwardable = (k: string) => nativeAttrs.has(k)
     || k.startsWith('data-') || k.startsWith('aria-');
   // Abandon on anything unrecognised rather than dropping it silently.
-  const unplaceable = Object.keys(otherProps).filter(
-    (k) => !placeable.has(k) && !forwardable(k),
-  );
+  //
+  // Only props that CARRY A VALUE count. Formik's `Field` renders this
+  // component as `createElement(component, {field, form, ...props, className},
+  // children)` — three arguments, so React defines `props.children` even when
+  // the value is `undefined`, and `className` is spread unconditionally beside
+  // it. `children` is in neither set above, so keying off `Object.keys` made
+  // `unplaceable` non-empty at EVERY Formik site and sent all of them to the
+  // MUI fallback. An absent prop is not an unplaceable prop.
+  const unplaceable = Object.entries(otherProps)
+    .filter(([k, v]) => v !== undefined && !placeable.has(k) && !forwardable(k))
+    .map(([k]) => k);
 
   const outOfContract = props.multiline ? 'multiline'
     : props.select ? 'select'

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
@@ -1,8 +1,8 @@
 {
   "__generated": "GENERATED FILE — do not edit by hand. Regenerate from the filigran-design-system repo: pnpm generate:mui-bridge --product opencti --write-to-product.",
   "product": "opencti",
-  "themeCssHash": "sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da",
+  "themeCssHash": "sha256:4719a8a35ab7c376301f1b39942ad6a67ae93ec882a7bfa8c9e439ab0afdbd8e",
   "generator": "@filigran/design-system scripts/generate-mui-bridge.ts",
   "tsFile": "fds-tokens.generated.ts",
-  "tsFileSha256": "sha256:5ef4336b2ec8871efc207c9e661e6e039235a2f25196a051ca231e60f15db45e"
+  "tsFileSha256": "sha256:c01e9cf98d7b7e5c6a11863be4100b98449110a1f30aaea435c083190fbd8c01"
 }

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
@@ -6,7 +6,7 @@
  * fields. Wiring: fds-migration/TOKEN-MAPPING.md.
  *
  * Source: @filigran/design-system packages/filigran-design-system/src/tokens/theme.css
- * Theme.css content hash: sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da
+ * Theme.css content hash: sha256:4719a8a35ab7c376301f1b39942ad6a67ae93ec882a7bfa8c9e439ab0afdbd8e
  * Regenerate (from the filigran-design-system repo, not here):
  *   pnpm generate:mui-bridge --product opencti --write-to-product
  *
@@ -18,7 +18,7 @@
 
 export const FDS_META = {
   product: "opencti",
-  themeCssHash: "sha256:304c750b700156220e4718f647ef20d7fe7e5fa6a2985f3ec958d9a87ddd82da",
+  themeCssHash: "sha256:4719a8a35ab7c376301f1b39942ad6a67ae93ec882a7bfa8c9e439ab0afdbd8e",
   generator: "@filigran/design-system scripts/generate-mui-bridge.ts",
 } as const;
 
@@ -212,14 +212,14 @@ const colorsLight = {
   "--bg-elevation-highlight-layer-1": "#f2f2f3",
   "--bg-elevation-highlight-layer-2": "#e4e5e7",
   "--bg-elevation-highlight-layer-3": "#f4f4f6",
-  "--bg-elevation-hover": "#f4f4f6",
-  "--bg-elevation-hover-layer-0": "#f4f4f6",
+  "--bg-elevation-hover": "#cacbce",
+  "--bg-elevation-hover-layer-0": "#cacbce",
   "--bg-elevation-hover-layer-1": "#e4e5e7",
-  "--bg-elevation-hover-layer-2": "#f4f4f6",
-  "--bg-elevation-hover-layer-3": "#e4e5e7",
+  "--bg-elevation-hover-layer-2": "#cacbce",
+  "--bg-elevation-hover-layer-3": "#cacbce",
   "--bg-input-default": "#e4e5e7",
   "--bg-input-disabled": "#cacbce",
-  "--bg-input-hover": "#f4f4f6",
+  "--bg-input-hover": "#cacbce",
   "--border-alert-alert": "#f2be3a",
   "--border-alert-error": "#b8180a",
   "--border-alert-info": "#0079a8",
@@ -395,6 +395,10 @@ const scalars = {
   "--darkblue-700": "#0015a8",
   "--darkblue-800": "#000f75",
   "--darkblue-900": "#000842",
+  "--depth-lg": "16px",
+  "--depth-md": "8px",
+  "--depth-sm": "4px",
+  "--depth-xl": "20px",
   "--font-content-base": "\"IBM Plex Sans\"",
   "--font-content-base-bold": "\"IBM Plex Sans\"",
   "--font-content-base-link": "\"IBM Plex Sans\"",
@@ -529,10 +533,6 @@ const scalars = {
   "--red-800": "#570a05",
   "--red-900": "#3b0602",
   "--shadow-global-shadow": "0px 2px 4px 0px #00000066",
-  "--shadow-lg": "16px",
-  "--shadow-md": "8px",
-  "--shadow-sm": "4px",
-  "--shadow-xl": "20px",
   "--text-1": "10px",
   "--text-10": "42px",
   "--text-11": "52px",

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.test.tsx
@@ -32,7 +32,11 @@ describe('Component: FintelTemplateForm', () => {
       />,
     );
 
-    await user.type(screen.getByLabelText('Name *'), 'MyFintelTemplate');
+    // 'Name', not 'Name *': the library Input puts the required marker in its
+    // own `aria-hidden` span, so the asterisk is deliberately outside the
+    // accessible name. MUI concatenated it. `required` is still announced —
+    // through `aria-required` on the input.
+    await user.type(screen.getByLabelText('Name'), 'MyFintelTemplate');
     await user.click(screen.getByRole('button', { name: 'Create' }));
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith(

--- a/opencti-platform/opencti-front/tests_e2e/model/drafts.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/drafts.pageModel.ts
@@ -47,7 +47,11 @@ export default class DraftsPage {
     const createDraftDrawer = this.getCreateDraftDrawer();
     await expect(createDraftDrawer).toBeVisible();
 
-    await createDraftDrawer.getByTestId('draft-creation-form-name-input').locator('input').fill(name);
+    // No `.locator('input')` hop: the pivot forwards `data-*` to the library
+    // Input, which places everything but `className` on the native <input>
+    // itself. MUI put the attribute on the field's root wrapper, so the extra
+    // hop used to be required and now finds nothing.
+    await createDraftDrawer.getByTestId('draft-creation-form-name-input').fill(name);
 
     for (const member of authorizedMembers) {
       await this.accessRestriction.addAccess(member.name, member.permission);

--- a/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
@@ -6,6 +6,24 @@ export default class TextFieldPageModel {
   private readonly inputLocator: Locator;
   private readonly parentLocator: Locator;
 
+  /**
+   * The field's own root, derived from the input rather than from the label.
+   *
+   * `getByText(label).locator('..')` used to reach it, because MUI puts the
+   * <label> as a direct child of the FormControl that also holds the helper
+   * text. The library Input wraps its label in a row of its own, so that
+   * parent is the label row and the helper text is a level above it — which is
+   * why an assertion on 'This field is required' stopped resolving.
+   *
+   * Two hops up from the input lands on the field root under BOTH engines
+   * (library: input → div.relative → root; MUI: input → InputBase → FormControl),
+   * and unlike widening the search it stays scoped to this one field, so a
+   * message belonging to a sibling field can never satisfy the assertion.
+   */
+  private static fieldRootOf(input: Locator) {
+    return input.locator('..').locator('..');
+  }
+
   constructor(
     readonly page: Page,
     label: string,
@@ -31,10 +49,10 @@ export default class TextFieldPageModel {
       this.parentLocator = root.getByText(label).locator('..');
     } else if (type === 'text-no-label') {
       this.inputLocator = root.getByRole('textbox', { name: label });
-      this.parentLocator = root.getByText(label).locator('..');
+      this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     } else {
       this.inputLocator = root.getByLabel(label);
-      this.parentLocator = root.getByText(label).locator('..');
+      this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     }
   }
 

--- a/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/TextField.pageModel.ts
@@ -51,7 +51,14 @@ export default class TextFieldPageModel {
       this.inputLocator = root.getByRole('textbox', { name: label });
       this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     } else {
-      this.inputLocator = root.getByLabel(label);
+      // `.and(control)`: `getByLabel` matches accessible names by SUBSTRING, and
+      // the library's number stepper ships two buttons named "Increase value" /
+      // "Decrease value". On the observable creation form, whose own field is
+      // labelled `value`, the lookup went from one match to three. Constraining
+      // to the elements this model is actually about — the form control — drops
+      // the buttons without touching the label semantics, and without renaming
+      // anything on either side.
+      this.inputLocator = root.getByLabel(label).and(root.locator('input, textarea'));
       this.parentLocator = TextFieldPageModel.fieldRootOf(this.inputLocator);
     }
   }

--- a/opencti-platform/opencti-front/tests_e2e/model/form/userForm.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/form/userForm.pageModel.ts
@@ -12,8 +12,12 @@ export default class UserFormPage {
     return this.getNameInput().fill(name);
   }
 
+  // No `.getByLabel(...)` hop on either of these: the pivot forwards `data-*`
+  // to the library Input, which places everything but `className` on the
+  // native <input>. The test id IS the input now, where MUI put it on the
+  // field's root wrapper and the descendant lookup was needed.
   getEmailInput() {
-    return this.page.getByTestId('user-creation-email-address-input').getByLabel('Email address');
+    return this.page.getByTestId('user-creation-email-address-input');
   }
 
   async fillEmailInput(email: string) {
@@ -22,7 +26,7 @@ export default class UserFormPage {
   }
 
   getPasswordInput() {
-    return this.page.getByTestId('user-creation-password-input').getByLabel('Password');
+    return this.page.getByTestId('user-creation-password-input');
   }
 
   async fillPasswordInput(password: string) {

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=47baf699442f75658cd0381a0c0886523229bc1c"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/0afac06f22d24ae83f4301dbd3713cfdc403f67ff8467b2569b7c13e249b707cb1782289a30661b6fb05b8bdba007363a80f16a520428f74b661118ff3ade955
+  checksum: 10c0/c28cda3610b35a96d13b1d30205cf8285f607ac820686b14bcc02f339963cde67b86a39e09c2dcdb5a3c502fc4a75902782b5a1fd59773f17740d6d11dccca36
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=1f7c64c0142d584a8f7c857b63a7fa7a0a8dd0ca"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
**Stacked on #17983** (the Formik unblocker). Merge that one first — this branch
contains it.

`1f7c64c → 47baf69`. Two library commits, and unlike the previous bump this one
moves real token **values**: that bump's entire bridge diff was two hash lines,
this one changes five colours and renames four tokens.

| lib PR | what it lands |
|---|---|
| [#191](https://github.com/XTM-Foundation/filigran-design-system/pull/191) | the Select trigger's leading edge, 16px → 12px |
| [#188](https://github.com/XTM-Foundation/filigran-design-system/pull/188) | `--shadow-*` → `--depth-*`, and the light-mode hover layers darkened to gray-200 |

## Proven by bytes in the installed dist

`dist/tokens/theme.css` — the delivered token source, and the file the bridge
generator actually reads:

| | old pin `1f7c64c` | new pin `47baf69` |
|---|---|---|
| depth scale | `--shadow-sm/md/lg/xl: 4/8/16/20px` | `--depth-sm/md/lg/xl: 4/8/16/20px` |
| `.light` hover-layer-0 | `var(--gray-50)` | `var(--gray-200)` |
| `.light` hover-layer-2 | `var(--gray-50)` | `var(--gray-200)` |
| `.light` hover-layer-3 | `var(--gray-150)` | `var(--gray-200)` |

`dist/components/select/Select.mjs` now reads
`h-9 w-fit items-center justify-between gap-1 rounded-sm border pl-3 pr-2`, and
`rounded-sm border pl-4 pr-2` no longer occurs in it.

**#191 closes an asymmetry this stack opened.** When #189 landed, Input,
Textarea and the Combobox trigger took the 12px leading edge and Select did
not — the Figma frame had not moved yet. The first PR of this series recorded
that difference rather than smoothing it over. All four fields now agree.

### Two traps for anyone repeating the check

- `--shadow-sm` and `--shadow-md` **do still appear** in `dist/index.css`.
  Those are Tailwind's own built-in shadow scale
  (`0 1px 3px 0 #0000001a`), not the library's 4/8/16/20px depth tokens. Same
  namespace, different thing — grepping `index.css` for `--shadow-` reports a
  false negative on this bump.
- `--depth-*` is **absent** from `dist/index.css`, and that is correct:
  Tailwind v4 emits only the theme variables some utility references, and
  nothing uses a `depth-*` utility yet. `tokens/theme.css` is where they live.

## Bridge

Regenerated with `pnpm generate:mui-bridge --product opencti
--write-to-product`. Four renames and five value changes, nothing else:

    --bg-elevation-hover          #f4f4f6 -> #cacbce
    --bg-elevation-hover-layer-0  #f4f4f6 -> #cacbce
    --bg-elevation-hover-layer-2  #f4f4f6 -> #cacbce
    --bg-elevation-hover-layer-3  #e4e5e7 -> #cacbce
    --bg-input-hover              #f4f4f6 -> #cacbce
    --shadow-{sm,md,lg,xl}        -> --depth-{sm,md,lg,xl}

**`--bg-input-hover` is worth naming separately**: it follows the elevation
rebind, so *every field hover in light mode darkens*, not only row and menu
hovers. That is the widest-reaching visual effect in this PR.

**The rename is safe product-side, checked before bumping.** `--shadow-sm`,
`--shadow-md`, `--shadow-lg` and `--shadow-xl` occur nowhere in hand-written
product code and nothing reads those keys off the bridge — all four hits were
inside the generated file itself.

## Verification

| check | result |
|---|---|
| `yarn check-ts` | clean |
| `check-fds-conformity.mjs` | 41 checks, 0 issues |
| `check-accessible-names.mjs` | clean |
| `script/check-utility-classes.js` | clean |

E2E is read live on this PR's runs and fixed test-side; a red showing a real
product regression is reported, not patched.
