### PR TITLE
fix(fds): size the small-button glyphs, centre the tabs actions (#17808)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
@@ -138,8 +138,9 @@ export const CoverageInformationFieldAdd: FunctionComponent<CoverageInformationF
                   />
                 </div>
               ))}
+              {/* Default (md) rather than small: the pass asks for this one at
+                  md, and it is the row's only action. */}
               <Button
-                size="small"
                 aria-label={t_i18n('Add coverage metric')}
                 id="addCoverageInfo"
                 onClick={() => {
@@ -284,8 +285,9 @@ export const CoverageInformationFieldEdit: FunctionComponent<CoverageInformation
                   )}
                 </div>
               ))}
+              {/* Default (md) rather than small: the pass asks for this one at
+                  md, and it is the row's only action. */}
               <Button
-                size="small"
                 aria-label={t_i18n('Add coverage metric')}
                 id="addCoverageInfo"
                 onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/common/form/HeaderField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/HeaderField.tsx
@@ -70,7 +70,7 @@ export const HeaderFieldAdd: FunctionComponent<HeaderFieldAddProps> = ({
               ))}
               <Button
                 size="small"
-                startIcon={<AddOutlined />}
+                startIcon={<AddOutlined fontSize="small" />}
                 aria-label="Add"
                 id="addHeader"
                 onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/HeightField.tsx
@@ -138,7 +138,7 @@ export const HeightFieldEdit: FunctionComponent<HeightFieldEditProps> = ({
             })}
             <Button
               size="small"
-              startIcon={<AddOutlined />}
+              startIcon={<AddOutlined fontSize="small" />}
               aria-label="Add"
               id="addHeight"
               onClick={() => {
@@ -236,7 +236,7 @@ export const HeightFieldAdd: FunctionComponent<HeightFieldAddProps> = ({
               ))}
               <Button
                 size="small"
-                startIcon={<AddOutlined />}
+                startIcon={<AddOutlined fontSize="small" />}
                 aria-label="Add"
                 id="addHeight"
                 onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/common/form/QueryAttributeField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/QueryAttributeField.tsx
@@ -137,7 +137,7 @@ export const QueryAttributeFieldAdd: FunctionComponent<QueryAttributeFieldAddPro
               ))}
               <Button
                 size="small"
-                startIcon={<AddOutlined />}
+                startIcon={<AddOutlined fontSize="small" />}
                 aria-label="Add"
                 id="addHeader"
                 onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/WeightField.tsx
@@ -93,7 +93,7 @@ export const WeightFieldAdd: FunctionComponent<WeightFieldAddProps> = ({
             ))}
             <Button
               size="small"
-              startIcon={<AddOutlined />}
+              startIcon={<AddOutlined fontSize="small" />}
               aria-label="Add"
               id="addHeight"
               onClick={() => {
@@ -236,7 +236,7 @@ export const WeightFieldEdit: FunctionComponent<WeightFieldEditProps> = ({
             })}
             <Button
               size="small"
-              startIcon={<AddOutlined />}
+              startIcon={<AddOutlined fontSize="small" />}
               aria-label="Add"
               id="addHeight"
               onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -160,6 +160,10 @@ const StixDomainObjectTabsBox = (props: StixDomainObjectTabsBoxProps) => {
       marginBottom: 3,
       display: 'flex',
       justifyContent: 'space-between',
+      // Without this the row's default `align-items: stretch` made
+      // `extraActions` -- the Aperçu par IA button -- as tall as the tabs strip
+      // instead of sitting on its centre line.
+      alignItems: 'center',
     }}
     >
       <TabsWithCustomViews

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
@@ -100,7 +100,7 @@ export const WorkflowTransitions: FunctionComponent<WorkflowTransitionsProps> = 
               size="small"
               onClick={handleClear}
               disabled={clearing}
-              startIcon={<Close />}
+              startIcon={<Close fontSize="small" />}
             >
               {t_i18n('Clear')}
             </Button>
@@ -129,7 +129,7 @@ export const WorkflowTransitions: FunctionComponent<WorkflowTransitionsProps> = 
                 size="small"
                 onClick={handleClear}
                 disabled={clearing}
-                startIcon={<LockOpenOutlined />}
+                startIcon={<LockOpenOutlined fontSize="small" />}
               >
                 {t_i18n('Clear')}
               </Button>

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormSchemaEditor.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormSchemaEditor.tsx
@@ -992,7 +992,7 @@ const FormSchemaEditor: FunctionComponent<FormSchemaEditorProps> = ({
               <Button
                 variant="secondary"
                 size="small"
-                startIcon={<Add />}
+                startIcon={<Add fontSize="small" />}
                 onClick={() => {
                   const newOptions = [...(field.options || []), { label: '', value: '' }];
                   handleFieldChange(`fields.${fieldIndex}.options`, newOptions);

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnectorCreation.tsx
@@ -264,7 +264,7 @@ const IngestionCatalogConnectorCreation = ({
                 component={Link}
                 size="small"
                 to={buildConnectorsUrl()}
-                startIcon={<HubOutlined />}
+                startIcon={<HubOutlined fontSize="small" />}
                 disabled={deploymentCount === 0}
               >
                 {`${deploymentCount} ${t_i18n('instances deployed')}`}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -91,7 +91,7 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
                     size="small"
                     variant="secondary"
                     onClick={openLifecycleDialog}
-                    startIcon={<TroubleshootOutlined />}
+                    startIcon={<TroubleshootOutlined fontSize="small" />}
                     color={indicator.decay_exclusion_applied_rule ? 'warn' : 'primary'}
                     keepMui
                   >

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.tsx
@@ -342,7 +342,7 @@ const DownloadFileButtonMenu = ({
       <Button
         variant="secondary"
         size="small"
-        startIcon={<GetAppOutlined />}
+        startIcon={<GetAppOutlined fontSize="small" />}
         onClick={handleOpen}
       >
         {t_i18n('Download')} ({(fileSize)})


### PR DESCRIPTION
The punctual items from the pass — plus the defect class behind two of them.

## Icon size in small buttons

The library `Button`'s icon slot is a bare `<span class="inline-flex shrink-0">`
— it does **not** size the glyph, the caller does. So an `AddOutlined` with no
size renders at MUI's 24px inside a `size="small"` button, overflows it and
shifts the label. That is the "alignement icon dans bouton" on *Ajouter une
hauteur* / *Ajouter un poids*.

It is not two sites: **twelve** buttons across nine files carry the same unsized
glyph in a small button, and the repo already spells the fix out elsewhere as
`fontSize="small"`. All twelve now match, including the two named.

## Ajouter la métrique de couverture

Drops `size="small"` for the default (md), at both mount points.

## The tabs row

`StixDomainObjectTabsBox` is a flex row with `justify-content: space-between`
and **no `align-items`**, so `extraActions` — the *Aperçu par IA* button —
stretched to the height of the tabs strip instead of sitting on its centre line.
The inner `Stack` already centred its own children, which is why this looked
like a button problem rather than a row problem. Same shape as last round's
filter-row fix.

## Two items where looking found something else

- **The "champ input non convertie" in Settings → Configuration is not an
  input.** It is the MUI **`Switch`** on the *Remove Filigran logos* row — the
  same bullet as the EE chip. `Switch` is a **26-file wave** with a different
  handler shape (`onChange(event, value)` vs `onCheckedChange(boolean)`) and the
  `FormControlLabel` trap, so it is not a leftover.
- **The one MUI `Select` left is a deliberate hold** — FDS-WORKAROUND #43. The
  library owns the field border and exposes no state tint, so converting would
  drop the active-relative-date signal. Its note already records a design
  decision pending with you.

The remaining direct MUI `IconButton`s (8 files) are left as well: a banner, a
graph toolbar, toasts and SSO forms rather than the list pages the pass named,
and each carries a reason the wrapper does not cover — `edge`, a glass `sx`, or
`component="a"`.

Gates run locally: `check-accessible-names` clean, conformity exit 0, utility
classes clean, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)