### PR TITLE
feat(fds): convert the Add filter picker to the library Combobox (#17799)

### DIFF
--- a/fds-migration/migration-state.json
+++ b/fds-migration/migration-state.json
@@ -339,6 +339,17 @@
       "files": [
         "opencti-platform/opencti-front/src/components/ViewSwitchingButtons.tsx"
       ]
+    },
+    {
+      "component": "Combobox",
+      "importFrom": "@filigran/design-system",
+      "guards": [
+        "imported-from-library"
+      ],
+      "reason": "night-2 visual pass: the `Add filter` picker. It never HOLDS a value -- picking an option adds a filter and the field empties -- so `value` is a literal null and ONLY a keystroke may write the input: in single mode the library answers a pick with setInputValue(getOptionLabel(option), \"select\"), and accepting that programmatic write left the field reading \"Label\" after the filter was added, so filling the same text a second time fired no input event and never reopened the panel. The name rides on `placeholder` + aria-label under `labelPosition=\"none\"`: the library renders labels ABOVE the control, and this one shares a flex row with an unlabelled search field. Covered by ListFilters.picker.test.tsx, which mirrors filters.pageModel's two-pass sequence.",
+      "files": [
+        "opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx"
+      ]
     }
   ]
 }

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.picker.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.picker.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import testRender, { createMockUserContext } from '../../../../utils/tests/test-render';
+
+vi.mock('../../../../relay/environment', () => ({
+  APP_BASE_PATH: '',
+  MESSAGING$: { messages$: { subscribe: () => ({}) } },
+  environment: {},
+  QueryRenderer: ({ render }: { render: (args: { props: null }) => React.ReactNode }) => render({ props: null }),
+  fetchQuery: vi.fn(),
+}));
+vi.mock('../../../../components/saved_filters/SavedFilters', () => ({ default: () => <div /> }));
+vi.mock('../../../../components/saved_filters/SavedFilterButton', () => ({ default: () => <div /> }));
+
+import ListFilters from './ListFilters';
+
+const schema = {
+  scos: [], sdos: [], smos: [], scrs: [],
+  schemaRelationsTypesMapping: new Map(),
+  schemaRelationsRefTypesMapping: new Map(),
+  filterKeysSchema: new Map(),
+};
+
+const props = (entityTypes: string[]) => ({
+  handleOpenFilters: vi.fn(),
+  handleCloseFilters: vi.fn(),
+  isOpen: false,
+  anchorEl: null,
+  availableFilterKeys: ['entity_type', 'name', 'objectLabel'],
+  filterElement: <div />,
+  entityTypes,
+  helpers: {
+    handleAddFilterWithEmptyValue: vi.fn(),
+    handleClearAllFilters: vi.fn(),
+  } as unknown as import('src/utils/filters/filtersHelpers-types').handleFilterHelpers,
+});
+
+describe('ListFilters — the Add filter picker', () => {
+  // Mirrors tests_e2e/model/filters.pageModel addFilterInDatatable, which
+  // searchOnDataEntitiesPerLabels runs TWICE against the same mounted field.
+  // The second pass is the regression: the library answers a pick by writing
+  // the chosen label back into the input, and if the product accepts that
+  // write the field never returns to empty -- so filling the same text again
+  // is a no-op, no input event fires, the panel never reopens and the option
+  // never appears.
+  it('returns to empty after a pick, so the same filter can be picked twice', () => {
+    testRender(<ListFilters {...props(['Stix-Core-Object'])} />, {
+      userContext: createMockUserContext({ schema }),
+    });
+    const input = screen.getByLabelText('Add filter') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'Label' } });
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toContain('Label');
+
+    fireEvent.click(screen.getAllByRole('option').find((o) => o.textContent === 'Label')!);
+    expect(input.value).toBe('');
+
+    fireEvent.change(input, { target: { value: 'Label' } });
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toContain('Label');
+  });
+
+  // The grouped branch (isNotUniqEntityTypes) is the one /dashboard/data/entities
+  // takes. Kept because it was the first hypothesis for the failure above and
+  // was wrong: grouping renders its options correctly.
+  it('renders options in both the grouped and ungrouped branches', () => {
+    const { unmount } = testRender(<ListFilters {...props(['Stix-Core-Object'])} />, {
+      userContext: createMockUserContext({ schema }),
+    });
+    fireEvent.click(screen.getByLabelText('Add filter'));
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(0);
+    unmount();
+
+    testRender(<ListFilters {...props(['Artifact'])} />, {
+      userContext: createMockUserContext({ schema }),
+    });
+    fireEvent.click(screen.getByLabelText('Add filter'));
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(0);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -5,8 +5,7 @@ import Popover from '@mui/material/Popover';
 import Tooltip from '@mui/material/Tooltip';
 import { RayEndArrow, RayStartArrow } from 'mdi-material-ui';
 import makeStyles from '@mui/styles/makeStyles';
-import TextField from '@mui/material/TextField';
-import MUIAutocomplete from '@mui/material/Autocomplete';
+import { Combobox, ComboboxContent, ComboboxControls, ComboboxField, ComboboxInput, ComboboxTrigger } from '@filigran/design-system';
 import { type handleFilterHelpers } from 'src/utils/filters/filtersHelpers-types';
 import { type SavedFiltersSelectionData } from 'src/components/saved_filters/SavedFilterSelection';
 import { useFormatter } from '../../../../components/i18n';
@@ -195,35 +194,67 @@ const ListFilters = ({
         </Tooltip>
       ) : (
         <>
-          <MUIAutocomplete
-            disabled={disabled}
+          {/* The picker never HOLDS a value: choosing an option adds a filter and
+              the field goes straight back to empty, which is why `value` is a
+              literal null rather than state. `placeholder` carries the name
+              instead of a <ComboboxLabel>: the library renders a label ABOVE the
+              control, and this control sits in a flex row beside the unlabelled
+              search field — a label here would make this the only tall item in
+              the row and re-open the very alignment defect the same pass asks to
+              fix. The accessible name is kept on the input. */}
+          <Combobox<OptionType>
             options={options as OptionType[]}
-            groupBy={isNotUniqEntityTypes ? (option) => option?.groupLabel ?? '' : undefined}
-            // The declared width was shrunk to 119px by the flex row, which cut the
-            // label off at 95px of the 101px it needs. flexShrink keeps it at 200.
-            sx={{ width: 200, flexShrink: 0 }}
+            labelPosition="none"
             value={null}
-            onChange={(_, selectOptionValue) => {
-              if (selectOptionValue?.value) handleChange(selectOptionValue.value);
+            onValueChange={(next) => {
+              const picked = Array.isArray(next) ? next[0] : next;
+              if (picked?.value) handleChange(picked.value);
+              setInputValue('');
             }}
+            disabled={disabled}
+            required={required}
+            groupBy={isNotUniqEntityTypes ? (option) => option?.groupLabel ?? '' : undefined}
+            getOptionLabel={(option) => option.label}
             inputValue={inputValue}
-            onInputChange={(_, newValue, reason) => {
-              if (reason === 'reset') {
+            // ONLY a keystroke may write this field. The picker holds no value,
+            // so its text is the user's typing and nothing else. In single mode
+            // the library answers a pick with
+            // `setInputValue(getOptionLabel(option), "select")` -- it writes the
+            // chosen label back into the input -- and accepting that write undid
+            // the clear below: the field kept saying "Label" after the filter was
+            // added, so filling "Label" a SECOND time changed nothing, fired no
+            // input event, never reopened the panel, and the option the page
+            // model waits for never appeared (_backgroundTask.spec.ts, second
+            // addLabelFilter). `clear` and `reset` are programmatic for the same
+            // reason, so the guard is on `type` rather than a list of exclusions.
+            onInputChange={(newValue, meta) => {
+              if (meta.cause !== 'type') {
                 return;
               }
               setInputValue(newValue);
             }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                variant="outlined"
-                size="small"
-                label={placeholder}
+          >
+            {/* The declared width was shrunk to 119px by the flex row, which cut
+                the label off at 95px of the 101px it needs. flexShrink keeps it
+                at 200. */}
+            <ComboboxField style={{ width: 200, flexShrink: 0 }}>
+              <ComboboxInput
+                placeholder={placeholder}
+                aria-label={placeholder}
                 required={required}
               />
-            )}
-            renderOption={(props, option) => <li {...props}>{option.label}</li>}
-          />
+              <ComboboxControls>
+                {/* No aria-label here on purpose. Naming the trigger after the
+                    field too gave TWO elements the accessible name "Add filter"
+                    -- the input and the chevron -- and getByLabel('Add filter')
+                    in filters.pageModel then failed strict mode. The library
+                    already names it "Toggle options", which is what every other
+                    converted Combobox in this product relies on. */}
+                <ComboboxTrigger />
+              </ComboboxControls>
+            </ComboboxField>
+            <ComboboxContent listAriaLabel={placeholder} />
+          </Combobox>
           {!hideSavedFilters && isDatatable && variant === 'default' && (
             <SavedFilters
               currentSavedFilter={currentSavedFilter}


### PR DESCRIPTION
Rebased onto the merged tip. **The e2e failure that kept this out of #17990 is
diagnosed and fixed**, with a regression test.

## The conversion

"Ajouter un filtre" becomes the library `Combobox`. It never *holds* a value —
picking an option adds a filter and the field empties again — so `value` is a
literal null. The name rides on `placeholder` plus an `aria-label` under
`labelPosition="none"`: the library renders labels *above* the control, and this
one shares a flex row with an unlabelled search field, where a label would make
it the only tall item and re-open the alignment defect the same pass asks to fix.

## The bug, and why my first guess was wrong

I had guessed the **grouped** option branch failed to render its `role="option"`
rows. That was wrong, and the test in this PR proves it: grouping renders its
options fine.

The real cause is one line of the library's single-mode `toggle`:

```js
onValueChange(option, META("select", event));
setInputValue(getOptionLabel(option), "select", event);   // writes the label BACK
```

The picker cleared the field on pick, but its guard on incoming writes only
ignored cause `reset` — so it accepted the `select` write and the clear was
immediately undone. The field kept reading `"Label"` after the filter was added.
`filters.pageModel` then fills `"Label"` a **second** time, the value does not
change, **no input event fires**, the panel never reopens, and the option it
waits for never appears.

That is exactly `_backgroundTask.spec.ts`'s second `addLabelFilter` — and it
explains the asymmetry: group0 picks **once** and passed; group1 picks **twice**
and did not.

The guard is now on `type` rather than a list of exclusions: only a keystroke may
write this field, because its text *is* the user's typing. The library's own doc
for `ComboboxChangeCause` says the same — branch on a keystroke, never on a
selection or a programmatic write.

## Test

`ListFilters.picker.test.tsx` mirrors the page model's two-pass sequence and
fails without the fix. It also keeps the grouped/ungrouped case that disproved
the first hypothesis, so nobody re-runs that guess.

**Not a library gap** — nothing to add to `LIBRARY-FEEDBACK.md`. The library
behaved as documented; the product was reading the wrong cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)