### PR TITLE
fix(fds): favorites spacing, the All entities title, trigger row (#17664)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -253,7 +253,10 @@ class ListLines extends Component {
             )}
             <div className={classes.filler} />
 
-            <div className={classes.views} style={{ display: 'flex', gap: 8 }}>
+            {/* alignItems: the row's own container centres its children, but
+                this inner one did not, so the buttons stretched to the row
+                height instead of sitting on the filters' centre line. */}
+            <div className={classes.views} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
 
               {numberOfElements && (
                 <div

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmark.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmark.jsx
@@ -59,6 +59,9 @@ const StixDomainObjectBookmarkComponent = ({ node }) => {
           '.MuiCardHeader-subheader': {
             fontSize: 12,
             color: theme.palette.text.secondary,
+            // 4px between the card title and its subtitle. The secondary tone
+            // the pass also asks for was already in place.
+            marginTop: '4px',
           },
         }}
         action={(

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmarks.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectBookmarks.jsx
@@ -39,7 +39,7 @@ class StixDomainObjectBookmarksComponent extends Component {
           <Typography
             variant="h4"
             gutterBottom={true}
-            style={{ padding: '0 0 5px 18px', float: 'left' }}
+            style={{ padding: '0 0 8px 18px', float: 'left' }}
           >
             {t('Favorite entities')}
           </Typography>
@@ -62,6 +62,20 @@ class StixDomainObjectBookmarksComponent extends Component {
             DummyCardComponent={<StixDomainObjectBookmarkDummy />}
             rowHeight={112}
           />
+          {/* The sibling title the pass asks for, under the favourites block:
+              same shape as "Favorite entities", 16px below the favourite cards
+              and 8px above the entity cards it labels. It lives here rather
+              than in the five *Cards pages because this component already
+              renders nothing when there are no favourites, so the title appears
+              exactly when the block it belongs under does -- and the two
+              spacings stay in one place. */}
+          <Typography
+            variant="h4"
+            gutterBottom={true}
+            style={{ padding: '0 0 8px 18px', margin: '16px 0 0 0' }}
+          >
+            {t('All entities')}
+          </Typography>
         </div>
       );
     }

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerCreation.tsx
@@ -1,7 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
 import Button from '@common/button/Button';
-import { useTheme } from '@mui/styles';
-import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 import { TriggersLinesPaginationQuery$variables } from './__generated__/TriggersLinesPaginationQuery.graphql';
 import TriggerDigestCreation from './TriggerDigestCreation';
@@ -27,7 +25,6 @@ const TriggerCreation: FunctionComponent<TriggerCreationProps> = ({
   open,
 }) => {
   const { t_i18n } = useFormatter();
-  const theme = useTheme<Theme>();
   // Live
   const [openLive, setOpenLive] = useState(false);
   const handleOpenCreateLive = () => {
@@ -40,8 +37,11 @@ const TriggerCreation: FunctionComponent<TriggerCreationProps> = ({
   };
   return (
     <>
+      {/* No marginRight: the row that holds these two buttons is a flex
+          container with `gap: 8`, so an 8px margin on top of it made the pair
+          16px apart -- the "trop éloignés" in the pass. The gap is the row's
+          to own. */}
       <Button
-        sx={{ marginRight: theme.spacing(1) }}
         onClick={handleOpenCreateDigest}
       >
         {t_i18n('', {


### PR DESCRIPTION
The small, many spacing items from the pass.

## Favourites

- 8px under the "Favorite entities" title
- 4px between a card's title and its subtitle (the secondary tone the pass also
  asks for was already in place)
- the sibling title it asks for under the block — same shape as "Favorite
  entities", **16px** below the favourite cards and **8px** above the entity
  cards it labels

That title lives in `StixDomainObjectBookmarks` rather than in the five `*Cards`
pages that mount it: the component already renders nothing when there are no
favourites, so the title appears exactly when the block it sits under does, and
both spacings stay in one place.

`All entities` needed **no new key** — it already exists in all nine locales, so
it follows the existing translations rather than introducing a second wording.

## The two trigger buttons

They were **16px** apart, not 8. The row holding them is a flex container with
`gap: 8`, and `TriggerCreation` added `marginRight: theme.spacing(1)` on top of
it, so the two spacings stacked. The margin goes; the gap is the row's to own.

## And their vertical alignment

The filter row centres its children, but the inner container holding the view
switcher and the create buttons declared `display: flex` with **no
`alignItems`**, so its children stretched to the row height instead of sitting
on the filters' centre line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)