### PR TITLE
fix(fds): finish the elevation layers on dialogs, drawers and popovers (#17729)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -20,6 +20,7 @@ import { KNOWLEDGE_KNFRONTENDEXPORT } from '../utils/hooks/useGranted';
 import Security from '../utils/Security';
 import { useExportTheme } from '../utils/ExportThemeContext';
 import { DASHBOARD_BUTTONS_STYLE } from '../private/components/workspaces/workspaceHeader/WorkspaceHeader';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../utils/fdsLayer';
 
 const styles = () => ({
   exportButtons: {
@@ -332,7 +333,9 @@ export class ExportButtons extends Component {
                 }
               </Menu>
               <Dialog
-                slotProps={{ paper: { elevation: 1 } }}
+                // Layer 2 like every other dialog paper, so the theme's
+                // `--bg-elevation-default` resolves to the same surface.
+                slotProps={{ paper: { elevation: 1, className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
                 open={exporting}
                 keepMounted={true}
                 fullScreen={true}

--- a/opencti-platform/opencti-front/src/components/RequestAccessDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/RequestAccessDialog.tsx
@@ -19,6 +19,7 @@ import { handleErrorInForm } from '../relay/environment';
 import useAuth from '../utils/hooks/useAuth';
 import { FieldOption, fieldSpacingContainerStyle } from '../utils/field';
 import type { Theme } from './Theme';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../utils/fdsLayer';
 
 const requestAccessDialogMutation = graphql`
   mutation RequestAccessDialogMutation($input: RequestAccessAddInput!) {
@@ -98,7 +99,13 @@ const RequestAccessDialog: React.FC<RequestAccessDialogProps> = ({ open, onClose
       <Dialog
         open={open}
         slotProps={{
-          paper: { variant: 'elevation', elevation: 1 },
+          // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+          paper: {
+            variant: 'elevation',
+            elevation: 1,
+            className: fdsLayerClass(SURFACE_LAYER),
+            sx: { ...layerInputVars },
+          },
         }}
         keepMounted={true}
         fullWidth={true}

--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -405,9 +405,16 @@ const ThemeDark = (
       styleOverrides: {
         paper: {
           backgroundImage: 'none',
+          // Sandy's ruling: a dialog is treated EXACTLY like a drawer, which
+          // means the same paper colour. The drawer's paper reads
+          // `--bg-elevation-default` at layer 2; this used to be a hardcoded
+          // hex that resolved to a different shade, which is why the two
+          // surfaces never matched. Every dialog paper now declares layer 2
+          // (the shared Dialog, and every direct MUI mount), so the alias lands
+          // on the same value. A platform-customised paper colour still wins.
           backgroundColor: paper === THEME_DARK_DEFAULT_PAPER
-            ? '#0F1D34'
-            : (paper ?? '#0F1D34'),
+            ? 'var(--bg-elevation-default)'
+            : (paper ?? 'var(--bg-elevation-default)'),
           borderRadius: 4,
         },
       },
@@ -602,15 +609,12 @@ const ThemeDark = (
             border: '0 !important',
           },
           '.error .react-mde textarea': {
-            border: '0 !important',
-            borderBottom: '2px solid #F14337 !important',
+            border: '1px solid var(--border-input-error) !important',
             '&:hover': {
-              border: '0 !important',
-              borderBottom: '2px solid #F14337 !important',
+              border: '1px solid var(--border-input-error) !important',
             },
             '&:focus': {
-              border: '0 !important',
-              borderBottom: '2px solid #F14337 !important',
+              border: '1px solid var(--border-input-error) !important',
             },
           },
           '.mde-header': {
@@ -626,18 +630,25 @@ const ThemeDark = (
             fontFamily: '"IBM Plex Sans", sans-serif',
             color: `${text_color} !important`,
           },
+          // The markdown editor is a textarea like any other field, so it takes
+          // the field surface instead of the bare underline it had. Written in
+          // tokens, which makes it layer-aware for free: inside a drawer or a
+          // dialog `--bg-input-default` resolves to that surface's own layer
+          // (#0c1527), and at page level it stays layer 0.
           '.mde-textarea-wrapper textarea': {
             fontFamily: '"IBM Plex Sans", sans-serif',
             fontSize: 13,
             color: text_color,
-            background: 'transparent',
-            borderBottom: '1px solid rgba(255, 255, 255, 0.7) !important',
-            transition: 'borderBottom .3s',
+            background: 'var(--bg-input-default)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '8px 12px',
+            border: '1px solid transparent !important',
+            transition: 'border-color .3s',
             '&:hover': {
-              borderBottom: '2px solid #ffffff !important',
+              border: '1px solid var(--border-input-hover) !important',
             },
             '&:focus': {
-              borderBottom: `2px solid ${primary || THEME_DARK_DEFAULT_PRIMARY} !important`,
+              border: '1px solid var(--border-input-focus) !important',
             },
           },
           '.mde-preview .mde-preview-content a': {

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -404,9 +404,16 @@ const ThemeLight = (
       styleOverrides: {
         paper: {
           backgroundImage: 'none',
+          // Sandy's ruling: a dialog is treated EXACTLY like a drawer, which
+          // means the same paper colour. The drawer's paper reads
+          // `--bg-elevation-default` at layer 2; this used to be a hardcoded
+          // hex that resolved to a different shade, which is why the two
+          // surfaces never matched. Every dialog paper now declares layer 2
+          // (the shared Dialog, and every direct MUI mount), so the alias lands
+          // on the same value. A platform-customised paper colour still wins.
           backgroundColor: paper === THEME_LIGHT_DEFAULT_PAPER
-            ? '#FFFFFF'
-            : (paper ?? '#FFFFFF'),
+            ? 'var(--bg-elevation-default)'
+            : (paper ?? 'var(--bg-elevation-default)'),
           borderRadius: 4,
         },
       },
@@ -600,15 +607,12 @@ const ThemeLight = (
             border: '0 !important',
           },
           '.error .react-mde textarea': {
-            border: '0 !important',
-            borderBottom: '2px solid #F14337 !important',
+            border: '1px solid var(--border-input-error) !important',
             '&:hover': {
-              border: '0 !important',
-              borderBottom: '2px solid #F14337 !important',
+              border: '1px solid var(--border-input-error) !important',
             },
             '&:focus': {
-              border: '0 !important',
-              borderBottom: '2px solid #F14337 !important',
+              border: '1px solid var(--border-input-error) !important',
             },
           },
           '.mde-header': {
@@ -624,18 +628,25 @@ const ThemeLight = (
             fontFamily: '"IBM Plex Sans", sans-serif',
             color: `${text_color} !important`,
           },
+          // The markdown editor is a textarea like any other field, so it takes
+          // the field surface instead of the bare underline it had. Written in
+          // tokens, which makes it layer-aware for free: inside a drawer or a
+          // dialog `--bg-input-default` resolves to that surface's own layer,
+          // and at page level it stays layer 0.
           '.mde-textarea-wrapper textarea': {
             fontFamily: '"IBM Plex Sans", sans-serif',
             fontSize: 13,
             color: `${text_color} !important`,
-            background: 'transparent',
-            borderBottom: '1px solid rgba(0, 0, 0, 0.87) !important',
-            transition: 'borderBottom .3s',
+            background: 'var(--bg-input-default)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '8px 12px',
+            border: '1px solid transparent !important',
+            transition: 'border-color .3s',
             '&:hover': {
-              borderBottom: '2px solid #000000 !important',
+              border: '1px solid var(--border-input-hover) !important',
             },
             '&:focus': {
-              borderBottom: `2px solid ${primary || THEME_LIGHT_DEFAULT_PRIMARY} !important`,
+              border: '1px solid var(--border-input-focus) !important',
             },
           },
           '.mde-preview .mde-preview-content a': {

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -37,6 +37,7 @@ import { FilterRepresentative } from './FiltersModel';
 import QuickRelativeDateFiltersButtons from './QuickRelativeDateFiltersButtons';
 
 import FilterFiltersInput from './FilterFiltersInput';
+import { FILTER_POPOVER_LAYER, fdsLayerClass, filterPopoverPaperSx } from '../../utils/fdsLayer';
 
 interface FilterChipMenuProps {
   handleClose: () => void;
@@ -536,7 +537,10 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
       slotProps={{
         paper: {
           elevation: 1,
-          style: { marginTop: 10 },
+          // Filter popovers: surface on `--bg-elevation-highlight` at layer 1,
+          // the fields inside at layer 2. See utils/fdsLayer.ts.
+          className: fdsLayerClass(FILTER_POPOVER_LAYER),
+          sx: { ...filterPopoverPaperSx, marginTop: '10px' },
         },
       }}
     >

--- a/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
@@ -13,6 +13,7 @@ import { useFormatter } from '../i18n';
 import { FilterRepresentative } from './FiltersModel';
 import type { FilterGroup } from '../../utils/filters/filtersHelpers-types';
 import FilterGroupsVisualDisplay from './FilterGroupsVisualDisplay';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../utils/fdsLayer';
 
 interface ImbricatedFilterGroupDisplayProps {
   filterObj: FilterGroup;
@@ -46,6 +47,8 @@ const ImbricatedFilterGroupDisplay: FunctionComponent<ImbricatedFilterGroupDispl
       />
 
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={open}
         onClose={handleClose}
         aria-labelledby="filter-groups-dialog-title"

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
@@ -13,6 +13,7 @@ import useGraphInteractions from '../utils/useGraphInteractions';
 import { fetchQuery } from '../../../relay/environment';
 import { GraphToolbarExpandToolsRelationshipsQuery$data } from './__generated__/GraphToolbarExpandToolsRelationshipsQuery.graphql';
 import { ObjectToParse } from '../utils/useGraphParser';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../utils/fdsLayer';
 
 const expandRelationshipsQuery = graphql`
   query GraphToolbarExpandToolsRelationshipsQuery($filters: FilterGroup) {
@@ -664,6 +665,8 @@ const GraphToolbarExpandTools = ({
       />
 
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         fullWidth
         maxWidth={false}
         open={isExpandOpen}

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -34,6 +34,7 @@ import { export_max_size } from '../../utils/utils';
 import FilterIconButton from '../FilterIconButton';
 import SearchInput from '../SearchInput';
 import inject18n from '../i18n';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../utils/fdsLayer';
 
 const styles = (theme) => ({
   container: {
@@ -558,6 +559,8 @@ class ListLines extends Component {
           )}
           {handleSwitchRedirectionMode && (
             <Dialog
+              // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+              slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
               open={this.state.openSettings}
               onClose={this.handleCloseSettings.bind(this)}
               size="small"

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -35,6 +35,7 @@ import AddExternalReferences from './AddExternalReferences';
 import { externalReferenceMutationRelationDelete } from './AddExternalReferencesLines';
 import ExternalReferenceEnrichment from './ExternalReferenceEnrichment';
 import ExternalReferencePopover from './ExternalReferencePopover';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -379,6 +380,8 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           )}
         </Card>
         <Dialog
+          // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+          slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayDialog}
           onClose={this.handleCloseDialog.bind(this)}
           title={t('Are you sure?')}
@@ -403,6 +406,8 @@ class StixSightingRelationshipExternalReferencesLinesContainer extends Component
           </DialogActions>
         </Dialog>
         <Dialog
+          // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+          slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
           open={this.state.displayExternalLink}
           onClose={this.handleCloseExternalLink.bind(this)}
           title={t('Do you want to browse this external link?')}

--- a/opencti-platform/opencti-front/src/private/components/common/bulk/dialog/BulkRelationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/bulk/dialog/BulkRelationDialog.tsx
@@ -25,6 +25,7 @@ import { PaginationOptions } from 'src/components/list_lines';
 import StixCyberObservableCreation from '@components/observations/stix_cyber_observables/StixCyberObservableCreation';
 import { type StixCoreResultsType } from '../utils/querySearchEntityByText';
 import { getRelationsFromOneEntityToAny, RelationsDataFromEntity, RelationsToEntity } from '../../../../../utils/Relation';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../../utils/fdsLayer';
 
 export const searchStixCoreObjectsByRepresentativeQuery = graphql`
   query BulkRelationDialogQuery(
@@ -477,7 +478,7 @@ const BulkRelationDialog: FunctionComponent<BulkRelationDialogProps> = ({
 
   return (
     <>
-      <Dialog open={isOpen} slotProps={{ paper: { elevation: 1 } }} scroll="paper" sx={{ overflowY: 'hidden', ...classes.dialog, ...classes.dialogContent }} onClose={onClose} maxWidth="xl">
+      <Dialog open={isOpen} slotProps={{ paper: { elevation: 1, className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }} scroll="paper" sx={{ overflowY: 'hidden', ...classes.dialog, ...classes.dialogContent }} onClose={onClose} maxWidth="xl">
         {isSubmitting && renderLoader()}
         <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', height: '70px' }}>
           <div>{t_i18n('Create relations in bulk for')}: {t_i18n(`entity_${stixDomainObjectType}`)}</div>

--- a/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/DialogFilters.tsx
@@ -9,6 +9,7 @@ import FilterIconButton from '../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../components/i18n';
 import { Filter, FilterGroup } from '../../../../utils/filters/filtersHelpers-types';
 import { FilterSearchContext } from '../../../../utils/filters/filtersUtils';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 interface DialogFiltersProps {
   handleOpenFilters: (event: React.SyntheticEvent) => void;
@@ -54,6 +55,8 @@ const DialogFilters: FunctionComponent<DialogFiltersProps> = ({
         </IconButton>
       </Tooltip>
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={open}
         onClose={handleCloseFilters}
         title={t_i18n('Advanced search')}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -13,6 +13,7 @@ import { useBuildFilterKeysMapFromEntityType, getDefaultFilterObject, getFilterD
 import SavedFilters from '../../../../components/saved_filters/SavedFilters';
 import SavedFilterButton from '../../../../components/saved_filters/SavedFilterButton';
 import ClearFiltersIcon from 'src/components/filters/ClearFiltersIcon';
+import { FILTER_POPOVER_LAYER, fdsLayerClass, filterPopoverPaperSx } from '../../../../utils/fdsLayer';
 
 const WORKFLOW_FILTER_KEYS = ['workflow_user', 'workflow_group', 'workflow_organization'];
 
@@ -22,6 +23,9 @@ const useStyles = makeStyles(() => ({
   container: {
     width: 600,
     padding: 20,
+    // Filter popovers: surface on `--bg-elevation-highlight` at layer 1, the
+    // fields inside at layer 2. See utils/fdsLayer.ts.
+    ...filterPopoverPaperSx,
   },
 }));
 
@@ -275,7 +279,7 @@ const ListFilters = ({
         </>
       )}
       <Popover
-        classes={{ paper: classes.container }}
+        classes={{ paper: `${fdsLayerClass(FILTER_POPOVER_LAYER)} ${classes.container}` }}
         open={isOpen}
         anchorEl={anchorEl}
         onClose={handleCloseFilters}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
@@ -6,6 +6,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { RayEndArrow, RayStartArrow } from 'mdi-material-ui';
 import React, { ReactElement } from 'react';
 import { useFormatter } from '../../../../components/i18n';
+import { FILTER_POPOVER_LAYER, fdsLayerClass, filterPopoverPaperSx } from '../../../../utils/fdsLayer';
 
 interface ListFiltersWithoutLocalStorageProps {
   handleOpenFilters: (event: React.SyntheticEvent) => void;
@@ -66,10 +67,14 @@ const ListFiltersWithoutLocalStorage = ({
         </Tooltip>
       )}
       <Popover
+        // Filter popovers: surface on `--bg-elevation-highlight` at layer 1,
+        // the fields inside at layer 2. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(FILTER_POPOVER_LAYER) } }}
         sx={{
           '& .MuiPaper-root': {
             width: 600,
             padding: 20,
+            ...filterPopoverPaperSx,
           },
         }}
         open={open}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
@@ -27,6 +27,7 @@ import { ObjectToParse } from '../../../../components/graph/utils/useGraphParser
 import { FieldOption } from '../../../../utils/field';
 import type { Theme } from '../../../../components/Theme';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
@@ -699,6 +700,11 @@ const StixCoreRelationshipCreation = ({
         open={open}
         anchor="right"
         elevation={1}
+        // This creation drawer mounts MUI's Drawer directly instead of the
+        // shared one, so it has to declare its own layer: a drawer is a
+        // layer-2 surface and its fields read the layer from the paper.
+        // See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         sx={{ zIndex: 1202 }}
         classes={{ paper: classes.drawerPaper }}
         onClose={handleClose}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -24,6 +24,7 @@ import ObjectMarkingField from '../form/ObjectMarkingField';
 import ConfidenceField from '../form/ConfidenceField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -836,6 +837,11 @@ class StixNestedRefRelationshipCreation extends Component {
         open={open}
         anchor="right"
         elevation={1}
+        // This creation drawer mounts MUI's Drawer directly instead of the
+        // shared one, so it has to declare its own layer: a drawer is a
+        // layer-2 surface and its fields read the layer from the paper.
+        // See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         sx={{ zIndex: 1202 }}
         classes={{ paper: classes.drawerPaper }}
         onClose={this.handleClose.bind(this)}

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxiiCollection/IngestionTaxiiCollectionPopover.tsx
@@ -23,6 +23,7 @@ import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { deleteNode } from '../../../../utils/store';
 import IngestionTaxiiCollectionEdition, { ingestionTaxiiCollectionMutationFieldPatch } from './IngestionTaxiiCollectionEdition';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const ingestionTaxiiPopoverDeletionMutation = graphql`
   mutation IngestionTaxiiCollectionPopoverDeletionMutation($id: ID!) {
@@ -233,6 +234,8 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         message={t_i18n('Do you want to delete this TAXII ingester?')}
       />
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStart}
         onClose={handleCloseStart}
         title={t_i18n('Are you sure?')}
@@ -257,6 +260,8 @@ const IngestionTaxiiPopover: FunctionComponent<IngestionTaxiiPopoverProps> = ({
         </DialogActions>
       </Dialog>
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayStop}
         onClose={handleCloseStop}
         title={t_i18n('Are you sure?')}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
@@ -18,6 +18,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { truncate } from '../../../../utils/String';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import StixSightingRelationshipCreationForm from './StixSightingRelationshipCreationForm';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -630,6 +631,11 @@ class StixSightingRelationshipCreation extends Component {
         open={open}
         anchor="right"
         elevation={1}
+        // This creation drawer mounts MUI's Drawer directly instead of the
+        // shared one, so it has to declare its own layer: a drawer is a
+        // layer-2 surface and its fields read the layer from the paper.
+        // See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         sx={{ zIndex: 1202 }}
         classes={{ paper: classes.drawerPaper }}
         onClose={this.handleClose.bind(this)}

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -48,6 +48,7 @@ import { UserSessionKillMutation } from './__generated__/UserSessionKillMutation
 import { UserUserSessionsKillMutation } from './__generated__/UserUserSessionsKillMutation.graphql';
 import UserHistory from './UserHistory';
 import UserTokenList from './UserTokenList';
+import { SURFACE_LAYER, fdsLayerClass, layerInputVars } from '../../../../utils/fdsLayer';
 
 const startDate = yearsAgo(1);
 const endDate = now();
@@ -746,6 +747,8 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         </Grid>
       </Grid>
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSession}
         onClose={handleCloseKillSession}
         title={t_i18n('Are you sure?')}
@@ -766,6 +769,8 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
         </DialogActions>
       </Dialog>
       <Dialog
+        // A dialog is a layer-2 surface, like a drawer. See utils/fdsLayer.ts.
+        slotProps={{ paper: { className: fdsLayerClass(SURFACE_LAYER), sx: { ...layerInputVars } } }}
         open={displayKillSessions}
         onClose={handleCloseKillSessions}
         title={t_i18n('Are you sure?')}

--- a/opencti-platform/opencti-front/src/utils/fdsLayer.ts
+++ b/opencti-platform/opencti-front/src/utils/fdsLayer.ts
@@ -61,3 +61,20 @@ export const fdsLayerClass = (layer: FdsLayer) => `layer-${layer}`;
 
 /** Drawers and dialogs: layer 2. */
 export const SURFACE_LAYER: FdsLayer = 2;
+
+/**
+ * Filter popovers, per the designer's standing rule for ALL of them: the
+ * popover SURFACE is `--bg-elevation-highlight` taken at layer 1, and the
+ * fields inside sit at layer 2, exactly as they do in a drawer or a dialog.
+ *
+ * Both halves live on the paper itself, so no wrapper element is introduced.
+ * The layer-2 class plus `layerInputVars` give the fields their background;
+ * the surface then has to name its layer-1 value explicitly, because the class
+ * it shares the node with has just moved the ambient alias to layer 2.
+ */
+export const FILTER_POPOVER_LAYER: FdsLayer = 2;
+
+export const filterPopoverPaperSx = {
+  ...layerInputVars,
+  background: 'var(--bg-elevation-highlight-layer-1)',
+} as const;


### PR DESCRIPTION
> **Stacked on #18003.** That PR gives the shared Drawer and Dialog their layer
> and introduces `utils/fdsLayer.ts`; this one builds on it. Merge #18003 first
> and this diff shrinks to its own four commits' worth of change.

F4, F5, F6 and F7 of Sandy's visual pass. #18003 covers the ~94% of surfaces
that go through the shared components; this finishes the surfaces that bypass
them, and the two things the shared components could not reach.

### Dialogs really do have the drawer's paper colour now (F4)

The theme painted `MuiDialog`'s paper with a **hardcoded `#0F1D34`**, while a
drawer's paper reads `--bg-elevation-default` at layer 2 (`#13213e`). That is
why the two never matched, whatever the layer said — the layer was never the
thing deciding this colour. The dialog paper now reads the same alias. A
platform-customised paper colour still wins.

Measured: dialog paper and drawer paper are both `rgb(19,33,62)`.

### Every direct MUI mount declares its layer (F4, F5)

Ten `<Dialog>` mounts and the three relationship-creation `<Drawer>`s mount MUI
directly instead of going through the shared components, so they never received
the layer. Each now carries `fdsLayerClass(SURFACE_LAYER)` and `layerInputVars`
on its paper — both on the same node, which is what makes the three input
aliases resolve at that layer (LIBRARY-FEEDBACK #57).

### Filter popovers — all of them (F7)

Sandy's standing rule: the popover **surface** is `--bg-elevation-highlight`
taken at **layer 1**, and the **fields inside** sit at **layer 2**. Both halves
live on the paper itself, so no wrapper element appears in the DOM;
`filterPopoverPaperSx` in `utils/fdsLayer.ts` carries the recipe. Applied to
`FilterChipPopover`, `ListFilters` and `ListFiltersWithoutLocalStorage`.

Measured on a live chip popover: surface `rgb(24,42,78)` = #182a4e,
`--bg-input-default` = `#0c1527`.

### The markdown editor is a field like any other (F6)

Its textarea was a bare underline on a transparent background. It now takes the
field surface written in tokens — `--bg-input-default`, `--radius-sm`,
`--border-input-hover` on hover, `--border-input-focus` on focus,
`--border-input-error` in error. Writing it in tokens makes it layer-aware for
free: `#0c1527` inside a drawer or a dialog, layer 0 at page level. Same change
in both themes.

### Verified on the authenticated stack

- Create-dashboard drawer: `Nom` and the markdown `Description` both `#0c1527`.
- EE licence dialog: paper `#13213e`, textarea `#0c1527`, layer-2 on the paper.
- Reports filter chip popover: surface `#182a4e`, fields' token at `#0c1527`.

### Known remainder, and it is the next PR

A MUI field inside these surfaces still paints transparent — the popover's
`MuiOutlinedInput`, for instance — because it never consumed
`--bg-input-default` in the first place. That is F3, the standing MUI-restyle
ruling, and it is handled in the follow-up rather than here: the token is now
correct at every one of these surfaces, so the restyle has something right to
read.

FIXLOG: F4, F5, F6, F7 → FIXED. F10 → FIXED (already converted at the tip; this
PR gives it the right layer, verified on screen).
