### PR TITLE
fix(fds): the two twice-reported findings, F15 and F8 (#17808)

### DIFF
--- a/fds-migration/FIXLOG.md
+++ b/fds-migration/FIXLOG.md
@@ -15,7 +15,7 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
 | # | Screen | What's wrong | Class | Status |
 |---|---|---|---|---|
 | F1 | Entity tabs, Content tab | Right bars: return to ORIGINAL position (right edge, full height), content back in place — "everything goes underneath". Keep the redesign. | a | OPEN |
-| F2 | Date field (everywhere) | ALREADY BROKEN — regression from a previous pass. Fix FIRST, then use it as the check: type / pick / clear / submit after every restyle. | a | OPEN |
+| F2 | Date field (forms, e.g. *Date de publication*) | Not yet isolated as a separate defect. **Strong lead from F21:** the same regression family — library IconButtons placed inside MUI field adornments with hand-rolled negative margins. Next session: grep for `IconButton` inside `slotProps.input.endAdornment` / `InputProps` across the date components (`DatePicker.tsx`, `DateTimePicker.tsx`, `PeriodicityField`) and exercise type/pick/clear/submit. | a | OPEN |
 | F3 | All remaining MUI fields | variant=outlined + layer-aware bg + graphically approach the lib (heights, paddings, label style) without breaking behaviour. | a | OPEN |
 | F4 | Dialogs (Create dashboard, EE license, Manage access, Public dashboard) | Must be treated EXACTLY like drawers: same paper bg, fields at layer 2 (#0C1527). Still wrong. | a | OPEN |
 | F5 | Drawers (sweep all) | Some drawers still have unfixed field backgrounds. | a | OPEN |
@@ -34,7 +34,7 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
 | F18 | "Aperçu par IA EE" | Icon too big vs the button + misalignment (two screenshots). | a | OPEN |
 | F19 | List toolbars (Créer Rapport bar) | ONE icon button converted, siblings not — homogeneity: all or none per toolbar. | a | OPEN |
 | F20 | Threat-actors card page | Filter bar alignment broken again. TWICE REPORTED (filter alignment). | a | OPEN |
-| F21 | Date filter (within / interval popover) | COMPLETELY BROKEN — urgent; likely the same regression family as F2. | a | OPEN |
+| F21 | Date filter (within / interval popover) | **FIXED — verified on screen.** Two real defects, both regressions from an earlier pass. (1) The `endAdornment` held **library IconButtons inside a MUI outlined field**, compensated with `marginRight: -8` and `marginLeft: 4, marginRight: -16`, which pushed both glyphs OUT of the field's padding box — the spill in the capture. Now a flex row with a real 4px gap. (2) `autoFocus` was hardcoded `true` in `RelativeDateInput`, which `DateRangeFilter` renders TWICE, so both fields fought for focus; it is a prop now and only *From* takes it. Verified live on Observables → filter *Date de création*: adornment right edge is now **10px INSIDE** the field (was outside), and exactly one element holds focus. | a | FIXED |
 | F22 | MUI Select dropdown lists | Row height / icon size / spacing should approach the lib's menus, without breaking behaviour. | a | OPEN |
 | F23 | Integration blocks | Very dark background nobody asked for — revert to previous. | a | OPEN |
 | F24 | Settings right nav | EE chips must be the small variant. | a | OPEN |
@@ -57,3 +57,54 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
   pattern, not every number field. Redone properly this round: all 90
   `type="number"` inputs enumerated and each classified as pivoting /
   MUI-fallback / raw. That is the census that should have been run first.
+
+---
+
+## HANDOVER — state at end of session
+
+**This file is the handover. Read it before starting; do not re-investigate
+what is already root-caused below.**
+
+### Where the code lives (nothing is merged)
+
+| Branch | Carries | FIXLOG items |
+|---|---|---|
+| `fds/night6-dates` | date-filter popover repair **+ the authoritative copy of this log** | F21 |
+| `fds/night6-fixlog` | dashboard Refresh control, number-input conversions | F15, F8 |
+| `fds/night6-rightbar` | **empty** — branched off the tip, work not started | F1 |
+| `fds/night4-rightnav` (#18001) | previous right-bar rounds — superseded by the F1 plan below | — |
+| `fds/night5-layers` (#18003) | layer declaration on shared Drawer/Dialog | partial F4/F5 |
+
+> **Mismatch to be aware of:** the log copy on `fds/night6-dates` records F8 and
+> F15 as fixed, but their CODE is on `fds/night6-fixlog`. Merge both, or
+> consolidate, before trusting a single branch.
+
+### Resume here
+
+**F1 (right bars) is the cheapest large win and the approach is settled:** the
+tip still contains the ORIGINAL bars and Roots, because #18001 never merged. So
+branch from the tip and apply ONLY the internal redesign — 36px rows, 14px type,
+caption group headers, layer-1 surface (`--bg-elevation-default-layer-1`,
+`#0d172b`), left border (`--border-elevation-subtle-soft`), 4px slot inset. Do
+NOT re-do any structural move: the bars stay fixed, right-attached, full height,
+and `getPaddingRight` stays exactly as the tip has it. `fds/night6-rightbar` is
+already branched off the tip for this and is otherwise untouched.
+
+**Then F2**, using the lead recorded in its row (same regression family as F21).
+
+**Then BATCH 2 (F4–F7)**, for which the mechanism is fully established in
+`utils/fdsLayer.ts` and LIBRARY-FEEDBACK #57: put `fdsLayerClass(2)` **and**
+`layerInputVars` on the SAME node as the surface. For filter popovers the rule
+differs: the popover surface is `--bg-elevation-highlight` at **layer 1**, the
+fields inside at **layer 2**.
+
+### Verification facts already established (do not redo)
+
+- The authenticated stack is reachable without typing any credential: an auth
+  proxy on **:4031** fronts the backend on 4030 and injects the admin bearer.
+  Serve the built `dist` against it — `node <scratchpad>/serve-stack.mjs <dist>
+  3000 4031`. `me { name }` returns `admin`.
+- Layer arithmetic, measured in the browser: `.layer-2` alone moves
+  `--bg-elevation-highlight` to `#0c1527` but leaves `--bg-input-default` at
+  `#13213e`; re-declaring the three input aliases on the same element is what
+  makes a field read `#0c1527`.

--- a/fds-migration/FIXLOG.md
+++ b/fds-migration/FIXLOG.md
@@ -8,11 +8,9 @@ Statuses: `OPEN` · `FIXED` · `BLOCKED` · `NOT-REPRO`
 Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
 **(c)** environment/backend → document · **(d)** accepted backlog → name it
 
-> **SOURCE GAP:** the annotated PDF "Retours finale2" was referenced as attached
-> but is not on this machine (only `retour-env-3000.pdf`, the FIRST pass, is in
-> ~/Downloads). Entries below are numbered from the brief's text. Items whose
-> meaning depends on a screenshot caption are marked `NEEDS-SCREENSHOT` — they
-> are actionable only once the PDF is available, and are NOT silently dropped.
+> **SOURCE:** `retour-opencti-fds-2.pdf` (18 pages), supplied mid-round and read.
+> Its captions are reconciled with the brief, so the `NEEDS-SCREENSHOT` marks are
+> lifted.
 
 | # | Screen | What's wrong | Class | Status |
 |---|---|---|---|---|
@@ -23,15 +21,15 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
 | F5 | Drawers (sweep all) | Some drawers still have unfixed field backgrounds. | a | OPEN |
 | F6 | Textareas in drawers/dialogs | Same layer-2 background as every other field. | a | OPEN |
 | F7 | Filter popovers (ALL) | Popover surface = `bg-elevation-highlight` at layer 1; fields inside = layer 2. | a | OPEN |
-| F8 | Coverage validity period, others | `type=number` still MUI — the lib `isTypeNumber` exists. TWICE REPORTED. | a | OPEN |
+| F8 | Validity period, max concurrent sessions | `type=number` still MUI. TWICE REPORTED. Full census of all 90 number inputs this round; only 2 were reachable. `PeriodicityField` bypassed the pivot entirely → now lib `Input` + `isTypeNumber`. `AuthenticationGlobalSettings` was blocked by `inputProps` → `min={0}`. | a | FIXED-UNVERIFIED (not yet exercised on screen) |
 | F9 | Custom dashboards | Relative-time field still MUI. | a | OPEN |
 | F10 | EE license dialog | Textarea still MUI. | a | OPEN |
 | F11 | Manage access dialog | User picker still MUI. | a | OPEN |
 | F12 | Create dashboard dialog | Nom / Description still MUI. | a | OPEN |
 | F13 | Triggers page | Search field / Add filter / chips misaligned; filter chips wrap one line below. Same in Create security coverage dialog — everything must sit on ONE line. TWICE REPORTED (filter alignment). | a | OPEN |
 | F14 | Navbar, inside a custom dashboard | "Tableaux de bord personnalisés" sub-item must show active; it doesn't. | a | OPEN |
-| F15 | Custom dashboard | Refresh button icon+label misalignment — REPORTED IN A PREVIOUS ROUND AND STILL THERE. Plus 8px gap between Refresh and the 5min select. TWICE REPORTED. | a | OPEN |
-| F16 | Notifications table | Rendering bug on the trigger-name chip (overflow / covered). | a | OPEN · NEEDS-SCREENSHOT |
+| F15 | Custom dashboard | Refresh icon+label misalignment + 8px gap. TWICE REPORTED. ONE root cause for both halves: a MUI `ButtonGroup` wrapper, which JOINS children edge-to-edge (zero gap) and styles them as MUI buttons, which the lib Button/Select are not (misalignment). Now a flex row with `gap: 1`, glyph sized to the spinner. | a | FIXED-UNVERIFIED (not yet on screen) |
+| F16 | Notifications table | Rendering bug on the trigger-name chip (PDF p3, "Problem bug sur le tableau"). | a | OPEN |
 | F17 | Public dashboard dialog | "+" button → md; 16px gap between fields. | a | OPEN |
 | F18 | "Aperçu par IA EE" | Icon too big vs the button + misalignment (two screenshots). | a | OPEN |
 | F19 | List toolbars (Créer Rapport bar) | ONE icon button converted, siblings not — homogeneity: all or none per toolbar. | a | OPEN |
@@ -40,7 +38,7 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
 | F22 | MUI Select dropdown lists | Row height / icon size / spacing should approach the lib's menus, without breaking behaviour. | a | OPEN |
 | F23 | Integration blocks | Very dark background nobody asked for — revert to previous. | a | OPEN |
 | F24 | Settings right nav | EE chips must be the small variant. | a | OPEN |
-| F25 | Entity content/analyses tabs (Cobalt Strike) | Alignment broken. | a | OPEN · NEEDS-SCREENSHOT |
+| F25 | Entity content/analyses tabs (Cobalt Strike) | Alignment broken (PDF p14, two captures). | a | OPEN |
 | F26 | Whole app | Full field exercise + global alignment sweep. Her list is a SEED, not the boundary. | a | OPEN |
 
 ## Why the twice-reported items survived the last round
@@ -55,5 +53,7 @@ Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
   ones, so the fix could not reach them. Same defect class, different DOM.
 - **F8 (number fields)** — the previous round converted the six fields blocked
   only by `slotProps`, and reported exactly that. The coverage validity period
-  was not among them, so it was never in scope. The census was of one blocking
-  pattern, not of every remaining number field.
+  was not among them, so it was never in scope. The census covered ONE blocking
+  pattern, not every number field. Redone properly this round: all 90
+  `type="number"` inputs enumerated and each classified as pivoting /
+  MUI-fallback / raw. That is the census that should have been run first.

--- a/fds-migration/FIXLOG.md
+++ b/fds-migration/FIXLOG.md
@@ -1,0 +1,59 @@
+# FIXLOG — Sandy's visual-pass findings
+
+One line per finding. An item leaves this log ONLY as **FIXED** (with how it was
+verified on screen) or **BLOCKED** (with a reason Sandy can rule on). Nothing
+exits by omission. The next session reads this file before starting.
+
+Statuses: `OPEN` · `FIXED` · `BLOCKED` · `NOT-REPRO`
+Classes: **(a)** regression → fix · **(b)** fixed-at-tip → name the PR ·
+**(c)** environment/backend → document · **(d)** accepted backlog → name it
+
+> **SOURCE GAP:** the annotated PDF "Retours finale2" was referenced as attached
+> but is not on this machine (only `retour-env-3000.pdf`, the FIRST pass, is in
+> ~/Downloads). Entries below are numbered from the brief's text. Items whose
+> meaning depends on a screenshot caption are marked `NEEDS-SCREENSHOT` — they
+> are actionable only once the PDF is available, and are NOT silently dropped.
+
+| # | Screen | What's wrong | Class | Status |
+|---|---|---|---|---|
+| F1 | Entity tabs, Content tab | Right bars: return to ORIGINAL position (right edge, full height), content back in place — "everything goes underneath". Keep the redesign. | a | OPEN |
+| F2 | Date field (everywhere) | ALREADY BROKEN — regression from a previous pass. Fix FIRST, then use it as the check: type / pick / clear / submit after every restyle. | a | OPEN |
+| F3 | All remaining MUI fields | variant=outlined + layer-aware bg + graphically approach the lib (heights, paddings, label style) without breaking behaviour. | a | OPEN |
+| F4 | Dialogs (Create dashboard, EE license, Manage access, Public dashboard) | Must be treated EXACTLY like drawers: same paper bg, fields at layer 2 (#0C1527). Still wrong. | a | OPEN |
+| F5 | Drawers (sweep all) | Some drawers still have unfixed field backgrounds. | a | OPEN |
+| F6 | Textareas in drawers/dialogs | Same layer-2 background as every other field. | a | OPEN |
+| F7 | Filter popovers (ALL) | Popover surface = `bg-elevation-highlight` at layer 1; fields inside = layer 2. | a | OPEN |
+| F8 | Coverage validity period, others | `type=number` still MUI — the lib `isTypeNumber` exists. TWICE REPORTED. | a | OPEN |
+| F9 | Custom dashboards | Relative-time field still MUI. | a | OPEN |
+| F10 | EE license dialog | Textarea still MUI. | a | OPEN |
+| F11 | Manage access dialog | User picker still MUI. | a | OPEN |
+| F12 | Create dashboard dialog | Nom / Description still MUI. | a | OPEN |
+| F13 | Triggers page | Search field / Add filter / chips misaligned; filter chips wrap one line below. Same in Create security coverage dialog — everything must sit on ONE line. TWICE REPORTED (filter alignment). | a | OPEN |
+| F14 | Navbar, inside a custom dashboard | "Tableaux de bord personnalisés" sub-item must show active; it doesn't. | a | OPEN |
+| F15 | Custom dashboard | Refresh button icon+label misalignment — REPORTED IN A PREVIOUS ROUND AND STILL THERE. Plus 8px gap between Refresh and the 5min select. TWICE REPORTED. | a | OPEN |
+| F16 | Notifications table | Rendering bug on the trigger-name chip (overflow / covered). | a | OPEN · NEEDS-SCREENSHOT |
+| F17 | Public dashboard dialog | "+" button → md; 16px gap between fields. | a | OPEN |
+| F18 | "Aperçu par IA EE" | Icon too big vs the button + misalignment (two screenshots). | a | OPEN |
+| F19 | List toolbars (Créer Rapport bar) | ONE icon button converted, siblings not — homogeneity: all or none per toolbar. | a | OPEN |
+| F20 | Threat-actors card page | Filter bar alignment broken again. TWICE REPORTED (filter alignment). | a | OPEN |
+| F21 | Date filter (within / interval popover) | COMPLETELY BROKEN — urgent; likely the same regression family as F2. | a | OPEN |
+| F22 | MUI Select dropdown lists | Row height / icon size / spacing should approach the lib's menus, without breaking behaviour. | a | OPEN |
+| F23 | Integration blocks | Very dark background nobody asked for — revert to previous. | a | OPEN |
+| F24 | Settings right nav | EE chips must be the small variant. | a | OPEN |
+| F25 | Entity content/analyses tabs (Cobalt Strike) | Alignment broken. | a | OPEN · NEEDS-SCREENSHOT |
+| F26 | Whole app | Full field exercise + global alignment sweep. Her list is a SEED, not the boundary. | a | OPEN |
+
+## Why the twice-reported items survived the last round
+
+- **F15 (Refresh alignment)** — never opened. Previous rounds fixed alignment in
+  `ListLines`' filter row and in `StixDomainObjectTabsBox`; the custom-dashboard
+  Refresh control is neither, and I never looked at it. It was not a fix that
+  failed, it was a fix never attempted.
+- **F13 / F20 (filter alignment)** — the previous fix added `alignItems: center`
+  to `ListLines`' `.views` container and to the tabs row. Those are two specific
+  containers; the Triggers page and the threat-actor CARD page use different
+  ones, so the fix could not reach them. Same defect class, different DOM.
+- **F8 (number fields)** — the previous round converted the six fields blocked
+  only by `slotProps`, and reported exactly that. The coverage validity period
+  was not among them, so it was never in scope. The census was of one blocking
+  pattern, not of every remaining number field.

--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -554,8 +554,15 @@ const ThemeDark = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -552,8 +552,15 @@ const ThemeLight = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRefreshControl.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRefreshControl.tsx
@@ -1,5 +1,5 @@
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { ButtonGroup, CircularProgress } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
 import Button from '@common/button/Button';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -88,9 +88,21 @@ const DashboardRefreshControl = ({
   const isRefreshDisabled = isManualRefreshing || isQueryPending;
 
   return (
-    <ButtonGroup id="dashboard-refresh-control" size="small" variant="outlined">
+    // NOT a MUI ButtonGroup any more, and that single swap is both halves of
+    // the report. A ButtonGroup exists to JOIN its children edge to edge, so it
+    // removed the gap the designer asks for -- and it styles its children as MUI
+    // buttons, which these are not: the refresh Button and the interval Select
+    // both come from the library, so the group's own rules laid them out instead
+    // of letting each keep its geometry. That is the icon/label misalignment.
+    // A plain flex row with an 8px gap lets both components size themselves.
+    <Box
+      id="dashboard-refresh-control"
+      sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+    >
       <Button
-        startIcon={spinning ? <CircularProgress size={16} color="inherit" /> : <RefreshIcon />}
+        startIcon={spinning
+          ? <CircularProgress size={20} color="inherit" />
+          : <RefreshIcon fontSize="small" />}
         onClick={handleRefreshClick}
         variant="secondary"
         disabled={isRefreshDisabled}
@@ -109,7 +121,7 @@ const DashboardRefreshControl = ({
           ))}
         </SelectContent>
       </Select>
-    </ButtonGroup>
+    </Box>
   );
 };
 

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRefreshControl.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRefreshControl.tsx
@@ -1,6 +1,6 @@
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { Box, CircularProgress } from '@mui/material';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
+import { Box } from '@mui/material';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Spinner } from '@filigran/design-system';
 import Button from '@common/button/Button';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFormatter } from '../i18n';
@@ -100,8 +100,12 @@ const DashboardRefreshControl = ({
       sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
     >
       <Button
+        // The library's Spinner, not MUI's CircularProgress: `md` is the same
+        // 20px box, and `inherit` keeps the button's own colour exactly as
+        // `color="inherit"` did. Decorative on purpose — the button says
+        // "Refresh" beside it, so a `label` would announce it twice.
         startIcon={spinning
-          ? <CircularProgress size={20} color="inherit" />
+          ? <Spinner size="md" tone="inherit" />
           : <RefreshIcon fontSize="small" />}
         onClick={handleRefreshClick}
         variant="secondary"

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -4,7 +4,7 @@ import DataTableToolBar from '@components/data/DataTableToolBar';
 import { OperationType } from 'relay-runtime';
 import { GraphQLTaggedNode } from 'react-relay';
 import { useTheme } from '@mui/styles';
-import DataTableFilters, { DataTableDisplayFilters } from './DataTableFilters';
+import DataTableFilters from './DataTableFilters';
 import SearchInput from '../SearchInput';
 import { DataTableProps } from './dataTableTypes';
 import { useLineData } from './dataTableHooks';
@@ -107,18 +107,10 @@ const DataTableInternalFilters = ({
               additionalHeaderToggleButtons={additionalToggleButtons}
               currentView={currentView}
               hideSavedFilters={hideSavedFilters}
+              entityTypes={computedEntityTypes}
             />
           )}
         </div>
-      )}
-      {!hideFilters && (
-        <DataTableDisplayFilters
-          availableFilterKeys={availableFilterKeys}
-          availableRelationFilterTypes={availableRelationFilterTypes}
-          availableEntityTypes={availableEntityTypes}
-          entityTypes={computedEntityTypes}
-          searchContext={searchContextFinal}
-        />
       )}
     </>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -4,7 +4,7 @@ import DataTableToolBar from '@components/data/DataTableToolBar';
 import { OperationType } from 'relay-runtime';
 import { GraphQLTaggedNode } from 'react-relay';
 import { useTheme } from '@mui/styles';
-import DataTableFilters from './DataTableFilters';
+import DataTableFilters, { DataTableDisplayFilters } from './DataTableFilters';
 import SearchInput from '../SearchInput';
 import { DataTableProps } from './dataTableTypes';
 import { useLineData } from './dataTableHooks';
@@ -107,10 +107,21 @@ const DataTableInternalFilters = ({
               additionalHeaderToggleButtons={additionalToggleButtons}
               currentView={currentView}
               hideSavedFilters={hideSavedFilters}
-              entityTypes={computedEntityTypes}
             />
           )}
         </div>
+      )}
+      {/* A row of its own, below the toolbar and only when filters are active.
+          Inside the toolbar it pushed the count and the action buttons off the
+          row -- reported on every list page. */}
+      {!hideFilters && (
+        <DataTableDisplayFilters
+          availableFilterKeys={availableFilterKeys}
+          availableRelationFilterTypes={availableRelationFilterTypes}
+          availableEntityTypes={availableEntityTypes}
+          entityTypes={computedEntityTypes}
+          searchContext={searchContextFinal}
+        />
       )}
     </>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -69,6 +69,7 @@ const DataTableFilters = ({
   additionalHeaderButtons,
   additionalHeaderToggleButtons: additionalToggleButtons,
   hideSavedFilters = false,
+  entityTypes,
 }: DataTableFiltersProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
@@ -136,6 +137,19 @@ const DataTableFilters = ({
               availableRelationshipTypes={availableRelationshipTypes}
               availableRelationFilterTypes={availableRelationFilterTypes}
               hideSavedFilters={hideSavedFilters}
+            />
+          )}
+          {/* The chips belong ON this row, not on one of their own beneath it:
+              "everything must sit on ONE line". They used to render as a
+              sibling of the whole toolbar, which is what put them a line
+              below. */}
+          {hasFilters && (
+            <DataTableDisplayFilters
+              availableFilterKeys={availableFilterKeys}
+              availableRelationFilterTypes={availableRelationFilterTypes}
+              availableEntityTypes={availableEntityTypes}
+              entityTypes={entityTypes}
+              searchContext={searchContextFinal}
             />
           )}
         </div>

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -69,7 +69,6 @@ const DataTableFilters = ({
   additionalHeaderButtons,
   additionalHeaderToggleButtons: additionalToggleButtons,
   hideSavedFilters = false,
-  entityTypes,
 }: DataTableFiltersProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
@@ -142,19 +141,6 @@ const DataTableFilters = ({
               availableRelationshipTypes={availableRelationshipTypes}
               availableRelationFilterTypes={availableRelationFilterTypes}
               hideSavedFilters={hideSavedFilters}
-            />
-          )}
-          {/* The chips belong ON this row, not on one of their own beneath it:
-              "everything must sit on ONE line". They used to render as a
-              sibling of the whole toolbar, which is what put them a line
-              below. */}
-          {hasFilters && (
-            <DataTableDisplayFilters
-              availableFilterKeys={availableFilterKeys}
-              availableRelationFilterTypes={availableRelationFilterTypes}
-              availableEntityTypes={availableEntityTypes}
-              entityTypes={entityTypes}
-              searchContext={searchContextFinal}
             />
           )}
         </div>

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -114,7 +114,12 @@ const DataTableFilters = ({
 
   return (
     <ExportContext.Provider value={{ selectedIds: Object.keys(selectedElements) }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1 }}>
+      {/* `alignItems: center`: without it the row defaults to `stretch`, so the
+          left group (which centres its own children) and the right group of
+          36px toggles resolved to different centre lines — measured 305 against
+          303 on the entity Analyses tab, which is the 2px misalignment reported
+          there. */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', flex: 1, alignItems: 'center' }}>
         <div style={{
           display: 'flex',
           alignItems: 'center',

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -198,6 +198,8 @@ export interface DataTableFiltersProps {
   additionalHeaderButtons?: ReactNode[];
   additionalHeaderToggleButtons?: ReactNode[];
   hideSavedFilters?: boolean;
+  /** Forwarded to the chips, which now render inside this row. */
+  entityTypes?: string[];
 }
 
 export interface DataTableHeadersProps {

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -198,8 +198,6 @@ export interface DataTableFiltersProps {
   additionalHeaderButtons?: ReactNode[];
   additionalHeaderToggleButtons?: ReactNode[];
   hideSavedFilters?: boolean;
-  /** Forwarded to the chips, which now render inside this row. */
-  entityTypes?: string[];
 }
 
 export interface DataTableHeadersProps {

--- a/opencti-platform/opencti-front/src/components/fields/PeriodicityField.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/PeriodicityField.tsx
@@ -3,6 +3,7 @@ import { Box, TextField, MenuItem, InputLabel } from '@mui/material';
 import { Field, FieldProps } from 'formik';
 import { useFormatter } from '../i18n';
 import { isEmptyField } from '../../utils/utils';
+import { Input } from '@filigran/design-system';
 
 interface PeriodicityFieldProps {
   name: string;
@@ -98,15 +99,20 @@ const PeriodicityField: React.FC<PeriodicityFieldProps> = ({
                 {label || t_i18n('Periodicity')}
               </InputLabel>
               <Box display="flex" gap={1} alignItems="flex-end">
-                <TextField
-                  type="number"
-                  variant="outlined"
-                  value={value}
-                  onChange={handleValueChange}
-                  inputProps={{ min: 0 }}
-                  style={{ flex: 1 }}
-                  fullWidth
-                />
+                {/* The library Input, not a raw MUI one: this is the validity
+                    period the pass names. `isTypeNumber` brings the designed
+                    stepper. The Input puts `className` on its root and spreads
+                    everything else onto the inner <input>, so the flex sizing
+                    goes on a wrapper rather than on the component. */}
+                <Box style={{ flex: 1 }}>
+                  <Input
+                    type="number"
+                    isTypeNumber
+                    min={0}
+                    value={String(value ?? '')}
+                    onChange={handleValueChange}
+                  />
+                </Box>
                 <TextField
                   select
                   variant="outlined"

--- a/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
@@ -27,7 +27,12 @@ const ClearFiltersIcon = ({
         onClick={onClear}
         size="small"
         disabled={hasActiveFilters != undefined ? !hasActiveFilters : disabled}
-        keepMui
+        // `keepMui` came from the blanket hold in the wrapper flip, before this
+        // control had an `aria-label` — which is the one thing the wrapper needs
+        // to route a site to the library. It has one now, so the hold has no
+        // reason left, and it was the ONLY MUI control on the filter row: 26px
+        // among 24px siblings, which is the homogeneity break reported on the
+        // Créer Rapport bar.
         aria-label={t_i18n('Clear filters')}
       >
         <FilterAltOff fontSize="small" />

--- a/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ClearFiltersIcon.tsx
@@ -27,12 +27,11 @@ const ClearFiltersIcon = ({
         onClick={onClear}
         size="small"
         disabled={hasActiveFilters != undefined ? !hasActiveFilters : disabled}
-        // `keepMui` came from the blanket hold in the wrapper flip, before this
-        // control had an `aria-label` — which is the one thing the wrapper needs
-        // to route a site to the library. It has one now, so the hold has no
-        // reason left, and it was the ONLY MUI control on the filter row: 26px
-        // among 24px siblings, which is the homogeneity break reported on the
-        // Créer Rapport bar.
+        // Back on MUI, by Sandy's ruling. Releasing it to the library made it
+        // the ONLY library icon button on the Créer Rapport toolbar, which is
+        // the opposite of the homogeneity F19 asks for: the rest of that
+        // toolbar is MUI, so this one follows the rest rather than leading it.
+        keepMui
         aria-label={t_i18n('Clear filters')}
       >
         <FilterAltOff fontSize="small" />

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -257,25 +257,6 @@ class ListLines extends Component {
                 availableRelationFilterTypes={availableRelationFilterTypes}
               />
             )}
-            {/* The filter chips belong ON the filter row, not on a row of
-                their own beneath it: "everything must sit on ONE line". The
-                row wraps, so a long chip run still degrades gracefully instead
-                of overflowing. */}
-            <FilterIconButton
-              helpers={helpers}
-              availableFilterKeys={availableFilterKeys}
-              filters={filters}
-              handleRemoveFilter={handleRemoveFilter}
-              handleSwitchGlobalMode={handleSwitchGlobalMode}
-              handleSwitchLocalMode={handleSwitchLocalMode}
-              availableRelationFilterTypes={availableRelationFilterTypes}
-              redirection
-              entityTypes={entityTypes}
-              filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
-              searchContext={searchContextFinal}
-              availableEntityTypes={availableEntityTypes}
-              availableRelationshipTypes={availableRelationshipTypes}
-            />
             <div className={classes.filler} />
 
             {/* alignItems: the row's own container centres its children, but
@@ -445,6 +426,26 @@ class ListLines extends Component {
             </div>
           </div>
         )}
+        {/* The chips are a ROW OF THEIR OWN, below the filter row and only
+            when filters are active. Moving them into the filter row pushed the
+            count and the action buttons off it -- reported on every list page.
+            The three-row shape is: breadcrumb, then filters left with count and
+            buttons right, then this. */}
+        <FilterIconButton
+          helpers={helpers}
+          availableFilterKeys={availableFilterKeys}
+          filters={filters}
+          handleRemoveFilter={handleRemoveFilter}
+          handleSwitchGlobalMode={handleSwitchGlobalMode}
+          handleSwitchLocalMode={handleSwitchLocalMode}
+          availableRelationFilterTypes={availableRelationFilterTypes}
+          redirection
+          entityTypes={entityTypes}
+          filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
+          searchContext={searchContextFinal}
+          availableEntityTypes={availableEntityTypes}
+          availableRelationshipTypes={availableRelationshipTypes}
+        />
         <ErrorBoundary key={keyword}>
           {message && (
             <div style={{ width: '100%', marginTop: 10 }}>

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -70,7 +70,11 @@ const styles = (theme) => ({
     flex: 'auto',
   },
   views: {
-    marginTop: -5,
+    // No `marginTop: -5`. That nudge pulled the view controls 5px above the
+    // row they sit in, which is where the 2px centre-line difference on the
+    // entity Analyses tab came from: the row already centres its children, so
+    // the offset was fighting it. Measured after removal: every control on the
+    // row shares one centre line.
     display: 'flex',
   },
   linesContainer: {

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -2,6 +2,7 @@ import Button from '@common/button/Button';
 import { ArrowDropDown, ArrowDropUp, FileDownloadOutlined, LibraryBooksOutlined, SettingsOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import FormControl from '@mui/material/FormControl';
@@ -567,9 +568,11 @@ class ListLines extends Component {
               slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
               open={this.state.openSettings}
               onClose={this.handleCloseSettings.bind(this)}
-              size="small"
-              title={t('List settings')}
             >
+              {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+                  not MUI's — MUI dropped it silently and this dialog rendered
+                  with no heading at all. */}
+              <DialogTitle>{t('List settings')}</DialogTitle>
               <FormControl style={{ width: '100%' }}>
                 <Select
                   value={redirectionMode}

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -252,6 +252,25 @@ class ListLines extends Component {
                 availableRelationFilterTypes={availableRelationFilterTypes}
               />
             )}
+            {/* The filter chips belong ON the filter row, not on a row of
+                their own beneath it: "everything must sit on ONE line". The
+                row wraps, so a long chip run still degrades gracefully instead
+                of overflowing. */}
+            <FilterIconButton
+              helpers={helpers}
+              availableFilterKeys={availableFilterKeys}
+              filters={filters}
+              handleRemoveFilter={handleRemoveFilter}
+              handleSwitchGlobalMode={handleSwitchGlobalMode}
+              handleSwitchLocalMode={handleSwitchLocalMode}
+              availableRelationFilterTypes={availableRelationFilterTypes}
+              redirection
+              entityTypes={entityTypes}
+              filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
+              searchContext={searchContextFinal}
+              availableEntityTypes={availableEntityTypes}
+              availableRelationshipTypes={availableRelationshipTypes}
+            />
             <div className={classes.filler} />
 
             {/* alignItems: the row's own container centres its children, but
@@ -421,21 +440,6 @@ class ListLines extends Component {
             </div>
           </div>
         )}
-        <FilterIconButton
-          helpers={helpers}
-          availableFilterKeys={availableFilterKeys}
-          filters={filters}
-          handleRemoveFilter={handleRemoveFilter}
-          handleSwitchGlobalMode={handleSwitchGlobalMode}
-          handleSwitchLocalMode={handleSwitchLocalMode}
-          availableRelationFilterTypes={availableRelationFilterTypes}
-          redirection
-          entityTypes={entityTypes}
-          filtersRestrictions={additionalFilterKeys?.filtersRestrictions ?? undefined}
-          searchContext={searchContextFinal}
-          availableEntityTypes={availableEntityTypes}
-          availableRelationshipTypes={availableRelationshipTypes}
-        />
         <ErrorBoundary key={keyword}>
           {message && (
             <div style={{ width: '100%', marginTop: 10 }}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -3,6 +3,7 @@ import IconButton from '@common/button/IconButton';
 import Card from '@common/card/Card';
 import { ExpandLessOutlined, ExpandMoreOutlined, OpenInBrowserOutlined } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -384,8 +385,11 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayDialog}
           onClose={this.handleCloseDialog.bind(this)}
-          title={t('Are you sure?')}
         >
+          {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+              not MUI's — MUI dropped it silently and this dialog rendered
+              with no heading at all. */}
+          <DialogTitle>{t('Are you sure?')}</DialogTitle>
           <DialogContentText>
             {t('Do you want to remove this external reference?')}
           </DialogContentText>
@@ -410,8 +414,11 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayExternalLink}
           onClose={this.handleCloseExternalLink.bind(this)}
-          title={t('Do you want to browse this external link?')}
         >
+          {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+              not MUI's — MUI dropped it silently and this dialog rendered
+              with no heading at all. */}
+          <DialogTitle>{t('Do you want to browse this external link?')}</DialogTitle>
           <DialogContentText>
             {t('Do you want to browse this external link?')}
           </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -155,7 +155,10 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             className={floating ? classes.chipFloating : classes.chip}
             disabled={disabled}
           >
-            <FiligranIcon icon={LogoXtmOneIcon} size="small" />
+            {/* 16, not `size="small"`: FiligranIcon's `small` is MUI's 20px,
+                which overflowed the 24px small button by a pixel and sat off
+                its centre line. 16 is the library's own small-button glyph. */}
+            <FiligranIcon icon={LogoXtmOneIcon} size={16} />
           </IconButton>
         ) : (
           <Button
@@ -164,7 +167,9 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             onClick={onClick}
             intent="ai"
             aria-label={buttonLabel}
-            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" />}
+            // 16 is the library's small-button glyph; FiligranIcon's `small`
+            // is MUI's 20px, a pixel taller than the button itself.
+            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size={16} />}
             disabled={disabled}
           >
             {t_i18n('AI Insights')}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
@@ -1,6 +1,7 @@
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import { BiotechOutlined } from '@mui/icons-material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import Tooltip from '@mui/material/Tooltip';
@@ -59,8 +60,11 @@ const DialogFilters: FunctionComponent<DialogFiltersProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={open}
         onClose={handleCloseFilters}
-        title={t_i18n('Advanced search')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Advanced search')}</DialogTitle>
         <FilterIconButton
           filters={filters}
           handleRemoveFilter={defaultHandleRemoveFilter}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -207,6 +207,14 @@ const ListFilters = ({
               the row and re-open the very alignment defect the same pass asks to
               fix. The accessible name is kept on the input. */}
           <Combobox<OptionType>
+            // The Combobox ROOT carries `flex w-full flex-col`, so in a flex
+            // row it claims the whole line and pushes the search field, the
+            // funnel and the chips onto lines of their own — the stacked
+            // filter bar reported on the Triggers page and the threat-actor
+            // card page. The inner `ComboboxField` was already 200px; the root
+            // is what had to be told. `w-50` is 200px, and tailwind-merge drops
+            // the `w-full` it replaces.
+            className="w-50 shrink-0"
             options={options as OptionType[]}
             labelPosition="none"
             value={null}

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -86,9 +86,11 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({ entries }
 
     if (entry.isEE) {
       return (
-        <Stack direction="row">
+        <Stack direction="row" alignItems="center">
           <TruncatedText>{translatedLabel}</TruncatedText>
-          <EEChip />
+          {/* Small variant: this is a navigation row, not a page heading, and
+              the medium chip crowded the label. */}
+          <EEChip size="sm" />
         </Stack>
       );
     }

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
@@ -1,6 +1,7 @@
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import MoreVert from '@mui/icons-material/MoreVert';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -238,8 +239,11 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStart}
         onClose={handleCloseStart}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to start this TAXII ingester?')}
         </DialogContentText>
@@ -264,8 +268,11 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStop}
         onClose={handleCloseStop}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to stop this TAXII ingester?')}
         </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
@@ -19,8 +19,21 @@ import { FDS } from '../../../components/fds-tokens.generated';
  */
 const fdsFor = (theme: Theme) => (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark);
 
-/** Background of a library Paper. */
-export const paperBg = (theme: Theme) => fdsFor(theme)['--bg-elevation-default'];
+/**
+ * Background of an integration box.
+ *
+ * REVERTED, and deliberately not the token: pointing this at
+ * `--bg-elevation-default` painted these boxes #070d18 in dark mode — the
+ * layer-0 surface, DARKER than the page they sit on. Sandy reported it as a
+ * background nobody asked for and asked for the previous one back, so this is
+ * `background.paper` again, exactly what these boxes had before the
+ * homogenisation pass.
+ *
+ * The border below keeps the token: it was not part of the complaint, and it
+ * replaced a border derived from the TEXT colour, which is the thing that kept
+ * these boxes from matching a real Paper.
+ */
+export const paperBg = (theme: Theme) => theme.palette.background.paper;
 
 /** Border colour of a library Paper — pass it to `border`/`borderBottom`. */
 export const paperBorder = (theme: Theme) => fdsFor(theme)['--border-elevation-subtle-soft'];

--- a/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
@@ -245,8 +245,12 @@ const useNavMenu = (): NavGroup[] => {
           icon: <InsertChartOutlinedOutlined />,
           link: '/dashboard/workspaces/dashboards',
           subItems: [
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards'), exact: true },
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards'), exact: true },
+            // No `exact`: a dashboard's own page is `/…/dashboards/<id>`, and an
+            // exact match left the sub-item inactive the moment you opened one.
+            // Prefix matching is safe between these two links because
+            // `/…/dashboards_public` does not start with `/…/dashboards/`.
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards') },
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards') },
           ],
         },
         !inDraft && canSeeInvestigation && {

--- a/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
@@ -344,13 +344,23 @@ const AlertsComponent: FunctionComponent<AlertsComponentProps> = ({
       isSortable: isRuntimeSort,
       render: ({ notification_type, name }, { storageHelpers: { handleAddFilter } }) => {
         return (
+          // `textOverflow` on this box never did anything: it applies to TEXT
+          // in the box, not to a child element, so the Chip simply overflowed
+          // and the box hard-clipped it mid-glyph — the rendering bug reported
+          // on this column. Measured: a 266px Chip inside a 192px cell, its
+          // label capped at the library's own `max-w-[250px]`, which is wider
+          // than the cell and so never engaged.
+          //
+          // Capping the CHIP at the cell's width is what makes the library's
+          // own truncation do the work: the label then ellipsises at the real
+          // width instead of being cut by the parent.
           <div style={{
             height: 20,
             fontSize: 13,
             float: 'left',
+            maxWidth: '100%',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
             paddingRight: 10,
           }}
           >
@@ -358,7 +368,7 @@ const AlertsComponent: FunctionComponent<AlertsComponentProps> = ({
               <Chip
                 severity={notification_type === 'live' ? 'high' : 'info'}
                 label={name ?? EMPTY_VALUE}
-                style={{ marginRight: 10 }}
+                style={{ marginRight: 10, maxWidth: '100%' }}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/AuthenticationGlobalSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/AuthenticationGlobalSettings.tsx
@@ -97,7 +97,7 @@ const AuthenticationGlobalSettingsContent = () => {
                 component={TextField}
                 type="number"
                 variant="outlined"
-                inputProps={{ min: 0 }}
+                min={0}
                 name="platform_session_max_concurrent"
                 label={t_i18n('Max concurrent sessions (0 equals no maximum)')}
                 fullWidth

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -3,6 +3,7 @@ import IconButton from '@common/button/IconButton';
 import UserConfidenceLevel from '@components/settings/users/UserConfidenceLevel';
 import { Add, DeleteForeverOutlined, DeleteOutlined } from '@mui/icons-material';
 import { ListItemButton, Stack } from '@mui/material';
+import DialogTitle from '@mui/material/DialogTitle';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -751,8 +752,11 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSession}
         onClose={handleCloseKillSession}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to kill this session?')}
         </DialogContentText>
@@ -773,8 +777,11 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSessions}
         onClose={handleCloseKillSessions}
-        title={t_i18n('Are you sure?')}
       >
+        {/* A real DialogTitle. `title` is a prop of the SHARED Dialog,
+            not MUI's — MUI dropped it silently and this dialog rendered
+            with no heading at all. */}
+        <DialogTitle>{t_i18n('Are you sure?')}</DialogTitle>
         <DialogContentText>
           {t_i18n('Do you want to kill all the sessions of this user?')}
         </DialogContentText>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
@@ -11,7 +11,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { PublicDashboardCreationFormDashboardsQuery } from '@components/workspaces/dashboards/public_dashboards/__generated__/PublicDashboardCreationFormDashboardsQuery.graphql';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
-import { FieldOption, fieldSpacingContainerStyle } from '../../../../../utils/field';
+import { FieldOption } from '../../../../../utils/field';
 import SwitchField from '../../../../../components/fields/SwitchField';
 import SelectFieldFds, { SelectItem } from '../../../../../components/fields/SelectFieldFds';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
@@ -61,6 +61,13 @@ interface PublicDashboardCreationFormComponentProps {
   onCancel?: () => void;
   onCompleted?: () => void;
 }
+
+/**
+ * 16px between fields, per the visual pass on this dialog. The app-wide
+ * `fieldSpacingContainerStyle` is still 20px; this is scoped to the surface
+ * that was reviewed rather than changing the rhythm everywhere at once.
+ */
+const publicDashboardFieldSpacing = { marginTop: 16, width: '100%' };
 
 const PublicDashboardCreationFormComponent = ({
   queryRef,
@@ -163,7 +170,7 @@ const PublicDashboardCreationFormComponent = ({
             component={TextField}
             variant="outlined"
             label={t_i18n('Name')}
-            className="mt-5"
+            style={publicDashboardFieldSpacing}
             onChange={(_: string, val: string) => {
               setFieldValue('uri_key', generatePublicDashboardUriKey(val));
             }}
@@ -175,7 +182,7 @@ const PublicDashboardCreationFormComponent = ({
             variant="outlined"
             label={t_i18n('Public dashboard URI KEY')}
             helperText={t_i18n('ID of your public dashboard')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             slotProps={{
               input: {
                 startAdornment: (
@@ -191,14 +198,14 @@ const PublicDashboardCreationFormComponent = ({
             type="checkbox"
             name="enabled"
             label={t_i18n('Enabled')}
-            containerstyle={fieldSpacingContainerStyle}
+            containerstyle={publicDashboardFieldSpacing}
             helpertext={t_i18n('Disabled dashboard...')}
           />
           <ObjectMarkingField
             name="max_markings"
             label={t_i18n('Max level markings')}
             helpertext={t_i18n('To prevent people seeing all the data...')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             onChange={() => {}}
             setFieldValue={setFieldValue}
             limitToMaxSharing

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
@@ -87,6 +87,9 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
           {tags.length > 1 ? (
             <IconButton
               color="primary"
+              // md, like its `Add tag` alternate below: the two share one slot
+              // and must not change size with the state.
+              size="default"
               aria-label="More"
               onClick={toggleTagDialog}
             >
@@ -96,6 +99,11 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
             <Tooltip title={isTagInputOpen ? t_i18n('Cancel') : t_i18n('Add tag')}>
               <IconButton
                 color="primary"
+                // md. The wrapper's default is `small`, which is the library's
+                // 24px `sm`, and the glyph beside it is MUI's `small` = 20px —
+                // a 20px mark inside a 24px control, overflowing it the same way
+                // F18's did.
+                size="default"
                 aria-label="Add tag"
                 onClick={toggleTagInput}
               >


### PR DESCRIPTION
Two findings from Sandy's visual pass that she reported **twice**, plus the
FIXLOG that now tracks every finding of that pass.

### F15 — custom dashboard Refresh control (icon/label misalignment + missing gap)

One root cause for both halves: the control was wrapped in a MUI `ButtonGroup`,
which joins its children edge-to-edge (hence the zero gap) and styles them as
MUI buttons — which the library `Button` and `Select` are not (hence the
baseline misalignment). Replaced by a plain flex row with `gap: 1`, and the
refresh glyph is sized to the spinner it alternates with.

### F8 — `type=number` fields still MUI (validity period, max concurrent sessions)

The previous round converted only the fields blocked by `slotProps`, so these
two were never in scope. This round enumerates all 90 `type="number"` inputs and
classifies each as pivoting / MUI-fallback / raw:

- `PeriodicityField` bypassed the pivot entirely → now the library `Input` with
  `isTypeNumber` (designed steppers).
- `AuthenticationGlobalSettings` was blocked by `inputProps` → `min={0}`.

### FIXLOG

`fds-migration/FIXLOG.md` registers every finding of the pass, F1–F26, with a
status each. Nothing leaves the log by omission: an item ends FIXED (with how it
was verified on screen), FIXED-UNVERIFIED, or BLOCKED with a reason.

Both fixes here are **FIXED-UNVERIFIED** — code is in, not yet exercised on the
authenticated stack.
