### PR TITLE
feat(fds): bump the pin to 23e0826 and take the small EE chip (#17905)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=23e082608838ab3c312186df9aae7bd0b4e0e81f",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -168,8 +168,7 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             disabled={disabled}
           >
             {t_i18n('AI Insights')}
-            {/* TODO(ee-small): take the Chip EE small variant here once the library ships it — night-2 pass, wires up after the next pin bump. */}
-            {showEEChip && <EEChip feature="AI Insights" />}
+            {showEEChip && <EEChip feature="AI Insights" size="sm" />}
           </Button>
         )}
       </span>

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
@@ -13,6 +13,12 @@ const EE_CHIP_GAP: CSSProperties = { marginInlineStart: 6 };
 interface EEChipProps {
   feature?: string;
   /**
+   * `sm` is the library's small EE chip (lib #192). The axis is EE-scoped in
+   * the design and in the library, which is exactly this component's scope --
+   * every chip here is `severity="ee"`, so `sm` is always legal.
+   */
+  size?: 'md' | 'sm';
+  /**
    * Default `true`: the chip renders as a real `<button>` that opens the EE
    * dialog. The legacy marker was a `<div>` carrying an `onClick` and no role,
    * so it was unreachable by keyboard -- the conversion fixes that on its own.
@@ -25,7 +31,7 @@ interface EEChipProps {
 }
 
 const EEChip = React.forwardRef<HTMLElement, EEChipProps>((
-  { feature, clickable = true, style },
+  { feature, clickable = true, size = 'md', style },
   ref,
 ) => {
   const isEnterpriseEdition = useEnterpriseEdition();
@@ -46,6 +52,7 @@ const EEChip = React.forwardRef<HTMLElement, EEChipProps>((
         ref={ref}
         label="EE"
         severity="ee"
+        size={size}
         onClick={clickable ? onClick : undefined}
         style={{ ...EE_CHIP_GAP, ...style }}
       />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
@@ -280,8 +280,7 @@ const StixCoreObjectContentFiles: FunctionComponent<StixCoreObjectContentFilesPr
         <ContentBloc
           title={(
             <>
-              {/* TODO(ee-small): take the Chip EE small variant here once the library ships it — night-2 pass, wires up after the next pin bump. */}
-              {t_i18n('Generated finished intelligence')} {!isEnterpriseEdition && <EEChip />}
+              {t_i18n('Generated finished intelligence')} {!isEnterpriseEdition && <EEChip size="sm" />}
               {isEnterpriseEdition
                 && (
                   <Tooltip

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
@@ -632,8 +632,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
                           primary={(
                             <>
                               {t_i18n('AI Powered')}
-                              {/* TODO(ee-small): take the Chip EE small variant here once the library ships it — night-2 pass, wires up after the next pin bump. */}
-                              <EEChip />
+                              <EEChip size="sm" />
                             </>
                           )}
                         />
@@ -650,8 +649,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
                         primary={(
                           <>
                             {t_i18n('Remove Filigran logos')}
-                            {/* TODO(ee-small): take the Chip EE small variant here once the library ships it — night-2 pass, wires up after the next pin bump. */}
-                            <EEChip />
+                            <EEChip size="sm" />
                           </>
                         )}
                       />

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
@@ -40,8 +40,7 @@ const SettingsAnalytics: FunctionComponent<SettingsAnalyticsProps> = ({
       {t_i18n('Third-party analytics')}
 
       <Stack direction="row" gap={1}>
-        {/* TODO(ee-small): take the Chip EE small variant here once the library ships it — night-2 pass, wires up after the next pin bump. */}
-        <EEChip />
+        <EEChip size="sm" />
         <Tooltip
           title={(
             <>

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=23e082608838ab3c312186df9aae7bd0b4e0e81f":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=47baf699442f75658cd0381a0c0886523229bc1c"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=23e082608838ab3c312186df9aae7bd0b4e0e81f"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/c28cda3610b35a96d13b1d30205cf8285f607ac820686b14bcc02f339963cde67b86a39e09c2dcdb5a3c502fc4a75902782b5a1fd59773f17740d6d11dccca36
+  checksum: 10c0/c250182bcc8a1efe1ab7b6cd162f067119a7b25cbe453e9d33a118667f63b43fc431cbc9f9e0d9111f44eafbefd595ee9f48687ace5f2bca6cb8ae421b6d4824
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=47baf699442f75658cd0381a0c0886523229bc1c"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=23e082608838ab3c312186df9aae7bd0b4e0e81f"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
Closes the one item the night-2 pass could only *mark*.

The five sites it named carried a greppable `TODO(ee-small)` waiting for the
library variant. Lib #192 ships it, so the markers are gone and the sites take
it. `grep -rn "TODO(ee-small)"` now returns nothing.

- `AIInsights.tsx` — the Aperçu IA chip
- `StixCoreObjectContentFiles.tsx` — "Renseignements finis générés"
- `Settings.tsx` — two rows (AI Powered, Remove Filigran logos)
- `SettingsAnalytics.tsx` — "Analyse par des tiers"

## On the prop

`size="sm"` is EE-scoped in the design and in the library — its own doc says so,
and the library warns a caller who asks for it outside that scope. That scope is
exactly this component: every chip `EEChip` renders is `severity="ee"`, so the
axis is always legal here.

It is exposed as an **opt-in prop defaulting to `md`** rather than applied to
every EE chip, because the pass named five sites, not all of them.

Verified on the installed build rather than the changelog: `ChipSize` is
`"md" | "sm"` in the shipped types and the small geometry is in the shipped Chip
bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)