### PR TITLE
fix(fds): route the last number fields through the Input pivot (#17926)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
@@ -22,9 +22,15 @@ const useStyles = makeStyles({
 });
 
 /**
- * Composition rule: the EE badge never sits INSIDE a button. It is a sibling at
- * a 4px gap to the button's right, so each keeps its own box. The button owns
- * the action, so the badge stays inert.
+ * Composition: the EE badge is a sibling at a 4px gap to the button's right, so
+ * each keeps its own box. The button owns the action, so the badge stays inert.
+ *
+ * NOTE: the "never INSIDE a button" rule this comment used to state as doctrine
+ * was REVERSED by the designer during the night-2 pass -- the Ariane IA button
+ * now carries its chip in the button's trailing slot, with `clickable={false}`
+ * making that legal. This site was not part of that instruction and is left as
+ * a sibling on purpose; it is the other consumer of the reversed rule and the
+ * one to revisit if the inside placement is meant to be general.
  */
 const eeRow: CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: 4 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
@@ -120,14 +120,8 @@ export const CoverageInformationFieldAdd: FunctionComponent<CoverageInformationF
                       type="number"
                       fullWidth
                       required
-                      slotProps={{
-                        input: {
-                          inputProps: {
-                            min: 0,
-                            max: 100,
-                          },
-                        },
-                      }}
+                      min={0}
+                      max={100}
                     />
                   </div>
                   <IconButton
@@ -250,14 +244,8 @@ export const CoverageInformationFieldEdit: FunctionComponent<CoverageInformation
                       type="number"
                       fullWidth
                       required
-                      slotProps={{
-                        input: {
-                          inputProps: {
-                            min: 0,
-                            max: 100,
-                          },
-                        },
-                      }}
+                      min={0}
+                      max={100}
                       onSubmit={(_: string, score: string) => {
                         if (isNotEmptyField(score)) {
                           commitMutation({

--- a/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
@@ -70,7 +70,7 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
                       component={TextField}
                       variant="standard"
                       type="number"
-                      slotProps={{ input: { min: 0 } }}
+                      min={0}
                       name={`${name}.${index}.measure`}
                       label={t_i18n(`Height (${lengthPrimaryUnit})`)}
                       onSubmit={(_: string, measure: string) => {
@@ -208,7 +208,7 @@ export const HeightFieldAdd: FunctionComponent<HeightFieldAddProps> = ({
                       name={`${name}.${index}.measure`}
                       label={t_i18n(`Height (${lengthPrimaryUnit})`)}
                       type="number"
-                      slotProps={{ input: { min: 0 } }}
+                      min={0}
                     />
                     <Field
                       component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
@@ -67,7 +67,7 @@ export const WeightFieldAdd: FunctionComponent<WeightFieldAddProps> = ({
                     name={`${name}.${index}.measure`}
                     label={t_i18n(`Weight (${weightPrimaryUnit})`)}
                     type="number"
-                    slotProps={{ input: { min: 0 } }}
+                    min={0}
                   />
                   <Field
                     component={DateTimePickerField}
@@ -154,7 +154,7 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
                       component={TextField}
                       variant="standard"
                       type="number"
-                      slotProps={{ input: { min: 0 } }}
+                      min={0}
                       name={`${name}.${index}.measure`}
                       label={t_i18n(`Weight (${weightPrimaryUnit})`)}
                       onSubmit={(_: string, measure: string) => {


### PR DESCRIPTION
The pass lists height, weight and coverage score as "input number à convertir".
They **already** went through the TextField pivot and **already** asked for
`type="number"`. What sent them to the MUI fallback was one prop each.

## The mechanism

The pivot abandons to MUI on any prop the library `Input` cannot place, and
`slotProps` is in neither the placeable nor the forwardable set. So this alone —

```jsx
slotProps={{ input: { min: 0 } }}
```

— kept the whole field on MUI, stepper included.

`min`, `max` and `step` **are** forwardable: the `Input` spreads native
attributes onto the inner `<input>`, which is exactly where they belong. The
same constraint expressed as `min={0}` / `max={100}` lets the field pivot and
take the designed stepper from lib #190.

## Scope

Six fields across `WeightField`, `HeightField` and `CoverageInformationField`.
Each was re-checked prop by prop against the pivot's own placeable/forwardable
sets afterwards — none has an unplaceable prop left.

**Two number fields are deliberately not touched.** `FeedCreation` and
`FeedEdition` carry an interactive `endAdornment` in their `slotProps`, which
the pivot lists as out of contract on its own terms — a real capability gap, not
a prop-placement accident.

While checking: `Settings.tsx`'s three fields already pivot, so the
"champ input non convertie" in Configuration is not one of these.

## Also

Corrects a stale doctrine comment on `EnterpriseEditionButton` which stated "the
EE badge never sits INSIDE a button" as a rule — reversed by the designer during
the night-2 pass. **Rendering is unchanged** (this site was not part of that
instruction); the comment simply no longer contradicts the shipped Ariane button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)