### PR TITLE
feat(fds): homogenise the fields, drawers and integration surfaces (#17728)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -490,6 +490,25 @@ const ThemeDark = (
         },
       },
     },
+    // Interim homogenisation (night-3 visual pass). Every MUI field that is
+    // OUTLINED now sits on the same background as a library Input --
+    // `--bg-input-default` -- so the fields still waiting for a conversion read
+    // as one family with the converted ones instead of as a second set.
+    //
+    // Deliberately scoped to the outlined variant, and deliberately NOT paired
+    // with a flip of `MuiTextField.defaultProps.variant` to `outlined`: that
+    // one line would change the height, the label behaviour and the hit area of
+    // every remaining MUI field at once, which is a change to look at on
+    // screenshots before it lands, and e2e resolves many of those fields by
+    // their label. The fields the pass named by hand are switched at their own
+    // call sites instead.
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: FDS.colors.dark['--bg-input-default'],
+        },
+      },
+    },
     MuiTextField: {
       defaultProps: {
         variant: 'standard',

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -488,6 +488,25 @@ const ThemeLight = (
         },
       },
     },
+    // Interim homogenisation (night-3 visual pass). Every MUI field that is
+    // OUTLINED now sits on the same background as a library Input --
+    // `--bg-input-default` -- so the fields still waiting for a conversion read
+    // as one family with the converted ones instead of as a second set.
+    //
+    // Deliberately scoped to the outlined variant, and deliberately NOT paired
+    // with a flip of `MuiTextField.defaultProps.variant` to `outlined`: that
+    // one line would change the height, the label behaviour and the hit area of
+    // every remaining MUI field at once, which is a change to look at on
+    // screenshots before it lands, and e2e resolves many of those fields by
+    // their label. The fields the pass named by hand are switched at their own
+    // call sites instead.
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: FDS.colors.light['--bg-input-default'],
+        },
+      },
+    },
     MuiTextField: {
       defaultProps: {
         variant: 'standard',

--- a/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@mui/styles';
 import { Theme } from '../../Theme';
+import { FDS } from '../../fds-tokens.generated';
 import { Stack, Typography } from '@mui/material';
 import IconButton from '../button/IconButton';
 import { Close } from '@mui/icons-material';
@@ -13,11 +14,19 @@ interface DrawerHeaderProps {
 
 const DrawerHeader = ({ title, onClose, endContent }: DrawerHeaderProps) => {
   const theme = useTheme<Theme>();
+  // Figma node 5415-3010 (Design_System_2026) draws the drawer on elevation
+  // LAYER 2, not on the bare alias. Read straight off that node, the header is
+  // #101b33 and the body #13213e in dark -- which are `-layer-2`, while the
+  // unsuffixed `--bg-elevation-*` aliases resolve to layer 0 (#070d18). Two
+  // independent hexes both landing on layer 2 is what fixes the layer; taking
+  // the bare alias would have painted the drawer a full step too dark.
+  // Colours only: the structural conversion to a library drawer comes later.
+  const fds = theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark;
   return (
     <Stack
       direction="row"
       sx={{
-        backgroundColor: theme.palette.background.secondary,
+        backgroundColor: fds['--bg-elevation-heading-layer-2'],
         paddingX: 3,
         paddingY: 2,
         alignItems: 'center',

--- a/opencti-platform/opencti-front/src/components/common/input/DatePicker.tsx
+++ b/opencti-platform/opencti-front/src/components/common/input/DatePicker.tsx
@@ -21,7 +21,8 @@ const DatePicker: React.FC<DatePickerProps<Date>> = ({
           ...slotProps?.textField,
           sx: {
             '& .MuiOutlinedInput-root': {
-              backgroundColor: theme.palette.background.secondary,
+              // background comes from the theme's MuiOutlinedInput override,
+              // which paints every outlined field with the library input token.
               '& fieldset': {
                 borderColor: value ? theme.palette.border.secondary : 'transparent',
               },

--- a/opencti-platform/opencti-front/src/components/common/input/DateTimePicker.tsx
+++ b/opencti-platform/opencti-front/src/components/common/input/DateTimePicker.tsx
@@ -21,7 +21,8 @@ const DateTimePicker: React.FC<DateTimePickerProps<Date>> = ({
           ...slotProps?.textField,
           sx: {
             '& .MuiOutlinedInput-root': {
-              backgroundColor: theme.palette.background.secondary,
+              // background comes from the theme's MuiOutlinedInput override,
+              // which paints every outlined field with the library input token.
               '& fieldset': {
                 borderColor: value ? theme.palette.border.secondary : 'transparent',
               },

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -4,6 +4,7 @@ import DrawerMUI from '@mui/material/Drawer';
 import Fab from '@mui/material/Fab';
 import { createStyles, useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
+import { FDS } from '../../../../components/fds-tokens.generated';
 import classNames from 'classnames';
 import React, { CSSProperties, forwardRef, isValidElement, useEffect, useState } from 'react';
 import { SubscriptionAvatars } from '../../../../components/Subscription';
@@ -244,6 +245,9 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
               }),
               paddingTop: `${bannerHeightNumber}px`,
               paddingBottom: `${bannerHeightNumber}px`,
+              // The sheet itself, so the banner gutters above and below the
+              // body match it instead of showing MUI's own Paper colour.
+              backgroundColor: (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark)['--bg-elevation-default-layer-2'],
             },
           },
         }}
@@ -263,7 +267,10 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
           className={classes.container}
           style={{
             ...containerStyle,
-            backgroundColor: theme.palette.background.drawer,
+            // Figma node 5415-3010: the drawer body is elevation LAYER 2
+            // (#13213e dark), not the bare `--bg-elevation-default` alias,
+            // which resolves to layer 0 (#070d18) -- a full step too dark.
+            backgroundColor: (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark)['--bg-elevation-default-layer-2'],
           }}
         >
           {renderSubHeader()}

--- a/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
@@ -30,6 +30,7 @@ import Loader, { LoaderVariant } from '../../../components/Loader';
 import PageContainer from '../../../components/PageContainer';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import useGranted, { INGESTION, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE, MODULES } from '../../../utils/hooks/useGranted';
+import { paperBg, paperBorder } from './paperSurface';
 
 export type IntegrationsTab = 'deployed' | 'available';
 
@@ -154,8 +155,8 @@ const IntegrationsHero = ({ deployedCount }: IntegrationsHeroProps) => {
         position: 'relative',
         overflow: 'hidden',
         borderRadius: 1,
-        border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-        backgroundColor: theme.palette.background.paper,
+        border: `1px solid ${paperBorder(theme)}`,
+        backgroundColor: paperBg(theme),
         padding: 3,
       }}
     >

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
@@ -16,6 +16,7 @@ import { useFormatter } from '../../../../components/i18n';
 import useGranted, { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { paperBorder } from '../paperSurface';
 
 // Shared column geometry between the header row and the lines, mirroring the
 // deployed tab lines view: the name column absorbs the remaining space and
@@ -55,7 +56,7 @@ export const AvailableIntegrationLinesHeader = () => {
         paddingInline: 1.5,
         paddingBlock: 1,
         backgroundColor: alpha(theme.palette.text.primary, 0.02),
-        borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+        borderBottom: `1px solid ${paperBorder(theme)}`,
       }}
     >
       <Typography component="div" sx={{ ...headerCellSx, flex: 1, minWidth: 0 }}>

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/BuiltInIntegrationCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/BuiltInIntegrationCard.tsx
@@ -10,6 +10,7 @@ import { useFormatter } from '../../../../components/i18n';
 import useGranted, { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import Card from '../../../../components/common/card/Card';
+import { paperBorder } from '../paperSurface';
 
 export interface BuiltInIntegrationCardProps {
   definition: BuiltInIntegrationDefinition;
@@ -31,7 +32,7 @@ const BuiltInIntegrationCard = ({ definition, deploymentCount, onClickCreate }: 
       sx={{
         height: '100%',
         '& .MuiCard-root': {
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+          border: `1px solid ${paperBorder(theme)}`,
           transition: 'transform 0.3s ease-in-out, border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
         },
         '&:hover .MuiCard-root': {

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Box, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
 import { ViewListOutlined, ViewModuleOutlined, WidgetsOutlined } from '@mui/icons-material';
 import Grid from '@mui/material/Grid2';
-import { alpha, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { useConnectorManagerStatus } from '@components/data/connectors/ConnectorManagerStatusContext';
 import IngestionCatalogCard from '@components/integrations/catalog/IngestionCatalogCard';
 import IngestionCatalogConnectorCreation from '@components/integrations/catalog/IngestionCatalogConnectorCreation';
@@ -28,6 +28,7 @@ import { IntegrationsData } from '@components/integrations/Integrations';
 import { useFormatter } from '../../../../components/i18n';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import SearchInput from '../../../../components/SearchInput';
+import { paperBg, paperBorder } from '../paperSurface';
 
 type AvailableViewMode = 'cards' | 'lines';
 
@@ -220,7 +221,7 @@ const IntegrationsAvailable = ({ data }: IntegrationsAvailableProps) => {
               label={t_i18n('Sort by')}
               value={sort}
               onChange={(event) => setSort(event.target.value as CatalogSortMode)}
-              sx={{ width: 200, backgroundColor: theme.palette.background.paper }}
+              sx={{ width: 200, backgroundColor: paperBg(theme) }}
             >
               <MenuItem value="name">{t_i18n('Name (A-Z)')}</MenuItem>
               <MenuItem value="deployed">{t_i18n('Most deployed')}</MenuItem>
@@ -232,7 +233,7 @@ const IntegrationsAvailable = ({ data }: IntegrationsAvailableProps) => {
               exclusive
               value={view}
               onChange={handleViewChange}
-              sx={{ backgroundColor: theme.palette.background.paper }}
+              sx={{ backgroundColor: paperBg(theme) }}
             >
               <ToggleButton value="cards" aria-label="cards" data-testid="available-view-cards">
                 <Tooltip title={t_i18n('Cards view')}>
@@ -263,8 +264,8 @@ const IntegrationsAvailable = ({ data }: IntegrationsAvailableProps) => {
                       <Box
                         sx={{
                           borderRadius: 1,
-                          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-                          backgroundColor: theme.palette.background.paper,
+                          border: `1px solid ${paperBorder(theme)}`,
+                          backgroundColor: paperBg(theme),
                           overflow: 'hidden',
                         }}
                       >

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
@@ -16,6 +16,7 @@ import Security from '../../../../utils/Security';
 import Card from '../../../../components/common/card/Card';
 import FiligranIcon from '@components/common/FiligranIcon';
 import { LogoFiligranIcon } from 'filigran-icon';
+import { paperBorder } from '../paperSurface';
 
 export interface IngestionCatalogCardProps {
   node: IngestionConnector;
@@ -162,7 +163,7 @@ const IngestionCatalogCard = ({
       sx={{
         height: '100%',
         '& .MuiCard-root': {
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+          border: `1px solid ${paperBorder(theme)}`,
           transition: 'transform 0.3s ease-in-out, border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
         },
         '&:hover .MuiCard-root': {

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogFacetSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogFacetSidebar.tsx
@@ -14,6 +14,7 @@ import {
   CatalogStatusFacet,
 } from '@components/integrations/catalog/hooks/useIngestionCatalogFilters';
 import { useFormatter } from '../../../../components/i18n';
+import { paperBg, paperBorder } from '../paperSurface';
 
 export const useCatalogStatusLabel = () => {
   const { t_i18n } = useFormatter();
@@ -235,8 +236,8 @@ const IngestionCatalogFacetSidebar = ({
           gap: 2,
           padding: 2,
           borderRadius: 1,
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-          backgroundColor: theme.palette.background.paper,
+          border: `1px solid ${paperBorder(theme)}`,
+          backgroundColor: paperBg(theme),
           maxHeight: { xs: 'none', md: `calc(100vh - ${theme.spacing(20)})` },
           overflowY: { xs: 'visible', md: 'auto' },
         }}

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedFacetSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedFacetSidebar.tsx
@@ -15,6 +15,7 @@ import {
   DeployedStatusFacet,
 } from '@components/integrations/deployed/useDeployedIntegrationsFilters';
 import { useFormatter } from '../../../../components/i18n';
+import { paperBg, paperBorder } from '../paperSurface';
 
 const STATUS_FACET_ICONS: Record<DeployedStatusFacet, SvgIconComponent> = {
   active: PlayCircleOutlined,
@@ -111,8 +112,8 @@ const DeployedFacetSidebar = ({
           gap: 2,
           padding: 2,
           borderRadius: 1,
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-          backgroundColor: theme.palette.background.paper,
+          border: `1px solid ${paperBorder(theme)}`,
+          backgroundColor: paperBg(theme),
           maxHeight: { xs: 'none', md: `calc(100vh - ${theme.spacing(20)})` },
           overflowY: { xs: 'visible', md: 'auto' },
         }}

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
@@ -10,6 +10,7 @@ import { DeployedIntegrationItem } from '@components/integrations/deployed/useDe
 import { useFormatter } from '../../../../components/i18n';
 import Card from '../../../../components/common/card/Card';
 import ItemBoolean from '../../../../components/ItemBoolean';
+import { paperBorder } from '../paperSurface';
 
 interface StatusDotProps {
   item: DeployedIntegrationItem;
@@ -101,7 +102,7 @@ const DeployedIntegrationCard = ({ item, onChange }: DeployedIntegrationCardProp
       sx={{
         height: '100%',
         '& .MuiCard-root': {
-          border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+          border: `1px solid ${paperBorder(theme)}`,
           transition: 'transform 0.3s ease-in-out, border-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
         },
         '&:hover .MuiCard-root': {

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
@@ -10,6 +10,7 @@ import { DeployedIntegrationItem } from '@components/integrations/deployed/useDe
 import { useFormatter } from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { paperBorder } from '../paperSurface';
 
 // Shared column geometry between the header row and the lines, so every
 // section renders as a proper aligned table. Widths are percentages of the
@@ -53,7 +54,7 @@ export const DeployedIntegrationLinesHeader = () => {
         paddingInline: 1.5,
         paddingBlock: 1,
         backgroundColor: alpha(theme.palette.text.primary, 0.02),
-        borderBottom: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+        borderBottom: `1px solid ${paperBorder(theme)}`,
       }}
     >
       <Typography component="div" sx={{ ...headerCellSx, flex: 1, minWidth: 0 }}>
@@ -228,7 +229,7 @@ const DeployedIntegrationLine = ({ item, onChange }: DeployedIntegrationLineProp
                   : {
                       color: theme.palette.text.secondary,
                       backgroundColor: alpha(theme.palette.text.primary, 0.04),
-                      border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+                      border: `1px solid ${paperBorder(theme)}`,
                     }),
               }}
             >

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, Suspense, useCallback, useEffect, useMemo, useState
 import { Link, useSearchParams } from 'react-router-dom';
 import { Box, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid2';
-import { alpha, useTheme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
 import { ViewListOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import { useQueryLoader } from 'react-relay';
 import { interval } from 'rxjs';
@@ -26,6 +26,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import SearchInput from '../../../../components/SearchInput';
 import useGranted, { MODULES } from '../../../../utils/hooks/useGranted';
 import { FIVE_SECONDS } from '../../../../utils/Time';
+import { paperBg, paperBorder } from '../paperSurface';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -160,7 +161,7 @@ const IntegrationsDeployedContent = ({
             label={t_i18n('Sort by')}
             value={sort}
             onChange={(event) => setSort(event.target.value as DeployedSortMode)}
-            sx={{ width: 200, backgroundColor: theme.palette.background.paper }}
+            sx={{ width: 200, backgroundColor: paperBg(theme) }}
           >
             <MenuItem value="name">{t_i18n('Name (A-Z)')}</MenuItem>
             <MenuItem value="status">{t_i18n('Status')}</MenuItem>
@@ -173,7 +174,7 @@ const IntegrationsDeployedContent = ({
             exclusive
             value={view}
             onChange={handleViewChange}
-            sx={{ backgroundColor: theme.palette.background.paper }}
+            sx={{ backgroundColor: paperBg(theme) }}
           >
             <ToggleButton value="cards" aria-label="cards" data-testid="integrations-view-cards">
               <Tooltip title={t_i18n('Cards view')}>
@@ -230,8 +231,8 @@ const IntegrationsDeployedContent = ({
                     <Box
                       sx={{
                         borderRadius: 1,
-                        border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-                        backgroundColor: theme.palette.background.paper,
+                        border: `1px solid ${paperBorder(theme)}`,
+                        backgroundColor: paperBg(theme),
                         overflow: 'hidden',
                       }}
                     >

--- a/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
@@ -31,6 +31,7 @@ import TitleMainEntity from '../../../../components/common/typography/TitleMainE
 import useConnectedDocumentModifier from '../../../../utils/hooks/useConnectedDocumentModifier';
 import Security from '../../../../utils/Security';
 import useGranted, { INGESTION_SETINGESTIONS, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE, MODULES } from '../../../../utils/hooks/useGranted';
+import { paperBg } from '../paperSurface';
 
 const feedDetailSyncQuery = graphql`
   query FeedDetailSyncQuery($id: String!) {
@@ -348,7 +349,7 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
               justifyContent: 'center',
               borderRadius: 1,
               border: `1px solid ${theme.palette.divider}`,
-              backgroundColor: theme.palette.background.paper,
+              backgroundColor: paperBg(theme),
             }}
           >
             <Icon sx={{ fontSize: 28, color: theme.palette.primary.main }} />

--- a/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
@@ -1,0 +1,26 @@
+import type { Theme } from '@mui/material/styles';
+import { FDS } from '../../../components/fds-tokens.generated';
+
+/**
+ * The library `Paper`'s own surface, for the integration boxes that are not
+ * converted to `<Paper>` yet.
+ *
+ * The visual pass asks these to "add the library paper, or at least simulate
+ * the same style (bg + border)". Simulating is what this is: the two values
+ * below are the ones the shipped `Paper` paints -- `bg-elevation-default` and
+ * `border-elevation-subtle-soft`, read off the component's own build -- rather
+ * than an eyeballed approximation of them. They live in one place so the
+ * structural conversion later is a find-and-replace on this helper, not on
+ * fourteen sites.
+ *
+ * What they replace is `alpha(theme.palette.text.primary, 0.08)` over
+ * `background.paper`: a border derived from the TEXT colour, which is why these
+ * boxes never quite matched a real Paper.
+ */
+const fdsFor = (theme: Theme) => (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark);
+
+/** Background of a library Paper. */
+export const paperBg = (theme: Theme) => fdsFor(theme)['--bg-elevation-default'];
+
+/** Border colour of a library Paper — pass it to `border`/`borderBottom`. */
+export const paperBorder = (theme: Theme) => fdsFor(theme)['--border-elevation-subtle-soft'];


### PR DESCRIPTION
PR 2 of the visual pass — make the not-yet-converted surfaces read as one family
with the converted ones. **Colours only**; the structural conversions come later.

## Drawers

Figma node `5415-3010` draws the drawer on elevation **layer 2**, not on the
bare alias. Read straight off that node, the header is `#101b33` and the body
`#13213e` in dark — and those are the `-layer-2` tokens, while the unsuffixed
`--bg-elevation-*` aliases resolve to layer 0 (`#070d18`).

Two independent hexes both landing on layer 2 is what fixes the layer. Taking
the bare alias would have painted every drawer a full step too dark — the
documented trap with these tokens. The sheet itself takes the body colour too,
so the banner gutters above and below stop showing MUI's own Paper colour.

## Outlined fields

Every **outlined** MUI field now sits on `--bg-input-default`, the library
Input's own background, through one theme override rather than per site. The
date and time pickers drop the background they each set by hand and inherit it.

**Deliberately not paired with flipping `MuiTextField.defaultProps.variant` to
`outlined`.** That one line changes the height, label behaviour and hit area of
every remaining MUI field at once — worth seeing on screenshots before it lands,
and e2e resolves many of those fields by their label. Left as a human call.

## Integration surfaces

Fourteen boxes drew a border from `alpha(theme.palette.text.primary, 0.08)` over
`background.paper` — a border derived from the **text** colour, which is why
they never quite matched a real Paper.

They now share one helper, `paperSurface.ts`, carrying the two values the
shipped `Paper` actually paints (`--bg-elevation-default`,
`--border-elevation-subtle-soft`, read off the component's own build). One place
to change when these become real `<Paper>`s, instead of fourteen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)