### PR TITLE
fix(backend): make Painless update scripts stable (#18012)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/draft-engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/draft-engine.ts
@@ -99,6 +99,10 @@ const elRemoveUpdateElementFromDraft = async (context: AuthContext, user: AuthUs
   }
 };
 
+// The ref field name is a script parameter, so a single script is compiled for every
+// relationship type instead of one per type (see script.max_compilations_rate).
+const DRAFT_APPEND_REF_SCRIPT_SOURCE = 'if (ctx._source[params.field] == null) { ctx._source[params.field] = []; }'
+  + ' ctx._source[params.field].addAll(params.ids);';
 const removeDraftDeleteLinkedRelations = async (
   context: AuthContext,
   user: AuthUser,
@@ -119,11 +123,8 @@ const removeDraftDeleteLinkedRelations = async (
     const targetId = isFromImpact ? rel.toId : rel.fromId;
     // Create params and scripted update
     const field = buildRefRelationKey(rel.relationship_type);
-    let script = `if (ctx._source['${field}'] == null) ctx._source['${field}'] = [];`;
-    script += `ctx._source['${field}'].addAll(params['${field}']);`;
-    const source = script;
-    const params = { [field]: [targetId] };
-    return { ...dep, _id: dep._id, data: { script: { source, params } } };
+    const params = { field, ids: [targetId] };
+    return { ...dep, _id: dep._id, data: { script: { source: DRAFT_APPEND_REF_SCRIPT_SOURCE, params } } };
   }).filter((e) => e);
   const bodyUpdate = elementsToUpdate.flatMap((doc) => [
     { update: { _index: doc._index, _id: doc._id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4529,6 +4529,8 @@ export const copyLiveElementToDraft = async (
   const allDraftIds = allDrafts.map((d) => d.internal_id);
   const addDraftIdScript = {
     script: {
+      // draftId is a script parameter, never interpolated: interpolating it would compile
+      // a new script for every draft ever created (see script.max_compilations_rate).
       source: `
         if (ctx._source.containsKey('draft_ids')) {
           for (int i=ctx._source['draft_ids'].length-1; i>=0; i--) {
@@ -4536,12 +4538,12 @@ export const copyLiveElementToDraft = async (
               ctx._source['draft_ids'].remove(i);
             }
           }
-          ctx._source['draft_ids'].add('${draftContext}');
+          ctx._source['draft_ids'].add(params.draftId);
         }
         else
-          {ctx._source.draft_ids = ['${draftContext}']}
+          {ctx._source.draft_ids = [params.draftId]}
       `,
-      params: { allDraftIds },
+      params: { allDraftIds, draftId: draftContext },
     },
   };
   await elUpdate(context, element._index, element.internal_id, addDraftIdScript);

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4811,6 +4811,79 @@ const validateElementsToIndex = (context: AuthContext, user: AuthUser, elements:
     throw UnsupportedError('Cannot index unsupported element in draft context');
   }
 };
+type DenormalizedRefTarget = { relation: string; field: string; elements: any[] };
+// Field names are script parameters and never interpolated in the source. Interpolating them
+// would compile one script per combination of ref relationship types carried by an entity,
+// which grows with the powerset of the ref types and quickly exhausts script.max_compilations_rate.
+export const EL_DENORMALIZED_REFS_SCRIPT_SOURCE = `
+  for (ref in params.appended_refs) {
+    if (ctx._source[ref.field] == null) { ctx._source[ref.field] = []; }
+    ctx._source[ref.field].addAll(ref.ids);
+  }
+  for (ref in params.distinct_refs) {
+    if (ctx._source[ref.field] == null) { ctx._source[ref.field] = []; }
+    for (id in ref.ids) {
+      if (!ctx._source[ref.field].contains(id)) { ctx._source[ref.field].add(id); }
+    }
+  }
+  for (field in params.timestamp_fields) { ctx._source[field] = params.updated_at; }
+  if (params.pir_ids != null) {
+    if (ctx._source.containsKey('pir_information') && ctx._source['pir_information'] != null) {
+      ctx._source['pir_information'].removeIf(item -> params.pir_ids.contains(item.pir_id));
+      ctx._source['pir_information'].addAll(params.new_pir_information);
+    } else { ctx._source['pir_information'] = params.new_pir_information; }
+  }
+`;
+export const buildDenormalizedRefsScriptParams = (targetsElements: DenormalizedRefTarget[], updatedAt: string) => {
+  const appendedRefs: { field: string; ids: string[] }[] = [];
+  const distinctRefs: { field: string; ids: string[] }[] = [];
+  const timestampFields: string[] = [];
+  const addTimestampField = (field: string) => {
+    if (!timestampFields.includes(field)) timestampFields.push(field);
+  };
+  let pirIds: string[] | null = null;
+  let newPirInformation: any[] | null = null;
+  for (let index = 0; index < targetsElements.length; index += 1) {
+    const target = targetsElements[index];
+    const field = buildRefRelationKey(target.relation, target.field);
+    const ids = target.elements.map((e: any) => e.id);
+    if (isStixRefUnidirectionalRelationship(target.relation)) {
+      // don't try to add unidirectional ref rel if already present (issue#7535)
+      distinctRefs.push({ field, ids });
+    } else {
+      appendedRefs.push({ field, ids });
+    }
+    const fromSide = target.elements.find((e: any) => e.side === 'from');
+    const toSide = target.elements.find((e: any) => e.side === 'to');
+    if (fromSide && isStixRefRelationship(target.relation)) {
+      // updated_at and modified only updated for ref relationships
+      if (isUpdatedAtObject(fromSide.type)) addTimestampField('updated_at');
+      if (isModifiedObject(fromSide.type)) addTimestampField('modified');
+    }
+    // freshness of an entity updated for any relationship
+    if ((fromSide && isUpdatedAtObject(fromSide.type)) || (toSide && isUpdatedAtObject(toSide.type))) {
+      addTimestampField('refreshed_at');
+    }
+    // Add Pir information for in-pir relationships
+    if (target.relation === RELATION_IN_PIR) {
+      // remove pir_information concerning the pir and add the new pir_information
+      newPirInformation = target.elements.map((e: any) => ({
+        pir_id: e.id,
+        pir_score: e.pir_score,
+        last_pir_score_date: updatedAt,
+      }));
+      pirIds = ids;
+    }
+  }
+  return {
+    updated_at: updatedAt,
+    appended_refs: appendedRefs,
+    distinct_refs: distinctRefs,
+    timestamp_fields: timestampFields,
+    pir_ids: pirIds,
+    new_pir_information: newPirInformation,
+  };
+};
 export const elIndexElements = async (
   context: AuthContext,
   user: AuthUser,
@@ -4881,64 +4954,8 @@ export const elIndexElements = async (
         return { relation: relType, field: refField, elements: resolvedData };
       });
       // Create params and scripted update
-      const params: any = { updated_at: now() };
-      const sources = targetsElements.map((t) => {
-        const field = buildRefRelationKey(t.relation, t.field);
-        let script = `if (ctx._source['${field}'] == null) ctx._source['${field}'] = [];`;
-        if (isStixRefUnidirectionalRelationship(t.relation)) {
-          // don't try to add unidirectional ref rel if already present (issue#7535)
-          script += `for(refId in params['${field}']) {
-          if(!ctx._source['${field}'].contains(refId)) { ctx._source['${field}'].add(refId) }} `;
-        } else {
-          script += `ctx._source['${field}'].addAll(params['${field}']);`;
-        }
-        const fromSide = t.elements.find((e: any) => e.side === 'from');
-        const toSide = t.elements.find((e: any) => e.side === 'to');
-        if (fromSide && isStixRefRelationship(t.relation)) {
-          // updated_at and modified only updated for ref relationships
-          if (isUpdatedAtObject(fromSide.type)) {
-            script += 'ctx._source[\'updated_at\'] = params.updated_at;';
-          }
-          if (isModifiedObject(fromSide.type)) {
-            script += 'ctx._source[\'modified\'] = params.updated_at;';
-          }
-        }
-        // freshness of an entity updated for any relationship
-        if ((fromSide && isUpdatedAtObject(fromSide.type)) || (toSide && isUpdatedAtObject(toSide.type))) {
-          script += 'ctx._source[\'refreshed_at\'] = params.updated_at;';
-        }
-        // Add Pir information for in-pir relationships
-        if (t.relation === RELATION_IN_PIR) {
-          // remove pir_information concerning the pir and add the new pir_information
-          script += `
-            if (ctx._source.containsKey('pir_information') && ctx._source['pir_information'] != null) {
-              ctx._source['pir_information'].removeIf(item -> params.pir_ids.contains(item.pir_id));
-              ctx._source['pir_information'].addAll(params.new_pir_information);
-            } else { ctx._source['pir_information'] = params.new_pir_information; }
-          `;
-        }
-        return script;
-      });
-      // Concat sources scripts by adding a ';' between each script to close each final script line
-      const source = sources.length > 1 ? R.join(' ', sources) : `${R.head(sources)}`;
-      // Construct params
-      for (let index = 0; index < targetsElements.length; index += 1) {
-        const targetElement = targetsElements[index];
-        params[buildRefRelationKey(targetElement.relation, targetElement.field)] = targetElement.elements.map((e: any) => e.id);
-      }
-      // Add new_pir_information params
-      const pirElements = targetsElements.filter((e) => e.relation === RELATION_IN_PIR);
-      for (let index = 0; index < pirElements.length; index += 1) {
-        const pirElement = pirElements[index];
-        params.new_pir_information = pirElement.elements
-          .map((e: any) => ({
-            pir_id: e.id,
-            pir_score: e.pir_score,
-            last_pir_score_date: params.updated_at,
-          }));
-        params.pir_ids = pirElement.elements.map((e: any) => e.id);
-      }
-      return { ...entity, id: entityId, data: { script: { source, params } } };
+      const params = buildDenormalizedRefsScriptParams(targetsElements, now());
+      return { ...entity, id: entityId, data: { script: { source: EL_DENORMALIZED_REFS_SCRIPT_SOURCE, params } } };
     });
     // bulk update elements (denormalized relations)
     if (elementsToUpdate.length > 0) {

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4156,6 +4156,26 @@ export const elUpdate = async (
   };
   return retryElOperations(updateOperation);
 };
+// Field names are passed as script parameters and never interpolated in the source.
+// Interpolating them would create one script per field combination, and every distinct
+// source has to be compiled by the engine, quickly exhausting script.max_compilations_rate.
+export const EL_REPLACE_SCRIPT_SOURCE = 'for (entry in params.replacements.entrySet()) { ctx._source[entry.getKey()] = entry.getValue(); }'
+  + ' for (key in params.removals) { ctx._source.remove(key); }';
+export const buildReplaceScriptParams = (doc: Record<string, any>) => {
+  const replacements: Record<string, any> = {};
+  const removals: string[] = [];
+  const entries = Object.entries(doc);
+  for (let index = 0; index < entries.length; index += 1) {
+    const [key, val] = entries[index];
+    // We clean the attribute only if data is null or undefined
+    if (val === undefined || val === null) {
+      removals.push(key);
+    } else {
+      replacements[key] = val;
+    }
+  }
+  return { replacements, removals };
+};
 export const elReplace = async (
   context: AuthContext,
   indexName: string,
@@ -4163,20 +4183,8 @@ export const elReplace = async (
   documentBody: any,
 ) => {
   const doc = R.dissoc('_index', documentBody.doc);
-  const entries = Object.entries(doc);
-  const rawSources = [];
-  for (let index = 0; index < entries.length; index += 1) {
-    const [key, val] = entries[index];
-    // We clean the attribute only if data is null or undefined
-    if (val === undefined || val === null) {
-      rawSources.push(`ctx._source.remove('${key}')`);
-    } else {
-      rawSources.push(`ctx._source['${key}'] = params['${key}']`);
-    }
-  }
-  const source = R.join(';', rawSources);
   return elUpdate(context, indexName, documentId, {
-    script: { source, params: doc },
+    script: { source: EL_REPLACE_SCRIPT_SOURCE, params: buildReplaceScriptParams(doc) },
   });
 };
 export const elDelete = (indexName: string, documentId: string) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildLocalMustFilter, buildReplaceScriptParams, isTransitoryError, prepareElementForIndexing } from '../../../src/database/engine';
+import { buildDenormalizedRefsScriptParams, buildLocalMustFilter, buildReplaceScriptParams, isTransitoryError, prepareElementForIndexing } from '../../../src/database/engine';
+import { RELATION_CREATED_BY, RELATION_OBJECT, RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship';
+import { RELATION_IN_PIR } from '../../../src/schema/internalRelationship';
 import * as engineConfig from '../../../src/database/engine-config';
 
 describe('prepareElementForIndexing testing', () => {
@@ -402,5 +404,57 @@ describe('buildReplaceScriptParams testing', () => {
     const params = buildReplaceScriptParams({});
     expect(params.replacements).toEqual({});
     expect(params.removals).toEqual([]);
+  });
+});
+
+describe('buildDenormalizedRefsScriptParams testing', () => {
+  const UPDATED_AT = '2026-08-30T00:00:00.000Z';
+
+  it('should route unidirectional refs to distinct_refs and the others to appended_refs', () => {
+    const params = buildDenormalizedRefsScriptParams([
+      { relation: RELATION_OBJECT_MARKING, field: 'internal_id', elements: [{ id: 'marking-1', side: 'from', type: 'Report' }] },
+      { relation: RELATION_OBJECT, field: 'internal_id', elements: [{ id: 'object-1', side: 'from', type: 'Report' }] },
+    ], UPDATED_AT);
+    expect(params.distinct_refs).toEqual([{ field: 'rel_object-marking.internal_id', ids: ['marking-1'] }]);
+    expect(params.appended_refs).toEqual([{ field: 'rel_object.internal_id', ids: ['object-1'] }]);
+    expect(params.updated_at).toEqual(UPDATED_AT);
+  });
+
+  it('should deduplicate the timestamp fields across targets', () => {
+    const params = buildDenormalizedRefsScriptParams([
+      { relation: RELATION_OBJECT_MARKING, field: 'internal_id', elements: [{ id: 'marking-1', side: 'from', type: 'Report' }] },
+      { relation: RELATION_CREATED_BY, field: 'internal_id', elements: [{ id: 'author-1', side: 'from', type: 'Report' }] },
+    ], UPDATED_AT);
+    expect(params.timestamp_fields).toEqual(['updated_at', 'modified', 'refreshed_at']);
+  });
+
+  it('should not touch timestamps for a non ref relationship', () => {
+    const params = buildDenormalizedRefsScriptParams([
+      { relation: 'uses', field: 'internal_id', elements: [{ id: 'target-1', side: 'from', type: 'Malware' }] },
+    ], UPDATED_AT);
+    expect(params.timestamp_fields).toEqual(['refreshed_at']);
+  });
+
+  it('should leave pir params null when no in-pir relationship is involved', () => {
+    const params = buildDenormalizedRefsScriptParams([
+      { relation: RELATION_OBJECT_MARKING, field: 'internal_id', elements: [{ id: 'marking-1', side: 'from', type: 'Report' }] },
+    ], UPDATED_AT);
+    expect(params.pir_ids).toBeNull();
+    expect(params.new_pir_information).toBeNull();
+  });
+
+  it('should build pir params for in-pir relationships', () => {
+    const params = buildDenormalizedRefsScriptParams([
+      { relation: RELATION_IN_PIR, field: 'internal_id', elements: [{ id: 'pir-1', side: 'from', type: 'Report', pir_score: 42 }] },
+    ], UPDATED_AT);
+    expect(params.pir_ids).toEqual(['pir-1']);
+    expect(params.new_pir_information).toEqual([{ pir_id: 'pir-1', pir_score: 42, last_pir_score_date: UPDATED_AT }]);
+  });
+
+  it('should support an empty target list', () => {
+    const params = buildDenormalizedRefsScriptParams([], UPDATED_AT);
+    expect(params.appended_refs).toEqual([]);
+    expect(params.distinct_refs).toEqual([]);
+    expect(params.timestamp_fields).toEqual([]);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildLocalMustFilter, isTransitoryError, prepareElementForIndexing } from '../../../src/database/engine';
+import { buildLocalMustFilter, buildReplaceScriptParams, isTransitoryError, prepareElementForIndexing } from '../../../src/database/engine';
 import * as engineConfig from '../../../src/database/engine-config';
 
 describe('prepareElementForIndexing testing', () => {
@@ -376,5 +376,31 @@ describe('isTransitoryError testing', () => {
 
   it('should return false when text fields are empty strings (not matched)', () => {
     expect(isTransitoryError({ message: '', reason: '', type: '', name: '', stack: '' })).toBe(false);
+  });
+});
+
+describe('buildReplaceScriptParams testing', () => {
+  it('should split set and unset attributes', () => {
+    const params = buildReplaceScriptParams({ name: 'test', description: null, score: 0, revoked: false });
+    expect(params.replacements).toEqual({ name: 'test', score: 0, revoked: false });
+    expect(params.removals).toEqual(['description']);
+  });
+
+  it('should remove undefined attributes', () => {
+    const params = buildReplaceScriptParams({ name: 'test', current_state_cursor: undefined });
+    expect(params.replacements).toEqual({ name: 'test' });
+    expect(params.removals).toEqual(['current_state_cursor']);
+  });
+
+  it('should keep empty strings and empty arrays as replacements', () => {
+    const params = buildReplaceScriptParams({ name: '', objectLabel: [] });
+    expect(params.replacements).toEqual({ name: '', objectLabel: [] });
+    expect(params.removals).toEqual([]);
+  });
+
+  it('should support an empty document', () => {
+    const params = buildReplaceScriptParams({});
+    expect(params.replacements).toEqual({});
+    expect(params.removals).toEqual([]);
   });
 });


### PR DESCRIPTION
### Proposed changes

Makes the four unstable Painless sources reported in #18012 constant, by moving field names and identifiers from the script text into the script parameters. Each of them now compiles once and is reused for every update, whatever the shape of the document.

**1. `elIndexElements` denormalized ref update** (`src/database/engine.ts`) — the biggest one, on the ingestion hot path. The per-field fragments and the conditional timestamp / PIR fragments are replaced by a single source driven by `params`:

```painless
for (ref in params.appended_refs) {
  if (ctx._source[ref.field] == null) { ctx._source[ref.field] = []; }
  ctx._source[ref.field].addAll(ref.ids);
}
for (ref in params.distinct_refs) { ... contains() check, issue#7535 ... }
for (field in params.timestamp_fields) { ctx._source[field] = params.updated_at; }
if (params.pir_ids != null) { ... }
```

The unidirectional / bidirectional distinction that used to select a script fragment now selects which of the two parameter lists a ref goes into, so no boolean is evaluated inside the script. `updated_at`, `modified` and `refreshed_at` all received the same value, so they are collected into a deduplicated `timestamp_fields` list. Params building is extracted into `buildDenormalizedRefsScriptParams()`.

**2. `copyLiveElementToDraft`** (`src/database/engine.ts`) — the draft id moves from the source to `params.draftId`. This one added a script per draft, permanently.

**3. `removeDraftDeleteLinkedRelations`** (`src/database/draft-engine.ts`) — the ref field name moves to `params.field`.

**4. `elReplace`** (`src/database/engine.ts`) — the fields to set and unset move to `params.replacements` / `params.removals`. Params building is extracted into `buildReplaceScriptParams()`.

The pattern follows what `elUpdateEntityConnections()` and `elUpdateFilesWithEntityRestrictions()` already do.

Out of scope: the `script` filter operator, which is unbounded by design and gated behind `isEsScriptFilterEnabled()`.

### Related issues

* closes #18012

### How to test this PR

* `yarn test:ci-unit` — `tests/01-unit/database/engine-test.js` covers `buildReplaceScriptParams()` (empty document, `null` / `undefined` unset, falsy-but-present values such as `0`, `false`, `''`, `[]`) and `buildDenormalizedRefsScriptParams()` (unidirectional vs appended routing, timestamp deduplication, non-ref relationship, PIR present / absent, empty target list).
* The four scripts were also replayed against a real Elasticsearch 8.19.20 on a scratch index, checking the resulting `_source` against the one produced by the previous scripts: ref fields absent then present, duplicate skipping on unidirectional refs, timestamps, `pir_information` absent / present / null, no-op update, unset of an absent key, dotted field names, draft id pruning. Same output in all cases, and 40 updates with 40 different field shapes triggered 0 additional compilations.
* Functional coverage otherwise comes from the existing integration suite: `elIndexElements` runs on every entity and relationship creation and `elReplace` is used in ~57 places, so a behaviour change would surface immediately.
* To observe the original problem, start Elasticsearch with a low limit (`-e script.max_compilations_rate=20/1m`) and run the backend integration tests: `master` fails with `circuit_breaking_exception: [script] Too many dynamic script compilations`, this branch does not. `GET _nodes/stats/script` is the direct measure — the `compilations` counter should flatten once the platform is warm.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Two behaviour notes, both verified against Elasticsearch:

* In `elReplace`, all replacements are now applied before all removals, where the previous script interleaved them in document key order. A given key appears only once in the document, so no key can be both set and unset in the same call.
* In `elIndexElements`, appended refs are applied before distinct refs, then the timestamps. Each target group maps to a distinct `rel_*` field, so the reordering cannot make two groups interfere.

The previous `elIndexElements` script also produced the literal source `"undefined"` when the target list was empty (`R.head([])`); the new constant source is a well-formed no-op in that case.
