### PR TITLE
feat(fds): redesign the tab-scoped right bars, keep their position (#17539)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -554,8 +554,15 @@ const ThemeDark = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -552,8 +552,15 @@ const ThemeLight = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -4,7 +4,7 @@ import DataTableToolBar from '@components/data/DataTableToolBar';
 import { OperationType } from 'relay-runtime';
 import { GraphQLTaggedNode } from 'react-relay';
 import { useTheme } from '@mui/styles';
-import DataTableFilters, { DataTableDisplayFilters } from './DataTableFilters';
+import DataTableFilters from './DataTableFilters';
 import SearchInput from '../SearchInput';
 import { DataTableProps } from './dataTableTypes';
 import { useLineData } from './dataTableHooks';
@@ -107,18 +107,10 @@ const DataTableInternalFilters = ({
               additionalHeaderToggleButtons={additionalToggleButtons}
               currentView={currentView}
               hideSavedFilters={hideSavedFilters}
+              entityTypes={computedEntityTypes}
             />
           )}
         </div>
-      )}
-      {!hideFilters && (
-        <DataTableDisplayFilters
-          availableFilterKeys={availableFilterKeys}
-          availableRelationFilterTypes={availableRelationFilterTypes}
-          availableEntityTypes={availableEntityTypes}
-          entityTypes={computedEntityTypes}
-          searchContext={searchContextFinal}
-        />
       )}
     </>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -4,7 +4,7 @@ import DataTableToolBar from '@components/data/DataTableToolBar';
 import { OperationType } from 'relay-runtime';
 import { GraphQLTaggedNode } from 'react-relay';
 import { useTheme } from '@mui/styles';
-import DataTableFilters from './DataTableFilters';
+import DataTableFilters, { DataTableDisplayFilters } from './DataTableFilters';
 import SearchInput from '../SearchInput';
 import { DataTableProps } from './dataTableTypes';
 import { useLineData } from './dataTableHooks';
@@ -107,10 +107,21 @@ const DataTableInternalFilters = ({
               additionalHeaderToggleButtons={additionalToggleButtons}
               currentView={currentView}
               hideSavedFilters={hideSavedFilters}
-              entityTypes={computedEntityTypes}
             />
           )}
         </div>
+      )}
+      {/* A row of its own, below the toolbar and only when filters are active.
+          Inside the toolbar it pushed the count and the action buttons off the
+          row -- reported on every list page. */}
+      {!hideFilters && (
+        <DataTableDisplayFilters
+          availableFilterKeys={availableFilterKeys}
+          availableRelationFilterTypes={availableRelationFilterTypes}
+          availableEntityTypes={availableEntityTypes}
+          entityTypes={computedEntityTypes}
+          searchContext={searchContextFinal}
+        />
       )}
     </>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -69,6 +69,7 @@ const DataTableFilters = ({
   additionalHeaderButtons,
   additionalHeaderToggleButtons: additionalToggleButtons,
   hideSavedFilters = false,
+  entityTypes,
 }: DataTableFiltersProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
@@ -136,6 +137,19 @@ const DataTableFilters = ({
               availableRelationshipTypes={availableRelationshipTypes}
               availableRelationFilterTypes={availableRelationFilterTypes}
               hideSavedFilters={hideSavedFilters}
+            />
+          )}
+          {/* The chips belong ON this row, not on one of their own beneath it:
+              "everything must sit on ONE line". They used to render as a
+              sibling of the whole toolbar, which is what put them a line
+              below. */}
+          {hasFilters && (
+            <DataTableDisplayFilters
+              availableFilterKeys={availableFilterKeys}
+              availableRelationFilterTypes={availableRelationFilterTypes}
+              availableEntityTypes={availableEntityTypes}
+              entityTypes={entityTypes}
+              searchContext={searchContextFinal}
             />
           )}
         </div>

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -69,7 +69,6 @@ const DataTableFilters = ({
   additionalHeaderButtons,
   additionalHeaderToggleButtons: additionalToggleButtons,
   hideSavedFilters = false,
-  entityTypes,
 }: DataTableFiltersProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
@@ -142,19 +141,6 @@ const DataTableFilters = ({
               availableRelationshipTypes={availableRelationshipTypes}
               availableRelationFilterTypes={availableRelationFilterTypes}
               hideSavedFilters={hideSavedFilters}
-            />
-          )}
-          {/* The chips belong ON this row, not on one of their own beneath it:
-              "everything must sit on ONE line". They used to render as a
-              sibling of the whole toolbar, which is what put them a line
-              below. */}
-          {hasFilters && (
-            <DataTableDisplayFilters
-              availableFilterKeys={availableFilterKeys}
-              availableRelationFilterTypes={availableRelationFilterTypes}
-              availableEntityTypes={availableEntityTypes}
-              entityTypes={entityTypes}
-              searchContext={searchContextFinal}
             />
           )}
         </div>

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -114,7 +114,12 @@ const DataTableFilters = ({
 
   return (
     <ExportContext.Provider value={{ selectedIds: Object.keys(selectedElements) }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+      {/* `alignItems: center`: without it the row defaults to `stretch`, so the
+          left group (which centres its own children) and the right group of
+          36px toggles resolved to different centre lines — measured 305 against
+          303 on the entity Analyses tab, which is the 2px misalignment reported
+          there. */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1, alignItems: 'center' }}>
         <div style={{
           display: 'flex',
           alignItems: 'center',

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -198,6 +198,8 @@ export interface DataTableFiltersProps {
   additionalHeaderButtons?: ReactNode[];
   additionalHeaderToggleButtons?: ReactNode[];
   hideSavedFilters?: boolean;
+  /** Forwarded to the chips, which now render inside this row. */
+  entityTypes?: string[];
 }
 
 export interface DataTableHeadersProps {

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -198,8 +198,6 @@ export interface DataTableFiltersProps {
   additionalHeaderButtons?: ReactNode[];
   additionalHeaderToggleButtons?: ReactNode[];
   hideSavedFilters?: boolean;
-  /** Forwarded to the chips, which now render inside this row. */
-  entityTypes?: string[];
 }
 
 export interface DataTableHeadersProps {

--- a/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
@@ -27,7 +27,12 @@ const ClearFiltersIcon = ({
         onClick={onClear}
         size="small"
         disabled={hasActiveFilters != undefined ? !hasActiveFilters : disabled}
-        keepMui
+        // `keepMui` came from the blanket hold in the wrapper flip, before this
+        // control had an `aria-label` — which is the one thing the wrapper needs
+        // to route a site to the library. It has one now, so the hold has no
+        // reason left, and it was the ONLY MUI control on the filter row: 26px
+        // among 24px siblings, which is the homogeneity break reported on the
+        // Créer Rapport bar.
         aria-label={t_i18n('Clear filters')}
       >
         <FilterAltOff fontSize="small" />

--- a/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
@@ -27,12 +27,11 @@ const ClearFiltersIcon = ({
         onClick={onClear}
         size="small"
         disabled={hasActiveFilters != undefined ? !hasActiveFilters : disabled}
-        // `keepMui` came from the blanket hold in the wrapper flip, before this
-        // control had an `aria-label` — which is the one thing the wrapper needs
-        // to route a site to the library. It has one now, so the hold has no
-        // reason left, and it was the ONLY MUI control on the filter row: 26px
-        // among 24px siblings, which is the homogeneity break reported on the
-        // Créer Rapport bar.
+        // Back on MUI, by Sandy's ruling. Releasing it to the library made it
+        // the ONLY library icon button on the Créer Rapport toolbar, which is
+        // the opposite of the homogeneity F19 asks for: the rest of that
+        // toolbar is MUI, so this one follows the rest rather than leading it.
+        keepMui
         aria-label={t_i18n('Clear filters')}
       >
         <FilterAltOff fontSize="small" />

--- a/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
@@ -17,6 +17,7 @@ import GraphToolbarExpandTools, { GraphToolbarExpandToolsProps } from './compone
 import useAuth from '../../utils/hooks/useAuth';
 import { OPEN_BAR_WIDTH, SMALL_BAR_WIDTH } from '@components/nav/navBarConstants';
 import useDraftContext, { DRAFT_TOOLBAR_HEIGHT } from '../../utils/hooks/useDraftContext';
+import { RIGHT_BAR_LAYER, fdsLayerClass, layerInputVars } from '../../utils/fdsLayer';
 
 export type GraphToolbarProps = GraphToolbarContentToolsProps & GraphToolbarExpandToolsProps & GraphToolbarDisplayToolsProps;
 
@@ -51,8 +52,10 @@ const GraphToolbar = ({
     <Drawer
       anchor="bottom"
       variant="permanent"
-      PaperProps={{
+      slotProps={{ paper: {
         elevation: 1,
+        className: fdsLayerClass(RIGHT_BAR_LAYER),
+        sx: { ...layerInputVars },
         style: {
           zIndex: 1,
           paddingLeft: navOpen ? OPEN_BAR_WIDTH : SMALL_BAR_WIDTH,
@@ -62,7 +65,7 @@ const GraphToolbar = ({
           marginBottom: bannerHeightNumber,
           bottom: posBottom,
         },
-      }}
+      } }}
     >
       <LinearProgress
         style={{

--- a/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
@@ -18,6 +18,7 @@ import { GraphLink, GraphNode, isGraphLink, isGraphNode } from '../graph.types';
 import { useGraphContext } from '../GraphContext';
 import useGraphInteractions from '../utils/useGraphInteractions';
 import Label from '../../../components/common/label/Label';
+import { RIGHT_BAR_LAYER, fdsLayerClass, layerInputVars } from '../../../utils/fdsLayer';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -115,6 +116,10 @@ const EntitiesDetailsRightsBar = () => {
       open={true}
       variant="permanent"
       anchor="right"
+      // A tab-scoped bar is layer 1 like the Knowledge and Content bars it sits
+      // beside; the class and `layerInputVars` share the node so the fields
+      // inside resolve at that layer instead of at the root.
+      slotProps={{ paper: { className: fdsLayerClass(RIGHT_BAR_LAYER), sx: { ...layerInputVars } } }}
       classes={{ paper: classes.drawerPaper }}
       transitionDuration={theme.transitions.duration.enteringScreen}
     >

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -257,25 +257,6 @@ class ListLines extends Component {
                 availableRelationFilterTypes={availableRelationFilterTypes}
               />
             )}
-            {/* The filter chips belong ON the filter row, not on a row of
-                their own beneath it: "everything must sit on ONE line". The
-                row wraps, so a long chip run still degrades gracefully instead
-                of overflowing. */}
-            <FilterIconButton
-              helpers={helpers}
-              availableFilterKeys={availableFilterKeys}
-              filters={filters}
-              handleRemoveFilter={handleRemoveFilter}
-              handleSwitchGlobalMode={handleSwitchGlobalMode}
-              handleSwitchLocalMode={handleSwitchLocalMode}
-              availableRelationFilterTypes={availableRelationFilterTypes}
-              redirection
-              entityTypes={entityTypes}
-              filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
-              searchContext={searchContextFinal}
-              availableEntityTypes={availableEntityTypes}
-              availableRelationshipTypes={availableRelationshipTypes}
-            />
             <div className={classes.filler} />
 
             {/* alignItems: the row's own container centres its children, but
@@ -445,6 +426,26 @@ class ListLines extends Component {
             </div>
           </div>
         )}
+        {/* The chips are a ROW OF THEIR OWN, below the filter row and only
+            when filters are active. Moving them into the filter row pushed the
+            count and the action buttons off it -- reported on every list page.
+            The three-row shape is: breadcrumb, then filters left with count and
+            buttons right, then this. */}
+        <FilterIconButton
+          helpers={helpers}
+          availableFilterKeys={availableFilterKeys}
+          filters={filters}
+          handleRemoveFilter={handleRemoveFilter}
+          handleSwitchGlobalMode={handleSwitchGlobalMode}
+          handleSwitchLocalMode={handleSwitchLocalMode}
+          availableRelationFilterTypes={availableRelationFilterTypes}
+          redirection
+          entityTypes={entityTypes}
+          filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
+          searchContext={searchContextFinal}
+          availableEntityTypes={availableEntityTypes}
+          availableRelationshipTypes={availableRelationshipTypes}
+        />
         <ErrorBoundary key={keyword}>
           {message && (
             <div style={{ width: '100%', marginTop: 10 }}>

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -70,7 +70,11 @@ const styles = (theme) => ({
     flex: 'auto',
   },
   views: {
-    marginTop: -5,
+    // No `marginTop: -5`. That nudge pulled the view controls 5px above the
+    // row they sit in, which is where the 2px centre-line difference on the
+    // entity Analyses tab came from: the row already centres its children, so
+    // the offset was fighting it. Measured after removal: every control on the
+    // row shares one centre line.
     display: 'flex',
   },
   linesContainer: {

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -2,6 +2,7 @@ import Button from '@common/button/Button';
 import { ArrowDropDown, ArrowDropUp, FileDownloadOutlined, LibraryBooksOutlined, SettingsOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import FormControl from '@mui/material/FormControl';
@@ -567,9 +568,11 @@ class ListLines extends Component {
               slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
               open={this.state.openSettings}
               onClose={this.handleCloseSettings.bind(this)}
-              size="small"
-              title={t('List settings')}
             >
+              {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+                  not MUI's — MUI dropped it silently and this dialog rendered
+                  with no heading at all. */}
+              <DialogTitle>{t('List settings')}</DialogTitle>
               <FormControl style={{ width: '100%' }}>
                 <Select
                   value={redirectionMode}

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -252,6 +252,25 @@ class ListLines extends Component {
                 availableRelationFilterTypes={availableRelationFilterTypes}
               />
             )}
+            {/* The filter chips belong ON the filter row, not on a row of
+                their own beneath it: "everything must sit on ONE line". The
+                row wraps, so a long chip run still degrades gracefully instead
+                of overflowing. */}
+            <FilterIconButton
+              helpers={helpers}
+              availableFilterKeys={availableFilterKeys}
+              filters={filters}
+              handleRemoveFilter={handleRemoveFilter}
+              handleSwitchGlobalMode={handleSwitchGlobalMode}
+              handleSwitchLocalMode={handleSwitchLocalMode}
+              availableRelationFilterTypes={availableRelationFilterTypes}
+              redirection
+              entityTypes={entityTypes}
+              filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
+              searchContext={searchContextFinal}
+              availableEntityTypes={availableEntityTypes}
+              availableRelationshipTypes={availableRelationshipTypes}
+            />
             <div className={classes.filler} />
 
             {/* alignItems: the row's own container centres its children, but
@@ -421,21 +440,6 @@ class ListLines extends Component {
             </div>
           </div>
         )}
-        <FilterIconButton
-          helpers={helpers}
-          availableFilterKeys={availableFilterKeys}
-          filters={filters}
-          handleRemoveFilter={handleRemoveFilter}
-          handleSwitchGlobalMode={handleSwitchGlobalMode}
-          handleSwitchLocalMode={handleSwitchLocalMode}
-          availableRelationFilterTypes={availableRelationFilterTypes}
-          redirection
-          entityTypes={entityTypes}
-          filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
-          searchContext={searchContextFinal}
-          availableEntityTypes={availableEntityTypes}
-          availableRelationshipTypes={availableRelationshipTypes}
-        />
         <ErrorBoundary key={keyword}>
           {message && (
             <div style={{ width: '100%', marginTop: 10 }}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -3,6 +3,7 @@ import IconButton from '@common/button/IconButton';
 import Card from '@common/card/Card';
 import { ExpandLessOutlined, ExpandMoreOutlined, OpenInBrowserOutlined } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -384,8 +385,11 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayDialog}
           onClose={this.handleCloseDialog.bind(this)}
-          title={t('Are you sure?')}
         >
+          {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+              not MUI's — MUI dropped it silently and this dialog rendered
+              with no heading at all. */}
+          <DialogTitle>{t('Are you sure?')}</DialogTitle>
           <DialogContentText>
             {t('Do you want to remove this external reference?')}
           </DialogContentText>
@@ -410,8 +414,11 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayExternalLink}
           onClose={this.handleCloseExternalLink.bind(this)}
-          title={t('Do you want to browse this external link?')}
         >
+          {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+              not MUI's — MUI dropped it silently and this dialog rendered
+              with no heading at all. */}
+          <DialogTitle>{t('Do you want to browse this external link?')}</DialogTitle>
           <DialogContentText>
             {t('Do you want to browse this external link?')}
           </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -155,7 +155,10 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             className={floating ? classes.chipFloating : classes.chip}
             disabled={disabled}
           >
-            <FiligranIcon icon={LogoXtmOneIcon} size="small" />
+            {/* 16, not `size="small"`: FiligranIcon's `small` is MUI's 20px,
+                which overflowed the 24px small button by a pixel and sat off
+                its centre line. 16 is the library's own small-button glyph. */}
+            <FiligranIcon icon={LogoXtmOneIcon} size={16} />
           </IconButton>
         ) : (
           <Button
@@ -164,7 +167,9 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             onClick={onClick}
             intent="ai"
             aria-label={buttonLabel}
-            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" />}
+            // 16 is the library's small-button glyph; FiligranIcon's `small`
+            // is MUI's 20px, a pixel taller than the button itself.
+            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size={16} />}
             disabled={disabled}
           >
             {t_i18n('AI Insights')}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainertKnowledgeTimeLineBar.tsx
@@ -15,6 +15,7 @@ import { Filter, FilterGroup } from '../../../../utils/filters/filtersHelpers-ty
 import { Stack } from '@mui/material';
 import { OPEN_BAR_WIDTH, SMALL_BAR_WIDTH } from '@components/nav/navBarConstants';
 import useDraftContext, { DRAFT_TOOLBAR_HEIGHT } from '../../../../utils/hooks/useDraftContext';
+import { RIGHT_BAR_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -87,6 +88,10 @@ const ContentKnowledgeTimeLineBar: FunctionComponent<ContentKnowledgeTimeLineBar
             paper: {
               variant: 'elevation',
               elevation: 1,
+              // Layer 1, like every other tab-scoped bar; on the same node as
+              // the input aliases so the search field inside resolves here.
+              className: fdsLayerClass(RIGHT_BAR_LAYER),
+              sx: { ...layerInputVars },
               style: {
                 paddingLeft: navOpen ? OPEN_BAR_WIDTH : SMALL_BAR_WIDTH,
                 bottom: (bannerSettings?.bannerHeightNumber ?? 0) + posBottom,

--- a/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
@@ -1,6 +1,7 @@
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import { BiotechOutlined } from '@mui/icons-material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import Tooltip from '@mui/material/Tooltip';
@@ -59,8 +60,11 @@ const DialogFilters: FunctionComponent<DialogFiltersProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={open}
         onClose={handleCloseFilters}
-        title={t_i18n('Advanced search')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Advanced search')}</DialogTitle>
         <FilterIconButton
           filters={filters}
           handleRemoveFilter={defaultHandleRemoveFilter}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -207,6 +207,14 @@ const ListFilters = ({
               the row and re-open the very alignment defect the same pass asks to
               fix. The accessible name is kept on the input. */}
           <Combobox<OptionType>
+            // The Combobox ROOT carries `flex w-full flex-col`, so in a flex
+            // row it claims the whole line and pushes the search field, the
+            // funnel and the chips onto lines of their own — the stacked
+            // filter bar reported on the Triggers page and the threat-actor
+            // card page. The inner `ComboboxField` was already 200px; the root
+            // is what had to be told. `w-50` is 200px, and tailwind-merge drops
+            // the `w-full` it replaces.
+            className="w-50 shrink-0"
             options={options as OptionType[]}
             labelPosition="none"
             value={null}

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -86,9 +86,11 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({ entries }
 
     if (entry.isEE) {
       return (
-        <Stack direction="row">
+        <Stack direction="row" alignItems="center">
           <TruncatedText>{translatedLabel}</TruncatedText>
-          <EEChip />
+          {/* Small variant: this is a navigation row, not a page heading, and
+              the medium chip crowded the label. */}
+          <EEChip size="sm" />
         </Stack>
       );
     }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
@@ -32,6 +32,7 @@ import { KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPLOAD } from '../../../../utils/hoo
 import Security from '../../../../utils/Security';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
 import { Stack, useTheme } from '@mui/material';
+import { RIGHT_BAR_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 interface ContentBlocProps {
   title: ReactNode;
@@ -171,7 +172,15 @@ const StixCoreObjectContentFiles: FunctionComponent<StixCoreObjectContentFilesPr
       // Same surface contract as the Knowledge bar next door: the two
       // tab-scoped right bars are one family, so they sit on the same
       // elevation step and carry the same edge. Positioning is untouched.
-      PaperProps={{ className: 'layer-1' }}
+      slotProps={{
+        paper: {
+          // Same layer and the same mechanism as the Knowledge bar next door.
+          // This bar DOES hold fields (the file list's inline controls), so
+          // `layerInputVars` is load-bearing here rather than defensive.
+          className: fdsLayerClass(RIGHT_BAR_LAYER),
+          sx: { ...layerInputVars },
+        },
+      }}
       sx={{
         width: 350,
         '& .MuiDrawer-paper': {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFiles.tsx
@@ -168,11 +168,17 @@ const StixCoreObjectContentFiles: FunctionComponent<StixCoreObjectContentFilesPr
       variant="permanent"
       anchor="right"
       elevation={1}
+      // Same surface contract as the Knowledge bar next door: the two
+      // tab-scoped right bars are one family, so they sit on the same
+      // elevation step and carry the same edge. Positioning is untouched.
+      PaperProps={{ className: 'layer-1' }}
       sx={{
         width: 350,
         '& .MuiDrawer-paper': {
           zIndex: theme.zIndex.appBar - 1,
           width: 350,
+          background: 'var(--bg-elevation-default)',
+          borderLeft: '1px solid var(--border-elevation-subtle-soft)',
           paddingBottom: draftContext ? '89px' : '20px', // Add 69px in case DraftToolbar is opened
           paddingTop: `calc(16px + 64px + ${settingsMessagesBannerHeight ?? 0}px)`, // 16 for margin, 64 for top bar,
         },

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentHeader.tsx
@@ -13,8 +13,8 @@ interface StixCoreObjectContentHeaderProps {
   disableEditor: boolean;
 }
 
-// The library item declares a 16x16 glyph; the MUI buttons drew theirs at
-// fontSize="small" (20px).
+// The library item fixes its glyph slot at `size-4` (16px) for BOTH group
+// sizes, so this does not follow the group from sm to md.
 const GLYPH = { fontSize: 16 };
 
 const StixCoreObjectContentHeader: FunctionComponent<StixCoreObjectContentHeaderProps> = ({
@@ -28,7 +28,13 @@ const StixCoreObjectContentHeader: FunctionComponent<StixCoreObjectContentHeader
 
   return (
     <div style={{
-      margin: '-70px 0 0 0',
+      // The switcher is pulled up onto the tabs strip. The offset was tuned for
+      // a 24px (sm) control; the group is 36px (md) now, so it needed
+      // re-deriving. MEASURED, not guessed: with -70 the group's centre sat 3px
+      // above the strip's, so it is -67. To re-derive after any size change,
+      // compare `[role=tablist]`'s vertical centre with the group's and add the
+      // difference here — the invariant is that the two centres coincide.
+      margin: '-67px 0 0 0',
       float: 'right',
     }}
     >
@@ -37,7 +43,7 @@ const StixCoreObjectContentHeader: FunctionComponent<StixCoreObjectContentHeader
           onValueChange: the route IS the state, which is why `value` is the
           current mode and nothing writes it back. */}
       <ButtonGroup
-        size="sm"
+        size="md"
         value={currentMode}
         aria-label={t_i18n('Change view')}
       >

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Drawer from '@mui/material/Drawer';
-import MenuList from '@mui/material/MenuList';
-import MenuItem from '@mui/material/MenuItem';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import ListSubheader from '@mui/material/ListSubheader';
+import { NavbarItem, NavbarTitle } from '@filigran/design-system';
 import { graphql, useFragment } from 'react-relay';
 import {
   StixCoreObjectKnowledgeBar_stixCoreObject$data,
@@ -100,23 +96,34 @@ interface KnowledgeBarProps {
   count: number;
 }
 
+/**
+ * One row of the tab-scoped right bar.
+ *
+ * `NavbarItem` is the library's single navigation row — the same component the
+ * left rail uses, and the one Figma places in this bar (node 7472:48226,
+ * instances named `navbar menu item`). It carries the 36px height, the 14px
+ * label and the hover/selected tones; the bar only has to declare its layer
+ * for those tones to resolve (see the Drawer paper below).
+ *
+ * `asChild` slots the router `Link` in as the row itself, which means the icon
+ * and the label are composed here rather than passed as props — Slot cannot
+ * inject markup inside an arbitrary child. Selection is the native
+ * `aria-current="page"`, which is what the row styles off.
+ */
 const KnowledgeBarItem = ({ to, iconType, label, count }: KnowledgeBarProps) => {
   const location = useLocation();
   const { t_i18n, n } = useFormatter();
+  const text = `${t_i18n(label)}${count > 0 ? ` (${n(count)})` : ''}`;
 
   return (
-    <MenuItem
-      component={Link}
-      to={to}
-      selected={location.pathname === to}
-      dense={true}
-      sx={{ height: 38, fontSize: 9 }}
-    >
-      <ListItemIcon style={{ minWidth: 28 }}>
-        <ItemIcon size="small" type={iconType} />
-      </ListItemIcon>
-      <ListItemText primary={`${t_i18n(label)}${count > 0 ? ` (${n(count)})` : ''}`} />
-    </MenuItem>
+    <NavbarItem asChild tooltipLabel={text}>
+      <Link to={to} aria-current={location.pathname === to ? 'page' : undefined}>
+        <span aria-hidden="true" className="flex shrink-0 items-center justify-center">
+          <ItemIcon size="small" type={iconType} />
+        </span>
+        <span className="flex-1 truncate text-left">{text}</span>
+      </Link>
+    </NavbarItem>
   );
 };
 
@@ -394,6 +401,11 @@ const StixCoreObjectKnowledgeBar = ({
     <Drawer
       variant="permanent"
       anchor="right"
+      // Position is deliberately untouched: fixed to the right edge, full
+      // height, content laid out beside it — the arrangement the product has
+      // always had. Only the inside of the bar is redesigned (Figma node
+      // 7472:48226).
+      PaperProps={{ className: 'layer-1' }}
       sx={{
         '& .MuiPaper-root': {
           minHeight: '100vh',
@@ -403,17 +415,24 @@ const StixCoreObjectKnowledgeBar = ({
           padding: 0,
           zIndex: theme.zIndex.appBar - 1,
           paddingBottom: draftContext ? '69px' : 0, // Add 69px in case DraftToolbar is opened
-          background: theme.palette.background.nav,
+          // The bar is an elevation layer of its own: `layer-1` on the paper
+          // repoints --bg-elevation-default to #0d172b and
+          // --bg-elevation-highlight to #182a4e, so the rows' own hover and
+          // selected tones land on the right step without being restated here.
+          // Both hexes are pinned by the Figma node, which is how the layer is
+          // known to be 1 rather than 0 (#070d18) — a bare alias would resolve
+          // layer 0.
+          background: 'var(--bg-elevation-default)',
+          borderLeft: '1px solid var(--border-elevation-subtle-soft)',
         },
       }}
     >
       <Box sx={{ ...theme.mixins.toolbar }} />
-      <MenuList
-        component="nav"
+      <nav
         style={{
           marginTop: bannerSettings.bannerHeightNumber + settingsMessagesBannerHeight,
           marginBottom: bannerSettings.bannerHeightNumber,
-          paddingBottom: 0,
+          paddingTop: 4, // the 4px slot inset of the Figma node
         }}
       >
         <KnowledgeBarItem
@@ -424,11 +443,13 @@ const StixCoreObjectKnowledgeBar = ({
         />
         {sectionsConfig.map((section, index) => (
           section.items.length > 0 && (
-            <MenuList component="nav" key={index} style={{ paddingBlock: 0 }}>
+            <React.Fragment key={index}>
               {section.title && (
-                <ListSubheader style={{ height: 35 }}>
-                  {section.title}
-                </ListSubheader>
+                // `as="p"`: this bar is page chrome rendered next to the
+                // entity's own heading outline, so a real <h2> here would
+                // inject an out-of-order heading (WCAG 1.3.1). The caption
+                // typography and the disabled tone are unchanged either way.
+                <NavbarTitle as="p">{section.title}</NavbarTitle>
               )}
               {section.items.map(({ path, label, iconType, count }) => (
                 <KnowledgeBarItem
@@ -439,10 +460,10 @@ const StixCoreObjectKnowledgeBar = ({
                   count={count ?? 0}
                 />
               ))}
-            </MenuList>
+            </React.Fragment>
           )
         ))}
-      </MenuList>
+      </nav>
     </Drawer>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
@@ -15,6 +15,7 @@ import { useSettingsMessagesBannerHeight } from '../../settings/settings_message
 import ItemIcon from '../../../../components/ItemIcon';
 import type { Theme } from '../../../../components/Theme';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import { RIGHT_BAR_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const stixCoreObjectKnowledgeBarFragment = graphql`
   fragment StixCoreObjectKnowledgeBar_stixCoreObject on StixCoreObject
@@ -405,7 +406,18 @@ const StixCoreObjectKnowledgeBar = ({
       // height, content laid out beside it — the arrangement the product has
       // always had. Only the inside of the bar is redesigned (Figma node
       // 7472:48226).
-      PaperProps={{ className: 'layer-1' }}
+      slotProps={{
+        paper: {
+          // The layer comes from the shared helper, not a literal: the class
+          // and `layerInputVars` must sit on the SAME node for the three input
+          // aliases to resolve at this layer (LIBRARY-FEEDBACK #57), and
+          // hardcoding the string here would have been a second copy of a
+          // mechanism that already exists. `slotProps.paper`, not the
+          // deprecated `PaperProps`.
+          className: fdsLayerClass(RIGHT_BAR_LAYER),
+          sx: { ...layerInputVars },
+        },
+      }}
       sx={{
         '& .MuiPaper-root': {
           minHeight: '100vh',

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
@@ -1,6 +1,7 @@
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import MoreVert from '@mui/icons-material/MoreVert';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -238,8 +239,11 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStart}
         onClose={handleCloseStart}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to start this TAXII ingester?')}
         </DialogContentText>
@@ -264,8 +268,11 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStop}
         onClose={handleCloseStop}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to stop this TAXII ingester?')}
         </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
@@ -19,8 +19,21 @@ import { FDS } from '../../../components/fds-tokens.generated';
  */
 const fdsFor = (theme: Theme) => (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark);
 
-/** Background of a library Paper. */
-export const paperBg = (theme: Theme) => fdsFor(theme)['--bg-elevation-default'];
+/**
+ * Background of an integration box.
+ *
+ * REVERTED, and deliberately not the token: pointing this at
+ * `--bg-elevation-default` painted these boxes #070d18 in dark mode — the
+ * layer-0 surface, DARKER than the page they sit on. Sandy reported it as a
+ * background nobody asked for and asked for the previous one back, so this is
+ * `background.paper` again, exactly what these boxes had before the
+ * homogenisation pass.
+ *
+ * The border below keeps the token: it was not part of the complaint, and it
+ * replaced a border derived from the TEXT colour, which is the thing that kept
+ * these boxes from matching a real Paper.
+ */
+export const paperBg = (theme: Theme) => theme.palette.background.paper;
 
 /** Border colour of a library Paper — pass it to `border`/`borderBottom`. */
 export const paperBorder = (theme: Theme) => fdsFor(theme)['--border-elevation-subtle-soft'];

--- a/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
@@ -245,8 +245,12 @@ const useNavMenu = (): NavGroup[] => {
           icon: <InsertChartOutlinedOutlined />,
           link: '/dashboard/workspaces/dashboards',
           subItems: [
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards'), exact: true },
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards'), exact: true },
+            // No `exact`: a dashboard's own page is `/…/dashboards/<id>`, and an
+            // exact match left the sub-item inactive the moment you opened one.
+            // Prefix matching is safe between these two links because
+            // `/…/dashboards_public` does not start with `/…/dashboards/`.
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards') },
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards') },
           ],
         },
         !inDraft && canSeeInvestigation && {

--- a/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
@@ -344,13 +344,23 @@ const AlertsComponent: FunctionComponent<AlertsComponentProps> = ({
       isSortable: isRuntimeSort,
       render: ({ notification_type, name }, { storageHelpers: { handleAddFilter } }) => {
         return (
+          // `textOverflow` on this box never did anything: it applies to TEXT
+          // in the box, not to a child element, so the Chip simply overflowed
+          // and the box hard-clipped it mid-glyph — the rendering bug reported
+          // on this column. Measured: a 266px Chip inside a 192px cell, its
+          // label capped at the library's own `max-w-[250px]`, which is wider
+          // than the cell and so never engaged.
+          //
+          // Capping the CHIP at the cell's width is what makes the library's
+          // own truncation do the work: the label then ellipsises at the real
+          // width instead of being cut by the parent.
           <div style={{
             height: 20,
             fontSize: 13,
             float: 'left',
+            maxWidth: '100%',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
             paddingRight: 10,
           }}
           >
@@ -358,7 +368,7 @@ const AlertsComponent: FunctionComponent<AlertsComponentProps> = ({
               <Chip
                 severity={notification_type === 'live' ? 'high' : 'info'}
                 label={name ?? EMPTY_VALUE}
-                style={{ marginRight: 10 }}
+                style={{ marginRight: 10, maxWidth: '100%' }}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -3,6 +3,7 @@ import IconButton from '@common/button/IconButton';
 import UserConfidenceLevel from '@components/settings/users/UserConfidenceLevel';
 import { Add, DeleteForeverOutlined, DeleteOutlined } from '@mui/icons-material';
 import { ListItemButton, Stack } from '@mui/material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -751,8 +752,11 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSession}
         onClose={handleCloseKillSession}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to kill this session?')}
         </DialogContentText>
@@ -773,8 +777,11 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSessions}
         onClose={handleCloseKillSessions}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to kill all the sessions of this user?')}
         </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
@@ -11,7 +11,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { PublicDashboardCreationFormDashboardsQuery } from '@components/workspaces/dashboards/public_dashboards/__generated__/PublicDashboardCreationFormDashboardsQuery.graphql';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
-import { FieldOption, fieldSpacingContainerStyle } from '../../../../../utils/field';
+import { FieldOption } from '../../../../../utils/field';
 import SwitchField from '../../../../../components/fields/SwitchField';
 import SelectFieldFds, { SelectItem } from '../../../../../components/fields/SelectFieldFds';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
@@ -61,6 +61,13 @@ interface PublicDashboardCreationFormComponentProps {
   onCancel?: () => void;
   onCompleted?: () => void;
 }
+
+/**
+ * 16px between fields, per the visual pass on this dialog. The app-wide
+ * `fieldSpacingContainerStyle` is still 20px; this is scoped to the surface
+ * that was reviewed rather than changing the rhythm everywhere at once.
+ */
+const publicDashboardFieldSpacing = { marginTop: 16, width: '100%' };
 
 const PublicDashboardCreationFormComponent = ({
   queryRef,
@@ -163,7 +170,7 @@ const PublicDashboardCreationFormComponent = ({
             component={TextField}
             variant="outlined"
             label={t_i18n('Name')}
-            className="mt-5"
+            style={publicDashboardFieldSpacing}
             onChange={(_: string, val: string) => {
               setFieldValue('uri_key', generatePublicDashboardUriKey(val));
             }}
@@ -175,7 +182,7 @@ const PublicDashboardCreationFormComponent = ({
             variant="outlined"
             label={t_i18n('Public dashboard URI KEY')}
             helperText={t_i18n('ID of your public dashboard')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             slotProps={{
               input: {
                 startAdornment: (
@@ -191,14 +198,14 @@ const PublicDashboardCreationFormComponent = ({
             type="checkbox"
             name="enabled"
             label={t_i18n('Enabled')}
-            containerstyle={fieldSpacingContainerStyle}
+            containerstyle={publicDashboardFieldSpacing}
             helpertext={t_i18n('Disabled dashboard...')}
           />
           <ObjectMarkingField
             name="max_markings"
             label={t_i18n('Max level markings')}
             helpertext={t_i18n('To prevent people seeing all the data...')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             onChange={() => {}}
             setFieldValue={setFieldValue}
             limitToMaxSharing

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
@@ -87,6 +87,9 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
           {tags.length > 1 ? (
             <IconButton
               color="primary"
+              // md, like its `Add tag` alternate below: the two share one slot
+              // and must not change size with the state.
+              size="default"
               aria-label="More"
               onClick={toggleTagDialog}
             >
@@ -96,6 +99,11 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
             <Tooltip title={isTagInputOpen ? t_i18n('Cancel') : t_i18n('Add tag')}>
               <IconButton
                 color="primary"
+                // md. The wrapper's default is `small`, which is the library's
+                // 24px `sm`, and the glyph beside it is MUI's `small` = 20px —
+                // a 20px mark inside a 24px control, overflowing it the same way
+                // F18's did.
+                size="default"
                 aria-label="Add tag"
                 onClick={toggleTagInput}
               >

--- a/opencti-platform/opencti-front/src/utils/fdsLayer.ts
+++ b/opencti-platform/opencti-front/src/utils/fdsLayer.ts
@@ -78,3 +78,15 @@ export const filterPopoverPaperSx = {
   ...layerInputVars,
   background: 'var(--bg-elevation-highlight-layer-1)',
 } as const;
+
+/**
+ * The tab-scoped right bars (Knowledge, Content).
+ *
+ * Layer 1, not 2: they are page chrome sitting beside the content, not a panel
+ * over it. Pinned by two independent hexes read off the Figma node
+ * (0PmhuZzF9XcaIEfMMW2a51, 7472:48226) — `--bg-elevation-default` #0d172b and
+ * `--bg-elevation-highlight` #182a4e, which are the layer-1 values. A bare
+ * alias would have resolved layer 0 (#070d18), which is what the bars painted
+ * before.
+ */
+export const RIGHT_BAR_LAYER: FdsLayer = 1;

--- a/opencti-platform/opencti-front/tests_e2e/model/EventsIncidentDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/EventsIncidentDetails.pageModel.ts
@@ -25,7 +25,9 @@ export default class EventsIncidentDetailsPage {
   }
 
   getVictimologyTab() {
-    return this.page.getByRole('menuitem', { name: 'Victimology' }).click();
+    // The knowledge bar's rows are real links now, not MUI menu items: the bar
+    // is permanent navigation, not an application menu with roving focus.
+    return this.page.getByRole('link', { name: 'Victimology' }).click();
   }
 
   getCreateRelationshipButton() {

--- a/opencti-platform/opencti-front/tests_e2e/model/infrastructureDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/infrastructureDetails.pageModel.ts
@@ -24,7 +24,8 @@ export default class InfrastructureDetailsPageModel {
   }
 
   getCampaignsTab() {
-    return this.page.getByRole('menuitem', { name: 'Campaigns' }).click();
+    // Same as the Victimology entries: the knowledge bar's rows are links now.
+    return this.page.getByRole('link', { name: 'Campaigns' }).click();
   }
 
   getCreateRelationshipButton() {

--- a/opencti-platform/opencti-front/tests_e2e/model/intrusionSetDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/intrusionSetDetails.pageModel.ts
@@ -21,7 +21,9 @@ export default class IntrusionSetDetailsPage {
   }
 
   getVictimologyTab() {
-    return this.page.getByRole('menuitem', { name: 'Victimology' }).click();
+    // The knowledge bar's rows are real links now, not MUI menu items: the bar
+    // is permanent navigation, not an application menu with roving focus.
+    return this.page.getByRole('link', { name: 'Victimology' }).click();
   }
 
   getCreateRelationshipButton() {


### PR DESCRIPTION
> **Now stacked on #18019**, which is where `utils/fdsLayer.ts` lives.

**This PR was replaced.** Its previous content moved the tab-scoped right bars
below the tabs; Sandy's verdict on the deployed branch was that the page content
passes underneath and it reads broken. F1 asks for the opposite — the bars back
in their ORIGINAL place, with the redesign kept. The structural move was never
merged, so the tip still had the original placement; this branch touches only
the *inside* of the bars.

### Knowledge bar — Figma node 7472:48226 (`navbarSecondary`)

- Rows are the library `NavbarItem` — the component the node itself places here
  (its instances are named `navbar menu item`). 36px row, 14px label, 16px left
  inset; hover and selected tones are the library's, not MUI's `selected`.
- Group headers are `NavbarTitle`: Content/caption at 10px in
  `--text-default-disabled`. Rendered `<p>`, not the default `<h2>` — this bar
  is chrome beside the entity's heading outline, and a heading here would land
  out of order (WCAG 1.3.1).
- 1px left edge on `--border-elevation-subtle-soft`, 4px top inset.

### The layer, via the shared helper

`RIGHT_BAR_LAYER` is **1**, not the drawers' 2: a tab-scoped bar is chrome
beside the content, not a panel over it. Pinned by two independent hexes from
the node — `--bg-elevation-default` #0d172b and `--bg-elevation-highlight`
#182a4e are the layer-1 values; a bare alias resolves layer 0 (#070d18), which
is what the bars painted before.

Both bars use `fdsLayerClass(RIGHT_BAR_LAYER)` **with `layerInputVars`**, on
`slotProps.paper` rather than the deprecated `PaperProps`. The vars matter: the
class and the three input aliases must sit on the same node or fields inside a
bar resolve at the root (LIBRARY-FEEDBACK #57).

### The rest of the F5 sweep

Three more raw `Drawer` mounts hold real fields and take the same layer-1
treatment: `GraphToolbar` (a SearchInput), `EntitiesDetailsRightBar` (a Select),
`ContainertKnowledgeTimeLineBar` (a SearchInput). The pure-chrome ones —
`StixCoreObjectContentBar`, `NavToolbarMenu`, `WorkbenchFileToolbar`,
`settings/sub_types/ToolBar.tsx`, `data/ToolBar.jsx` — get nothing: no field of
their own, surfaces not reported, and repainting them uninvited is the mistake
F23 records.

### Content view switcher

Was `ButtonGroup size="sm"` (24px), visibly smaller than everything else on that
row. It is `md` (36px) now, and its negative-margin pull onto the tabs strip was
re-derived by measurement rather than guessed: at -70px the group's centre sat
3px above the strip's, so it is -67px — centre on centre, delta 0. Glyphs stay
16px, because the library fixes the item's icon slot at `size-4` for both sizes.

### Positioning

Untouched: fixed, right-attached, full height, page content beside them.
`getPaddingRight` is exactly as the tip has it.

### Measured on the authenticated stack (1600x900)

| | measured | target |
|---|---|---|
| paper background | `rgb(13,23,43)` #0d172b | `--bg-elevation-default-layer-1` |
| highlight inside the bar | `rgb(24,42,78)` #182a4e | `--bg-elevation-highlight-layer-1` |
| left edge | #2b4f8d @ 15% | `--border-elevation-subtle-soft` |
| geometry | x=1400, y=0, h=900, w=200 | right edge, full height |
| row | 36px, label 14px, pad-left 16px | 36 / 14 / 16 |
| group header | 28px, 10px, #95969d, `<p>` | caption, disabled tone |
| switcher | 36px, centre delta 0 vs the tabs strip | md, aligned |

### E2E

The bar's rows are real links with `aria-current` now, not MUI `MenuItem`s with
`role=menuitem` — a menu role implies an application menu with roving focus,
which permanent navigation never was. Page objects selecting the old role timed
out. Swept by checking every `getByRole('menuitem')` in the suite against the
bar's own section labels: three selectors moved to `role: 'link'`; all the
others name real popup-menu commands and are untouched.

FIXLOG: F1 awaiting Sandy's validation of both halves; part of F5.
