### PR TITLE
fix(fds): declare the elevation layer on drawers and dialogs (#17728)

### DIFF
--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -2118,3 +2118,54 @@ a `role="group"` of links marked with `aria-current` instead of a radiogroup.
 That is a design arbitration, not a defect, so it is not re-raised as a new
 entry — but it is the reason this resolution is recorded with a caveat rather
 than a clean tick. If the arbitration lands on links, both sites change again.
+---
+
+## 57. `.layer-N` does not re-declare the input backgrounds, so fields never follow their layer
+
+Raised from a deployed-environment bug at pin `bd57527`: every form field in a
+drawer or a dialog paints the layer-0 background.
+
+**Needed.** The layer system is nesting depth (Figma node 5416-12183): page is
+layer 0, a panel over it layer 1, a panel inside that layer 2. A drawer or
+dialog is layer 2, and the designer's ruling is that a field on it reads
+`#0c1527` — which is exactly `--bg-elevation-highlight-layer-2`.
+
+**Today.** The library ships `.layer-0` … `.layer-3`, and each block
+re-declares the elevation aliases — `--bg-elevation-default`,
+`--bg-elevation-highlight`, `--bg-elevation-hover`, the borders. It does NOT
+re-declare the three input backgrounds that alias them:
+
+```css
+--bg-input-default:  var(--bg-elevation-highlight);
+--bg-input-disabled: var(--bg-elevation-disabled);
+--bg-input-hover:    var(--bg-elevation-hover);
+```
+
+Those three are declared once, at the root. A `var()` inside a custom-property
+declaration is substituted at computed-value time **on the element that declares
+it**, so they resolve against the ROOT's elevation values — layer 0 — and a
+`.layer-2` further down can no longer reach them.
+
+**Measured** in a browser on the shipped build, not reasoned:
+
+| context | `--bg-elevation-highlight` | `--bg-input-default` |
+|---|---|---|
+| root (layer 0) | `#13213e` | `#13213e` |
+| `.layer-1` | `#182a4e` | `#13213e` |
+| `.layer-2` | `#0c1527` | `#13213e` |
+| `.layer-3` | `#13213e` | `#13213e` |
+
+The input background is **constant across every layer**. That is the defect.
+
+**Consequence.** The product compensates by re-declaring the same three aliases
+on the element that carries the layer class, where they resolve against that
+element's own elevation values (`src/utils/fdsLayer.ts`, `layerInputVars`).
+With it, `.layer-2` yields `#0c1527` — the designer's value.
+
+**Ask.** Move those three declarations into each `.layer-N` block. They are
+already written as aliases; they are simply in the wrong scope. Only the three
+backgrounds are affected — the rest of the input family aliases feedback and
+text tokens, which are layer-independent and correctly left alone.
+
+**Removal test.** Delete `layerInputVars` from the product; a field inside a
+drawer still reads `#0c1527`.

--- a/opencti-platform/opencti-front/src/components/common/dialog/Dialog.tsx
+++ b/opencti-platform/opencti-front/src/components/common/dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import { Box, DialogActionsProps, DialogContent, DialogContentProps, DialogTitle
 import MUIDialog, { DialogProps as MUIDialogProps } from '@mui/material/Dialog';
 import { ReactNode } from 'react';
 import IconButton from '../button/IconButton';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../utils/fdsLayer';
 
 type DialogProps = {
   title?: ReactNode;
@@ -38,7 +39,13 @@ const Dialog = ({
       onClick={(e) => e.stopPropagation()}
       slotProps={{
         paper: {
+          // A dialog is a layer-2 surface: the class re-declares the elevation
+          // aliases, `layerInputVars` carries the three input backgrounds the
+          // library's own .layer-N blocks forget. Both must sit on the SAME
+          // node. See utils/fdsLayer.ts.
+          className: fdsLayerClass(SURFACE_LAYER),
           sx: {
+            ...layerInputVars,
             paddingTop: 3,
             // Symmetric with paddingTop. The `py: 0` below is deliberate -- the
             // PAPER owns the outer gutter, not DialogContent -- but the paper

--- a/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
@@ -2,18 +2,33 @@ import { Stack, Typography } from '@mui/material';
 import IconButton from '../button/IconButton';
 import { Close } from '@mui/icons-material';
 import React from 'react';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../utils/fdsLayer';
 
 interface DrawerHeaderProps {
   title: string;
+  /**
+   * The elevation layer this header sits on. Defaults to the drawer layer.
+   *
+   * The header carries the layer class ITSELF rather than trusting its mount:
+   * `StixDomainObjectEdition` puts this header inside a RAW MUI Drawer, which
+   * declares no layer, so reading the bare `--bg-elevation-heading` fell back
+   * to layer 0 and the header came out a step too dark. Inside the shared
+   * Drawer the paper already declares the same layer, so re-declaring it here
+   * is a no-op. Exposed as a prop so a drawer at another depth can say so
+   * rather than inherit a wrong constant.
+   */
+  layer?: Parameters<typeof fdsLayerClass>[0];
   onClose?: () => void;
   endContent?: React.ReactNode;
 }
 
-const DrawerHeader = ({ title, onClose, endContent }: DrawerHeaderProps) => {
+const DrawerHeader = ({ title, onClose, endContent, layer = SURFACE_LAYER }: DrawerHeaderProps) => {
   return (
     <Stack
       direction="row"
+      className={fdsLayerClass(layer)}
       sx={{
+        ...layerInputVars,
         // Resolves to the layer-2 value: the drawer paper declares layer 2.
         backgroundColor: 'var(--bg-elevation-heading)',
         paddingX: 3,

--- a/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
@@ -1,6 +1,3 @@
-import { useTheme } from '@mui/styles';
-import { Theme } from '../../Theme';
-import { FDS } from '../../fds-tokens.generated';
 import { Stack, Typography } from '@mui/material';
 import IconButton from '../button/IconButton';
 import { Close } from '@mui/icons-material';
@@ -13,20 +10,12 @@ interface DrawerHeaderProps {
 }
 
 const DrawerHeader = ({ title, onClose, endContent }: DrawerHeaderProps) => {
-  const theme = useTheme<Theme>();
-  // Figma node 5415-3010 (Design_System_2026) draws the drawer on elevation
-  // LAYER 2, not on the bare alias. Read straight off that node, the header is
-  // #101b33 and the body #13213e in dark -- which are `-layer-2`, while the
-  // unsuffixed `--bg-elevation-*` aliases resolve to layer 0 (#070d18). Two
-  // independent hexes both landing on layer 2 is what fixes the layer; taking
-  // the bare alias would have painted the drawer a full step too dark.
-  // Colours only: the structural conversion to a library drawer comes later.
-  const fds = theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark;
   return (
     <Stack
       direction="row"
       sx={{
-        backgroundColor: fds['--bg-elevation-heading-layer-2'],
+        // Resolves to the layer-2 value: the drawer paper declares layer 2.
+        backgroundColor: 'var(--bg-elevation-heading)',
         paddingX: 3,
         paddingY: 2,
         alignItems: 'center',

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -4,7 +4,7 @@ import DrawerMUI from '@mui/material/Drawer';
 import Fab from '@mui/material/Fab';
 import { createStyles, useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
-import { FDS } from '../../../../components/fds-tokens.generated';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 import classNames from 'classnames';
 import React, { CSSProperties, forwardRef, isValidElement, useEffect, useState } from 'react';
 import { SubscriptionAvatars } from '../../../../components/Subscription';
@@ -234,7 +234,15 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
         slotProps={{
           paper: {
             ref,
+            // A drawer is a layer-2 surface. The class re-declares the
+            // elevation aliases; `layerInputVars` carries the three input
+            // backgrounds the library's own .layer-N blocks forget, and both
+            // must sit on the SAME node. With the layer declared, the colours
+            // below are plain aliases instead of the hardcoded layer-2 values
+            // this file used to carry -- the layer now decides them.
+            className: fdsLayerClass(SURFACE_LAYER),
             sx: {
+              ...layerInputVars,
               minHeight: '100vh',
               width: getDrawerWidth(size),
               position: 'fixed',
@@ -247,7 +255,7 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
               paddingBottom: `${bannerHeightNumber}px`,
               // The sheet itself, so the banner gutters above and below the
               // body match it instead of showing MUI's own Paper colour.
-              backgroundColor: (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark)['--bg-elevation-default-layer-2'],
+              backgroundColor: 'var(--bg-elevation-default)',
             },
           },
         }}
@@ -267,10 +275,9 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
           className={classes.container}
           style={{
             ...containerStyle,
-            // Figma node 5415-3010: the drawer body is elevation LAYER 2
-            // (#13213e dark), not the bare `--bg-elevation-default` alias,
-            // which resolves to layer 0 (#070d18) -- a full step too dark.
-            backgroundColor: (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark)['--bg-elevation-default-layer-2'],
+            // Figma node 5415-3010. The alias is correct now that the paper
+            // declares layer 2 -- it resolves to the layer-2 value here.
+            backgroundColor: 'var(--bg-elevation-default)',
           }}
         >
           {renderSubHeader()}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
@@ -8,6 +8,7 @@ import inject18n from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import StixDomainObjectEditionOverview from './StixDomainObjectEditionOverview';
 import Loader from '../../../../components/Loader';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const styles = (theme) => ({
   drawerPaperInGraph: {
@@ -49,8 +50,10 @@ class StixDomainObjectEdition extends Component {
         open={open}
         anchor="right"
         elevation={0}
-        sx={{ zIndex: 1202 }}
-        classes={{ paper: classes.drawerPaperInGraph }}
+        // Raw MUI Drawer, not the shared one: it has to declare the layer
+        // itself or its fields resolve at layer 0. See utils/fdsLayer.ts.
+        sx={{ zIndex: 1202, '& .MuiDrawer-paper': { ...layerInputVars } }}
+        classes={{ paper: `${classes.drawerPaperInGraph} ${fdsLayerClass(SURFACE_LAYER)}` }}
         onClose={handleClose.bind(this)}
       >
         {stixDomainObjectId ? (

--- a/opencti-platform/opencti-front/src/utils/fdsLayer.ts
+++ b/opencti-platform/opencti-front/src/utils/fdsLayer.ts
@@ -1,0 +1,63 @@
+/**
+ * Elevation LAYERS — the half of the library's contract the product has to
+ * declare itself.
+ *
+ * The library ships `.layer-0` … `.layer-3` classes that re-declare the
+ * elevation aliases (`--bg-elevation-default`, `--bg-elevation-highlight`, …)
+ * to that layer's value. Nesting depth is the whole idea: the page is layer 0,
+ * a panel over it is layer 1, a panel inside that is layer 2 (Figma
+ * 0PmhuZzF9XcaIEfMMW2a51, node 5416-12183).
+ *
+ * The product declared NO layer anywhere, so every surface resolved at the
+ * root — layer 0 — including drawers and dialogs and every field inside them.
+ *
+ * WHY A CLASS IS NOT ENOUGH, and this is the part that bites:
+ *
+ * A `var()` inside a custom-property declaration is substituted at
+ * computed-value time ON THE ELEMENT THAT DECLARES IT. The library declares
+ *
+ *     --bg-input-default: var(--bg-elevation-highlight);
+ *
+ * once, at the root. So it is resolved against the ROOT's highlight — layer 0 —
+ * and adding `.layer-2` further down re-declares the elevation alias but can no
+ * longer reach the input one. Measured in the browser on the served build:
+ *
+ *     context              --bg-elevation-highlight   --bg-input-default
+ *     root (layer 0)       #13213e                    #13213e
+ *     .layer-2 alone       #0c1527                    #13213e   <- the bug
+ *     .layer-2 + below     #0c1527                    #0c1527   <- wanted
+ *
+ * Re-declaring the three aliases ON THE SAME ELEMENT as the layer class makes
+ * them resolve against that element's own elevation values. Exactly three input
+ * tokens alias an elevation token; the rest of the family aliases feedback and
+ * text tokens, which are layer-independent and correctly left alone.
+ *
+ * This is a LIBRARY GAP (LIBRARY-FEEDBACK #57), not a product decision: the
+ * `.layer-N` blocks should carry these three themselves. When they do, drop
+ * `layerInputVars` and keep the class.
+ */
+
+export type FdsLayer = 0 | 1 | 2 | 3;
+
+/**
+ * The three input backgrounds that alias an elevation token, re-declared so
+ * they resolve at the layer of the element carrying them.
+ */
+export const layerInputVars = {
+  '--bg-input-default': 'var(--bg-elevation-highlight)',
+  '--bg-input-disabled': 'var(--bg-elevation-disabled)',
+  '--bg-input-hover': 'var(--bg-elevation-hover)',
+} as const;
+
+/**
+ * The library class for a layer. Put it on the SAME node that carries
+ * `layerInputVars`, or the compensation resolves against the wrong layer.
+ *
+ * Drawers and dialogs are layer 2 — the designer's ruling, and it agrees with
+ * the drawer's own Figma frame (node 5415-3010), whose body reads
+ * `--bg-elevation-default-layer-2`.
+ */
+export const fdsLayerClass = (layer: FdsLayer) => `layer-${layer}`;
+
+/** Drawers and dialogs: layer 2. */
+export const SURFACE_LAYER: FdsLayer = 2;


### PR DESCRIPTION
**The deployed blocker.** Every form field in a drawer or dialog paints the
layer-0 background instead of layer 2's `#0c1527`.

## The system

Layers are **nesting depth** (Figma node `5416-12183`): the page is layer 0, a
panel over it layer 1, a panel inside that layer 2. The library ships
`.layer-0` … `.layer-3` classes that re-declare the elevation aliases to that
layer's value.

**The product declared no layer anywhere**, so every surface — drawers and
dialogs included — resolved at the root.

## Why the class alone is not the fix

A `var()` inside a custom-property declaration is substituted at computed-value
time **on the element that declares it**. The library declares
`--bg-input-default: var(--bg-elevation-highlight)` **once, at the root**, so it
resolves against the root's highlight — layer 0 — and a `.layer-2` further down
re-declares the elevation alias but can no longer reach the input one.

Measured in a browser on the shipped build, not reasoned:

| context | `--bg-elevation-highlight` | `--bg-input-default` |
|---|---|---|
| root (layer 0) | `#13213e` | `#13213e` |
| `.layer-1` | `#182a4e` | `#13213e` |
| `.layer-2` | `#0c1527` | `#13213e` ← **the bug** |
| `.layer-3` | `#13213e` | `#13213e` |

The input background is **constant across every layer**.

Re-declaring those three aliases on the element that carries the class makes
them resolve against that element's own elevation values, and `.layer-2` then
yields **`#0c1527`** — your number, reached *by the system* rather than
hardcoded.

Exactly three input tokens alias an elevation token; the rest of the family
aliases feedback and text tokens, which are layer-independent and correctly left
alone.

## Scope

Applied to the two shared surfaces — **172 dialogs and 233 drawers**. 11 direct
MUI `Dialog`s and 15 direct `Drawer`s still bypass them; that is the next pass.

With the layer declared, the drawer's colours go back to plain aliases: the
hardcoded `-layer-2` lookups from the night-3 repaint are gone, because the
layer now decides them. Same values, derived instead of copied.

## Library gap

**LIBRARY-FEEDBACK #57** — those three declarations belong inside each
`.layer-N` block. Removal test included: delete `layerInputVars` from the
product and a field in a drawer should still read `#0c1527`.

Gates run locally: `check-accessible-names` clean, conformity exit 0, utility
classes clean, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)