### PR TITLE
chore(deps): remove react-rectangle-selection (#18017)

### DIFF
--- a/opencti-platform/opencti-front/index.d.ts
+++ b/opencti-platform/opencti-front/index.d.ts
@@ -1,4 +1,3 @@
 declare module '*.png';
 declare module '*.jpg';
 declare module '*.svg';
-declare module 'react-rectangle-selection';

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -111,7 +111,6 @@
     "react-mde": "11.5.0",
     "react-otp-input": "3.1.1",
     "react-pdf": "10.5.0",
-    "react-rectangle-selection": "1.0.4",
     "react-relay": "21.0.1",
     "react-relay-network-modern": "6.2.2",
     "react-router-dom": "6.30.6",
@@ -185,8 +184,6 @@
     "axios": "1.20.0",
     "d3-color": "3.1.0",
     "json5": "2.2.3",
-    "react": "19.2.8",
-    "webpack": "5.110.1",
     "unrs-resolver": "1.11.1",
     "react-relay": "patch:react-relay@21.0.1#./patch/react-relay.patch"
   },

--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -1,7 +1,6 @@
 import ForceGraph2D from 'react-force-graph-2d';
 import ForceGraph3D from 'react-force-graph-3d';
 import React, { type MutableRefObject, ReactNode, useEffect, useRef } from 'react';
-import { v4 as uuid } from 'uuid';
 import { useTheme } from '@mui/material/styles';
 import RectangleSelection from './components/RectangleSelection';
 import { useGraphContext } from './GraphContext';
@@ -27,7 +26,6 @@ const Graph = ({
   onPositionsChanged,
   children,
 }: GraphProps) => {
-  const graphId = `graph-${uuid()}`;
   const theme = useTheme<Theme>();
   const { width, height } = useResizeObserver(parentRef);
   const nodeClicked = useRef<{ node?: GraphNode; time?: number }>({});
@@ -137,11 +135,10 @@ const Graph = ({
 
   return (
     <RectangleSelection
-      graphId={graphId}
       disabled={!selectFreeRectangle}
       onSelection={selectFromFreeRectangle}
     >
-      <div style={{ position: 'relative' }} id={graphId}>
+      <div style={{ position: 'relative' }}>
         <GraphLoadingAlert />
         {selectedEntities.length > 0 && <EntitiesDetailsRightsBar />}
         {mode3D ? (

--- a/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.test.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import testRender from '../../../utils/tests/test-render';
+import RectangleSelection, { RectangleSelectionProps } from './RectangleSelection';
+
+// Offset of the graph canvas in the viewport, as it never sits at the document
+// origin in the application (left navigation and top bar).
+const CANVAS_LEFT = 100;
+const CANVAS_TOP = 50;
+
+const renderSelection = (props?: Partial<RectangleSelectionProps>) => {
+  const onSelection = vi.fn();
+  const { container, unmount } = testRender(
+    <RectangleSelection onSelection={onSelection} {...props}>
+      <div>
+        <button type="button">Toolbar</button>
+        <canvas />
+      </div>
+    </RectangleSelection>,
+  );
+
+  const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+  canvas.getBoundingClientRect = () => ({
+    left: CANVAS_LEFT,
+    top: CANVAS_TOP,
+    right: CANVAS_LEFT + 800,
+    bottom: CANVAS_TOP + 600,
+    width: 800,
+    height: 600,
+    x: CANVAS_LEFT,
+    y: CANVAS_TOP,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+  return { canvas, toolbar: screen.getByRole('button'), onSelection, unmount };
+};
+
+const overlay = () => screen.queryByTestId('rectangle-selection-overlay');
+
+describe('RectangleSelection', () => {
+  it('renders its children and no overlay before any interaction', () => {
+    const { onSelection } = renderSelection();
+    expect(overlay()).toBeNull();
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it('ignores a plain click without any move', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseUp(document);
+    expect(overlay()).toBeNull();
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it('reports coordinates relative to the graph canvas', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    fireEvent.mouseUp(document);
+    expect(onSelection).toHaveBeenCalledTimes(1);
+    expect(onSelection.mock.calls[0][0]).toEqual({
+      origin: [150 - CANVAS_LEFT, 100 - CANVAS_TOP],
+      target: [350 - CANVAS_LEFT, 250 - CANVAS_TOP],
+    });
+  });
+
+  it('normalizes a rectangle dragged towards the top left', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 350, clientY: 250 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 100 });
+    fireEvent.mouseUp(document);
+    expect(onSelection.mock.calls[0][0]).toEqual({
+      origin: [150 - CANVAS_LEFT, 100 - CANVAS_TOP],
+      target: [350 - CANVAS_LEFT, 250 - CANVAS_TOP],
+    });
+  });
+
+  it('forwards the modifier keys held during the drag', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250, shiftKey: true, altKey: true });
+    fireEvent.mouseUp(document);
+    expect(onSelection.mock.calls[0][1]).toEqual({ altKey: true, shiftKey: true });
+  });
+
+  it('draws the overlay over the dragged area', () => {
+    const { canvas } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 350, clientY: 250 });
+    fireEvent.mouseMove(document, { clientX: 150, clientY: 100 });
+    expect(overlay()).toHaveStyle({
+      left: `${150 - CANVAS_LEFT}px`,
+      top: `${100 - CANVAS_TOP}px`,
+      width: '200px',
+      height: '150px',
+    });
+  });
+
+  it('clears the overlay once the drag is released', () => {
+    const { canvas } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    expect(overlay()).not.toBeNull();
+    fireEvent.mouseUp(document);
+    expect(overlay()).toBeNull();
+  });
+
+  it('keeps tracking a drag that runs outside the graph', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    // The cursor leaves the graph, the rectangle must keep following it.
+    fireEvent.mouseOut(canvas, { relatedTarget: document.body });
+    fireEvent.mouseMove(document, { clientX: 900, clientY: 700 });
+    fireEvent.mouseUp(document);
+    expect(onSelection).toHaveBeenCalledTimes(1);
+    expect(onSelection.mock.calls[0][0]).toEqual({
+      origin: [150 - CANVAS_LEFT, 100 - CANVAS_TOP],
+      target: [900 - CANVAS_LEFT, 700 - CANVAS_TOP],
+    });
+  });
+
+  it('does not start a selection outside the graph canvas', () => {
+    const { toolbar, onSelection } = renderSelection();
+    fireEvent.mouseDown(toolbar, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    fireEvent.mouseUp(document);
+    expect(overlay()).toBeNull();
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it('does not start a selection on a non-primary button', () => {
+    const { canvas, onSelection } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 2, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    fireEvent.mouseUp(document);
+    expect(overlay()).toBeNull();
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const { canvas, onSelection } = renderSelection({ disabled: true });
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    fireEvent.mouseUp(document);
+    expect(overlay()).toBeNull();
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it('releases the document listeners when unmounted mid-drag', () => {
+    const { canvas, onSelection, unmount } = renderSelection();
+    fireEvent.mouseDown(canvas, { button: 0, clientX: 150, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 350, clientY: 250 });
+    unmount();
+    fireEvent.mouseUp(document);
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.tsx
@@ -1,5 +1,4 @@
-import React, { ReactNode, useState } from 'react';
-import RectangleSelectionLib from 'react-rectangle-selection';
+import React, { MouseEvent as ReactMouseEvent, ReactNode, useEffect, useRef, useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { hexToRGB } from '../../../utils/Colors';
 import type { Theme } from '../../Theme';
@@ -15,53 +14,110 @@ interface RectangleKeys {
 }
 
 export interface RectangleSelectionProps {
-  graphId: string;
   children: ReactNode;
   onSelection: (coords: RectangleCoordinates, keys: RectangleKeys) => void;
   disabled?: boolean;
 }
 
+interface Selection extends RectangleCoordinates {
+  keys: RectangleKeys;
+}
+
+/**
+ * Project a pointer position into the coordinate system of the graph canvas.
+ * getBoundingClientRect() and clientX/clientY are both viewport-relative, so
+ * no scroll compensation is needed here.
+ */
+const canvasPoint = (
+  { clientX, clientY }: { clientX: number; clientY: number },
+  rect: DOMRect | null,
+): [number, number] => {
+  const { left, top } = rect ?? { left: 0, top: 0 };
+  return [clientX - left, clientY - top];
+};
+
+/**
+ * Order the two corners of a drag into a top-left / bottom-right pair, so
+ * consumers always receive a normalized rectangle whatever the direction
+ * the user dragged in.
+ */
+const normalize = ({ origin, target }: RectangleCoordinates): RectangleCoordinates => ({
+  origin: [Math.min(origin[0], target[0]), Math.min(origin[1], target[1])],
+  target: [Math.max(origin[0], target[0]), Math.max(origin[1], target[1])],
+});
+
+/**
+ * Draw a selection rectangle over the graph and hand its coordinates over
+ * once the drag is released.
+ *
+ * Coordinates are relative to the graph canvas, as consumers convert them
+ * back to graph space with ForceGraphMethods.screen2GraphCoords().
+ */
 const RectangleSelection = ({
-  graphId,
   children,
   onSelection,
   disabled = false,
 }: RectangleSelectionProps) => {
   const theme = useTheme<Theme>();
-  const [coords, setCoords] = useState<RectangleCoordinates | null>(null);
-  const [keys, setKeys] = useState<RectangleKeys>({ altKey: false, shiftKey: false });
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  // Bounding box of the graph canvas, read once when the drag starts to
+  // avoid a layout measurement on every mouse move.
+  const canvasRect = useRef<DOMRect | null>(null);
+  // Origin of the ongoing drag. Kept out of the state so that a plain click
+  // does not draw a rectangle: the selection only exists once the mouse moved.
+  const dragOrigin = useRef<[number, number] | null>(null);
+  // Mirrors the selection so the document listeners, registered once per
+  // drag, always read the rectangle as it currently stands.
+  const currentSelection = useRef<Selection | null>(null);
 
-  const updateStateOnSelect = (
-    { altKey, shiftKey }: MouseEvent,
-    selectionCoords: RectangleCoordinates,
-  ) => {
-    if (!disabled) {
-      setKeys({ altKey, shiftKey });
-      const graphCanvas = document.querySelector(`#${graphId} canvas`);
-      if (graphCanvas) {
-        const { left, top } = graphCanvas.getBoundingClientRect();
-        // The library provides page coordinates (pageX/pageY) but
-        // getBoundingClientRect() is viewport-relative; account for scroll.
-        const offsetLeft = left + window.scrollX;
-        const offsetTop = top + window.scrollY;
-        setCoords({
-          origin: [
-            Math.min(selectionCoords.origin[0], selectionCoords.target[0]) - offsetLeft,
-            Math.min(selectionCoords.origin[1], selectionCoords.target[1]) - offsetTop,
-          ],
-          target: [
-            Math.max(selectionCoords.origin[0], selectionCoords.target[0]) - offsetLeft,
-            Math.max(selectionCoords.origin[1], selectionCoords.target[1]) - offsetTop,
-          ],
-        });
-      }
-    }
+  // A drag may only start on the graph canvas itself: the wrapper also holds
+  // the toolbar, the loading alert and the details bar, which stay clickable.
+  const startSelection = (event: ReactMouseEvent) => {
+    if (disabled || event.button !== 0) return;
+    const canvas = event.target;
+    if (!(canvas instanceof HTMLCanvasElement)) return;
+    canvasRect.current = canvas.getBoundingClientRect();
+    dragOrigin.current = canvasPoint(event, canvasRect.current);
+    setIsDragging(true);
   };
 
-  const sendState = () => {
-    if (!disabled && coords) onSelection(coords, keys);
-    setCoords(null);
-  };
+  // Tracking happens on the document so that a drag running past the edges of
+  // the graph keeps following the cursor and is still applied when the button
+  // is released outside.
+  useEffect(() => {
+    if (!isDragging) return undefined;
+
+    const onMouseMove = (event: MouseEvent) => {
+      if (!dragOrigin.current) return;
+      const drawn = {
+        origin: dragOrigin.current,
+        target: canvasPoint(event, canvasRect.current),
+        keys: { altKey: event.altKey, shiftKey: event.shiftKey },
+      };
+      currentSelection.current = drawn;
+      setSelection(drawn);
+    };
+
+    const onMouseUp = () => {
+      const drawn = currentSelection.current;
+      if (drawn) onSelection(normalize(drawn), drawn.keys);
+      dragOrigin.current = null;
+      canvasRect.current = null;
+      currentSelection.current = null;
+      setSelection(null);
+      setIsDragging(false);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [isDragging, onSelection]);
+
+  const rectangle = selection ? normalize(selection) : null;
 
   const overlayColor = theme.palette.background?.accent
     ? hexToRGB(theme.palette.background.accent, 0.3)
@@ -69,37 +125,33 @@ const RectangleSelection = ({
   const borderColor = theme.palette.warn.main;
 
   return (
-    <RectangleSelectionLib
+    <div
       style={{
-        // Hide the library's built-in selection box: it uses pageX/pageY as
-        // CSS left/top which is incorrect when the graph is not at the
-        // document origin (e.g. behind a side-nav or top-bar).
-        display: 'none',
+        position: 'relative',
+        height: 'inherit',
+        width: 'inherit',
+        userSelect: isDragging ? 'none' : undefined,
       }}
-      disabled={disabled}
-      onMouseUp={sendState}
-      onSelect={updateStateOnSelect}
+      onMouseDown={startSelection}
     >
-      <div style={{ position: 'relative', height: 'inherit', width: 'inherit' }}>
-        {/* Render our own overlay positioned relative to the graph container */}
-        {coords && (
-          <div
-            style={{
-              position: 'absolute',
-              left: coords.origin[0],
-              top: coords.origin[1],
-              width: coords.target[0] - coords.origin[0],
-              height: coords.target[1] - coords.origin[1],
-              backgroundColor: overlayColor,
-              border: `1px dashed ${borderColor}`,
-              pointerEvents: 'none',
-              zIndex: 10,
-            }}
-          />
-        )}
-        {children}
-      </div>
-    </RectangleSelectionLib>
+      {rectangle && (
+        <div
+          data-testid="rectangle-selection-overlay"
+          style={{
+            position: 'absolute',
+            left: rectangle.origin[0],
+            top: rectangle.origin[1],
+            width: rectangle.target[0] - rectangle.origin[0],
+            height: rectangle.target[1] - rectangle.origin[1],
+            backgroundColor: overlayColor,
+            border: `1px dashed ${borderColor}`,
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        />
+      )}
+      {children}
+    </div>
   );
 };
 

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1414,16 +1414,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/source-map@npm:^0.3.3":
-  version: 0.3.11
-  resolution: "@jridgewell/source-map@npm:0.3.11"
-  dependencies:
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-  checksum: 10c0/50a4fdafe0b8f655cb2877e59fe81320272eaa4ccdbe6b9b87f10614b2220399ae3e05c16137a59db1f189523b42c7f88bd097ee991dbd7bc0e01113c583e844
-  languageName: node
-  linkType: hard
-
 "@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
@@ -1431,7 +1421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.31":
+"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.31":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -4400,7 +4390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.3":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -5019,177 +5009,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/ast@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/helper-numbers": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-  checksum: 10c0/67a59be8ed50ddd33fbb2e09daa5193ac215bf7f40a9371be9a0d9797a114d0d1196316d2f3943efdb923a3d809175e1563a3cb80c814fb8edccd1e77494972b
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/floating-point-hex-parser@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/floating-point-hex-parser@npm:1.13.2"
-  checksum: 10c0/0e88bdb8b50507d9938be64df0867f00396b55eba9df7d3546eb5dc0ca64d62e06f8d881ec4a6153f2127d0f4c11d102b6e7d17aec2f26bb5ff95a5e60652412
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-api-error@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-api-error@npm:1.13.2"
-  checksum: 10c0/31be497f996ed30aae4c08cac3cce50c8dcd5b29660383c0155fce1753804fc55d47fcba74e10141c7dd2899033164e117b3bcfcda23a6b043e4ded4f1003dfb
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-buffer@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/helper-buffer@npm:1.14.1"
-  checksum: 10c0/0d54105dc373c0fe6287f1091e41e3a02e36cdc05e8cf8533cdc16c59ff05a646355415893449d3768cda588af451c274f13263300a251dc11a575bc4c9bd210
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-numbers@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-numbers@npm:1.13.2"
-  dependencies:
-    "@webassemblyjs/floating-point-hex-parser": "npm:1.13.2"
-    "@webassemblyjs/helper-api-error": "npm:1.13.2"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/9c46852f31b234a8fb5a5a9d3f027bc542392a0d4de32f1a9c0075d5e8684aa073cb5929b56df565500b3f9cc0a2ab983b650314295b9bf208d1a1651bfc825a
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-bytecode@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/helper-wasm-bytecode@npm:1.13.2"
-  checksum: 10c0/c4355d14f369b30cf3cbdd3acfafc7d0488e086be6d578e3c9780bd1b512932352246be96e034e2a7fcfba4f540ec813352f312bfcbbfe5bcfbf694f82ccc682
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/helper-wasm-section@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/helper-wasm-section@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-  checksum: 10c0/1f9b33731c3c6dbac3a9c483269562fa00d1b6a4e7133217f40e83e975e636fd0f8736e53abd9a47b06b66082ecc976c7384391ab0a68e12d509ea4e4b948d64
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/ieee754@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/ieee754@npm:1.13.2"
-  dependencies:
-    "@xtuc/ieee754": "npm:^1.2.0"
-  checksum: 10c0/2e732ca78c6fbae3c9b112f4915d85caecdab285c0b337954b180460290ccd0fb00d2b1dc4bb69df3504abead5191e0d28d0d17dfd6c9d2f30acac8c4961c8a7
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/leb128@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/leb128@npm:1.13.2"
-  dependencies:
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/dad5ef9e383c8ab523ce432dfd80098384bf01c45f70eb179d594f85ce5db2f80fa8c9cba03adafd85684e6d6310f0d3969a882538975989919329ac4c984659
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/utf8@npm:1.13.2":
-  version: 1.13.2
-  resolution: "@webassemblyjs/utf8@npm:1.13.2"
-  checksum: 10c0/d3fac9130b0e3e5a1a7f2886124a278e9323827c87a2b971e6d0da22a2ba1278ac9f66a4f2e363ecd9fac8da42e6941b22df061a119e5c0335f81006de9ee799
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-edit@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-edit@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-section": "npm:1.14.1"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-    "@webassemblyjs/wasm-opt": "npm:1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:1.14.1"
-    "@webassemblyjs/wast-printer": "npm:1.14.1"
-  checksum: 10c0/5ac4781086a2ca4b320bdbfd965a209655fe8a208ca38d89197148f8597e587c9a2c94fb6bd6f1a7dbd4527c49c6844fcdc2af981f8d793a97bf63a016aa86d2
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-gen@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-gen@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/ieee754": "npm:1.13.2"
-    "@webassemblyjs/leb128": "npm:1.13.2"
-    "@webassemblyjs/utf8": "npm:1.13.2"
-  checksum: 10c0/d678810d7f3f8fecb2e2bdadfb9afad2ec1d2bc79f59e4711ab49c81cec578371e22732d4966f59067abe5fba8e9c54923b57060a729d28d408e608beef67b10
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-opt@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-opt@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-buffer": "npm:1.14.1"
-    "@webassemblyjs/wasm-gen": "npm:1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:1.14.1"
-  checksum: 10c0/515bfb15277ee99ba6b11d2232ddbf22aed32aad6d0956fe8a0a0a004a1b5a3a277a71d9a3a38365d0538ac40d1b7b7243b1a244ad6cd6dece1c1bb2eb5de7ee
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wasm-parser@npm:1.14.1, @webassemblyjs/wasm-parser@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wasm-parser@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@webassemblyjs/helper-api-error": "npm:1.13.2"
-    "@webassemblyjs/helper-wasm-bytecode": "npm:1.13.2"
-    "@webassemblyjs/ieee754": "npm:1.13.2"
-    "@webassemblyjs/leb128": "npm:1.13.2"
-    "@webassemblyjs/utf8": "npm:1.13.2"
-  checksum: 10c0/95427b9e5addbd0f647939bd28e3e06b8deefdbdadcf892385b5edc70091bf9b92fa5faac3fce8333554437c5d85835afef8c8a7d9d27ab6ba01ffab954db8c6
-  languageName: node
-  linkType: hard
-
-"@webassemblyjs/wast-printer@npm:1.14.1":
-  version: 1.14.1
-  resolution: "@webassemblyjs/wast-printer@npm:1.14.1"
-  dependencies:
-    "@webassemblyjs/ast": "npm:1.14.1"
-    "@xtuc/long": "npm:4.2.2"
-  checksum: 10c0/8d7768608996a052545251e896eac079c98e0401842af8dd4de78fba8d90bd505efb6c537e909cd6dae96e09db3fa2e765a6f26492553a675da56e2db51f9d24
-  languageName: node
-  linkType: hard
-
 "@x0k/json-schema-merge@npm:^1.0.3":
   version: 1.0.5
   resolution: "@x0k/json-schema-merge@npm:1.0.5"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
   checksum: 10c0/438ff36ef0ee9c767dffef1736e710de686e0ac94e984d3747b25f183bfaefe03d26db5852b2c5dfffe2b42c901af11d036e9d28875366bea5a6c9118c9d9f39
-  languageName: node
-  linkType: hard
-
-"@xtuc/ieee754@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@xtuc/ieee754@npm:1.2.0"
-  checksum: 10c0/a8565d29d135039bd99ae4b2220d3e167d22cf53f867e491ed479b3f84f895742d0097f935b19aab90265a23d5d46711e4204f14c479ae3637fbf06c4666882f
-  languageName: node
-  linkType: hard
-
-"@xtuc/long@npm:4.2.2":
-  version: 4.2.2
-  resolution: "@xtuc/long@npm:4.2.2"
-  checksum: 10c0/8582cbc69c79ad2d31568c412129bf23d2b1210a1dfb60c82d5a1df93334da4ee51f3057051658569e2c196d8dc33bc05ae6b974a711d0d16e801e1d0647ccd1
   languageName: node
   linkType: hard
 
@@ -5304,17 +5129,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-keywords@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "ajv-keywords@npm:5.1.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-  peerDependencies:
-    ajv: ^8.8.2
-  checksum: 10c0/18bec51f0171b83123ba1d8883c126e60c6f420cef885250898bf77a8d3e65e3bfb9e8564f497e30bdbe762a83e0d144a36931328616a973ee669dc74d4a9590
-  languageName: node
-  linkType: hard
-
 "ajv@npm:^6.14.0":
   version: 6.15.0
   resolution: "ajv@npm:6.15.0"
@@ -5327,7 +5141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.18.0, ajv@npm:^8.20.0, ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.18.0, ajv@npm:^8.20.0":
   version: 8.20.0
   resolution: "ajv@npm:8.20.0"
   dependencies:
@@ -5800,7 +5614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
+"browserslist@npm:^4.24.0":
   version: 4.28.8
   resolution: "browserslist@npm:4.28.8"
   dependencies:
@@ -5819,13 +5633,6 @@ __metadata:
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 10c0/fb2294e64d23c573d0dd1f1e7a466c3e978fe94a4e0f8183937912ca374619773bef8e2aceb854129d2efecbbc515bbd0cc78d2734a3e3031edb0888531bbc8e
-  languageName: node
-  linkType: hard
-
-"buffer-from@npm:^1.0.0":
-  version: 1.1.2
-  resolution: "buffer-from@npm:1.1.2"
-  checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
   languageName: node
   linkType: hard
 
@@ -5993,13 +5800,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chrome-trace-event@npm:^1.0.2":
-  version: 1.0.4
-  resolution: "chrome-trace-event@npm:1.0.4"
-  checksum: 10c0/3058da7a5f4934b87cf6a90ef5fb68ebc5f7d06f143ed5a4650208e5d7acae47bc03ec844b29fbf5ba7e46e8daa6acecc878f7983a4f4bb7271593da91e61ff5
-  languageName: node
-  linkType: hard
-
 "classcat@npm:^5.0.3, classcat@npm:^5.0.4":
   version: 5.0.5
   resolution: "classcat@npm:5.0.5"
@@ -6111,13 +5911,6 @@ __metadata:
   version: 14.0.3
   resolution: "commander@npm:14.0.3"
   checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
-  languageName: node
-  linkType: hard
-
-"commander@npm:^2.20.0":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
   languageName: node
   linkType: hard
 
@@ -7108,16 +6901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.24.4":
-  version: 5.24.5
-  resolution: "enhanced-resolve@npm:5.24.5"
-  dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.3.3"
-  checksum: 10c0/76c32ce5485ecea0ef808c9289bc6f7c49ce85142943598d89a23a846f2909556d3dc6db97a007442a48c185baad5514c1c76d20a2656497f9511d13ccfab73b
-  languageName: node
-  linkType: hard
-
 "entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
@@ -7260,7 +7043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^2.0.0, es-module-lexer@npm:^2.1.0":
+"es-module-lexer@npm:^2.0.0":
   version: 2.3.2
   resolution: "es-module-lexer@npm:2.3.2"
   checksum: 10c0/5e7389424c43478439f12f9a6aca1750f6f99afa384fc3de329f4a45f152ab156671055008adaafc74960877abf8cc338aeebf6bed8c21297b146fd6eb7a22f8
@@ -7744,13 +7527,6 @@ __metadata:
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
-  languageName: node
-  linkType: hard
-
-"events@npm:^3.2.0":
-  version: 3.3.0
-  resolution: "events@npm:3.3.0"
-  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -8582,7 +8358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -9615,17 +9391,6 @@ __metadata:
   version: 1.1.2
   resolution: "jerrypick@npm:1.1.2"
   checksum: 10c0/afb25bfe4a10daf0ba3d17d78e63ef610dc660a1aa7be22fdf439ca010efa86fca0c5e6cbca7b9da9f07c2869ae58e0f5e2433faeba7224ce690938058e4903f
-  languageName: node
-  linkType: hard
-
-"jest-worker@npm:^27.4.5":
-  version: 27.5.1
-  resolution: "jest-worker@npm:27.5.1"
-  dependencies:
-    "@types/node": "npm:*"
-    merge-stream: "npm:^2.0.0"
-    supports-color: "npm:^8.0.0"
-  checksum: 10c0/8c4737ffd03887b3c6768e4cc3ca0269c0336c1e4b1b120943958ddb035ed2a0fc6acab6dc99631720a3720af4e708ff84fb45382ad1e83c27946adf3623969b
   languageName: node
   linkType: hard
 
@@ -10790,13 +10555,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-stream@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "merge-stream@npm:2.0.0"
-  checksum: 10c0/867fdbb30a6d58b011449b8885601ec1690c3e41c759ecd5a9d609094f7aed0096c37823ff4a7190ef0b8f22cc86beb7049196ff68c016e3b3c671d0dac91ce5
-  languageName: node
-  linkType: hard
-
 "meros@npm:^1.1.4":
   version: 1.3.2
   resolution: "meros@npm:1.3.2"
@@ -11211,45 +10969,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimizer-webpack-plugin@npm:^5.7.0":
-  version: 5.8.0
-  resolution: "minimizer-webpack-plugin@npm:5.8.0"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.31"
-    jest-worker: "npm:^27.4.5"
-    schema-utils: "npm:^4.3.3"
-    terser: "npm:^5.51.0"
-  peerDependencies:
-    webpack: ^5.1.0
-  peerDependenciesMeta:
-    "@minify-html/node":
-      optional: true
-    "@swc/core":
-      optional: true
-    "@swc/css":
-      optional: true
-    "@swc/html":
-      optional: true
-    clean-css:
-      optional: true
-    cssnano:
-      optional: true
-    csso:
-      optional: true
-    esbuild:
-      optional: true
-    html-minifier-terser:
-      optional: true
-    lightningcss:
-      optional: true
-    postcss:
-      optional: true
-    uglify-js:
-      optional: true
-  checksum: 10c0/f7dfc6e02ff9b0579661abf91ac2fac0a146f251f6df6b8ea1411185ae7945bb98b14f8c21094d0babd14f5def1500437f77da96410b29ece806c4fdadd73662
-  languageName: node
-  linkType: hard
-
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
   resolution: "minipass-collect@npm:2.0.1"
@@ -11486,13 +11205,6 @@ __metadata:
   dependencies:
     content-type: "npm:^2.1.0"
   checksum: 10c0/656fa57de02f1a0c4c09f9e17eb78e8182547c07093e810ff8f16249b6ae31f2c546a3d457905e94f3276b25f0e2741ea1a3bc3912192932ed7e493adfea535e
-  languageName: node
-  linkType: hard
-
-"neo-async@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "neo-async@npm:2.6.2"
-  checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
   languageName: node
   linkType: hard
 
@@ -11972,7 +11684,6 @@ __metadata:
     react-mde: "npm:11.5.0"
     react-otp-input: "npm:3.1.1"
     react-pdf: "npm:10.5.0"
-    react-rectangle-selection: "npm:1.0.4"
     react-relay: "npm:21.0.1"
     react-relay-network-modern: "npm:6.2.2"
     react-router-dom: "npm:6.30.6"
@@ -13232,16 +12943,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-rectangle-selection@npm:1.0.4":
-  version: 1.0.4
-  resolution: "react-rectangle-selection@npm:1.0.4"
-  dependencies:
-    react: "npm:^16.7.0"
-    webpack: "npm:^4.28.4"
-  checksum: 10c0/54b5bfdd2bdaa62b0e0d895e747f511c9a44caa3d282ecadc8a8f923eb7c3f95663b9a3adce17d0e3b4ff1c4e1d6dc248e3e1d34206e5443bb96e725f341889a
-  languageName: node
-  linkType: hard
-
 "react-redux@npm:8.x.x || 9.x.x, react-redux@npm:^9.2.0":
   version: 9.3.0
   resolution: "react-redux@npm:9.3.0"
@@ -14035,18 +13736,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^4.3.3":
-  version: 4.3.3
-  resolution: "schema-utils@npm:4.3.3"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.9"
-    ajv: "npm:^8.9.0"
-    ajv-formats: "npm:^2.1.1"
-    ajv-keywords: "npm:^5.1.0"
-  checksum: 10c0/1c8d2c480a026d7c02ab2ecbe5919133a096d6a721a3f201fa50663e4f30f6d6ba020dfddd93cb828b66b922e76b342e103edd19a62c95c8f60e9079cc403202
-  languageName: node
-  linkType: hard
-
 "seedrandom@npm:^3.0.5":
   version: 3.0.5
   resolution: "seedrandom@npm:3.0.5"
@@ -14312,27 +14001,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.20":
-  version: 0.5.21
-  resolution: "source-map-support@npm:0.5.21"
-  dependencies:
-    buffer-from: "npm:^1.0.0"
-    source-map: "npm:^0.6.0"
-  checksum: 10c0/9ee09942f415e0f721d6daad3917ec1516af746a8120bba7bb56278707a37f1eb8642bde456e98454b8a885023af81a16e646869975f06afc1a711fb90484e7d
-  languageName: node
-  linkType: hard
-
 "source-map@npm:^0.5.7":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 10c0/904e767bb9c494929be013017380cbba013637da1b28e5943b566031e29df04fba57edf3f093e0914be094648b577372bd8ad247fa98cfba9c600794cd16b599
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.6.0":
-  version: 0.6.1
-  resolution: "source-map@npm:0.6.1"
-  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
   languageName: node
   linkType: hard
 
@@ -14734,15 +14406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^8.0.0":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
-  languageName: node
-  linkType: hard
-
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -14761,13 +14424,6 @@ __metadata:
   version: 6.5.0
   resolution: "tabbable@npm:6.5.0"
   checksum: 10c0/7d778af05a3093800265831198cad9d0024f3d65cdd4405007490f7430b42ff4e80060b4679f45281fb96ddbddc5fb895e8ea36e3ebdc811051e14acc9c7c02c
-  languageName: node
-  linkType: hard
-
-"tapable@npm:^2.3.0, tapable@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "tapable@npm:2.3.3"
-  checksum: 10c0/47992e861053f861154e92fb4a98ac4ab47b6463717e60792dd1e8c755da0c4964cd8bb68c308a9066d6da89000b6310457b4d5d985c30de4ccc29066068cc17
   languageName: node
   linkType: hard
 
@@ -14793,20 +14449,6 @@ __metadata:
     node-fetch: "npm:^3.3.2"
     stream-events: "npm:^1.0.5"
   checksum: 10c0/18b5228feff52a011f601a394bb65f3f2b66e3818618b78de1df80761506e359f4252328f6672763804414041a383ea5a31cc8ccd6dc258c170eb1eaa52c5822
-  languageName: node
-  linkType: hard
-
-"terser@npm:^5.51.0":
-  version: 5.51.2
-  resolution: "terser@npm:5.51.2"
-  dependencies:
-    "@jridgewell/source-map": "npm:^0.3.3"
-    acorn: "npm:^8.15.0"
-    commander: "npm:^2.20.0"
-    source-map-support: "npm:~0.5.20"
-  bin:
-    terser: bin/terser
-  checksum: 10c0/e6dd3d9152ad51b5a990e55bf0647701278970193d2ce2359a401623e65827a27a1803f5d58593a1f0b5e10ff3fa316a8d014d4f88a28d98ea94fb69359aeae5
   languageName: node
   linkType: hard
 
@@ -15829,15 +15471,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.5.2":
-  version: 2.5.2
-  resolution: "watchpack@npm:2.5.2"
-  dependencies:
-    graceful-fs: "npm:^4.1.2"
-  checksum: 10c0/8290e89f03e1e7136e1ef9b8d04bd03822963fa4b442781a40999e7b9ba29ab333a7a5285312b2d4f3e91bc8c5c526cf1f91f5ce0e857dafe56db28ab1c17dca
-  languageName: node
-  linkType: hard
-
 "web-streams-polyfill@npm:^3.0.3":
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
@@ -15856,45 +15489,6 @@ __metadata:
   version: 8.0.1
   resolution: "webidl-conversions@npm:8.0.1"
   checksum: 10c0/3f6f327ca5fa0c065ed8ed0ef3b72f33623376e68f958e9b7bd0df49fdb0b908139ac2338d19fb45bd0e05595bda96cb6d1622222a8b413daa38a17aacc4dd46
-  languageName: node
-  linkType: hard
-
-"webpack-sources@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "webpack-sources@npm:3.5.1"
-  checksum: 10c0/9463e6895ea0e40b243936ab338d410bec04aff3a43f0cde8cc916a16effece071990ded93c8cad2a73bd7c9b8c293fc27130e440d55df613ea20284de657dd8
-  languageName: node
-  linkType: hard
-
-"webpack@npm:5.110.1":
-  version: 5.110.1
-  resolution: "webpack@npm:5.110.1"
-  dependencies:
-    "@types/estree": "npm:^1.0.8"
-    "@types/json-schema": "npm:^7.0.15"
-    "@webassemblyjs/ast": "npm:^1.14.1"
-    "@webassemblyjs/wasm-edit": "npm:^1.14.1"
-    "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.16.0"
-    browserslist: "npm:^4.28.1"
-    chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.24.4"
-    es-module-lexer: "npm:^2.1.0"
-    events: "npm:^3.2.0"
-    graceful-fs: "npm:^4.2.11"
-    mime-db: "npm:^1.54.0"
-    minimizer-webpack-plugin: "npm:^5.7.0"
-    neo-async: "npm:^2.6.2"
-    schema-utils: "npm:^4.3.3"
-    tapable: "npm:^2.3.0"
-    watchpack: "npm:^2.5.2"
-    webpack-sources: "npm:^3.5.1"
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 10c0/ba2e05ebbfb7e1feeb37febafa862a4f5ed6fd16c77d8825734a74adc402af83beca27f7abe38cf7b57035d0ad34d6b7369a19e56852a00a634309d40b988f67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Proposed changes

* Remove `react-rectangle-selection` and fold the pointer bookkeeping it still provided into `RectangleSelection.tsx`. The wrapper already hid the library's own selection box and re-implemented the overlay and the coordinate conversion, so this deletes a dependency, not a feature.
* Drop the `webpack` and `react` entries from `resolutions`. Both existed only to neutralise this package: it was the sole dependant on `webpack` in the whole front, and the only one declaring `react` as a hard dependency. `webpack` leaves `node_modules` entirely (9.7 MB, 20 direct dependencies, −430 lines of `yarn.lock`); the lockfile is byte-identical with and without the `react` resolution once the package is gone.
* Drop `declare module 'react-rectangle-selection'` from `index.d.ts` — the component is now typed instead of being an opaque `any`.
* Derive the rectangle from `clientX`/`clientY` against the canvas bounding box. Both are viewport-relative, so the scroll compensation the wrapper needed to work around the library's `pageX`/`pageY` positioning disappears.
* Normalise the rectangle inside the component, so consumers always receive an ordered top-left / bottom-right pair.
* Start a drag only when the mousedown target is the graph canvas: the wrapper also holds the toolbar, the loading alert and the details bar, and dragging from those used to start a selection. The target is used directly, which removes the `document.querySelector()` lookup — and with it the `graphId` prop and the `graph-${uuid()}` identifier that `Graph.tsx` rebuilt on every render for that single consumer.
* Track the drag with document-level `mousemove` / `mouseup` listeners, the same pattern as `LassoSelection` and `RelationSelection`. The rectangle keeps following the cursor past the edges of the graph instead of being committed and truncated on `mouseleave`, and a release outside the graph applies the full rectangle.
* Two smaller fixes that came for free: a drag no longer starts on a non-primary mouse button, and text selection is suppressed while dragging.
* Add unit tests for the component, which had none.

The exported `RectangleSelectionProps` contract is otherwise unchanged, so `useGraphInteractions.ts` is untouched.

Why not another library: the maintained candidates (`@air/react-drag-to-select`, `react-selecto`, `dragselect`, `@viselect/react`) are all *DOM element* selection engines, and their hit-testing pass is unusable here — the graph is a single `<canvas>` and selection is resolved in graph space via `screen2GraphCoords`. We would import a whole engine for its pointer tracking and discard the rest, which is exactly the situation being removed. The rationale is detailed in the issue.

### Related issues

* closes #18017

### How to test this PR

1. Open any knowledge graph, investigation or correlation view in 2D.
2. Activate **Free rectangle select** in the graph toolbar.
3. Drag a rectangle over some nodes and release: the dashed overlay must follow the cursor and the enclosed nodes must end up selected.
4. Drag in each of the four directions (including bottom-right → top-left): the selection must be identical whatever the direction.
5. Hold <kbd>Shift</kbd> or <kbd>Alt</kbd> while dragging: the new nodes must be added to the current selection instead of replacing it.
6. Drag past the edges of the graph and release outside it: the rectangle must keep following the cursor and the full area must be applied.
7. Drag starting from the toolbar, the loading alert or the entity details bar: no rectangle must appear and those controls must stay usable.
8. Scroll the page (e.g. on a narrow window with the side panel open) and repeat: the rectangle must stay under the cursor.
9. Deactivate the mode: dragging must pan the graph again.

Regression coverage: `src/components/graph/components/RectangleSelection.test.tsx` (12 cases).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

`yarn build`, `yarn check-ts`, `yarn lint` and `yarn test` are green. The single failing test in the suite, `src/utils/Time.test.ts > minutesBefore`, is timezone-dependent and fails identically on `master`.
