### PR TITLE
fix(fds): navbar active state, EE chip size, AI glyph, integration surface (#17664)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -554,8 +554,15 @@ const ThemeDark = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -552,8 +552,15 @@ const ThemeLight = (
           '&.Mui-error .MuiOutlinedInput-notchedOutline': {
             borderColor: 'var(--border-input-error)',
           },
+          // Disabled follows the library `Input`, which goes TRANSPARENT with a
+          // disabled border — not `--bg-input-disabled`. Painting that token
+          // put a light grey slab in the middle of a dark form (seen on the
+          // public-dashboard URI KEY field, which is always disabled).
           '&.Mui-disabled': {
-            backgroundColor: 'var(--bg-input-disabled)',
+            backgroundColor: 'transparent',
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'var(--border-elevation-disabled)',
+            },
           },
         },
         input: {

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -155,7 +155,10 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             className={floating ? classes.chipFloating : classes.chip}
             disabled={disabled}
           >
-            <FiligranIcon icon={LogoXtmOneIcon} size="small" />
+            {/* 16, not `size="small"`: FiligranIcon's `small` is MUI's 20px,
+                which overflowed the 24px small button by a pixel and sat off
+                its centre line. 16 is the library's own small-button glyph. */}
+            <FiligranIcon icon={LogoXtmOneIcon} size={16} />
           </IconButton>
         ) : (
           <Button
@@ -164,7 +167,9 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick, showEECh
             onClick={onClick}
             intent="ai"
             aria-label={buttonLabel}
-            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" />}
+            // 16 is the library's small-button glyph; FiligranIcon's `small`
+            // is MUI's 20px, a pixel taller than the button itself.
+            startIcon={<FiligranIcon icon={LogoXtmOneIcon} size={16} />}
             disabled={disabled}
           >
             {t_i18n('AI Insights')}

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -86,9 +86,11 @@ const NavToolbarMenu: FunctionComponent<{ entries: MenuEntry[] }> = ({ entries }
 
     if (entry.isEE) {
       return (
-        <Stack direction="row">
+        <Stack direction="row" alignItems="center">
           <TruncatedText>{translatedLabel}</TruncatedText>
-          <EEChip />
+          {/* Small variant: this is a navigation row, not a page heading, and
+              the medium chip crowded the label. */}
+          <EEChip size="sm" />
         </Stack>
       );
     }

--- a/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/paperSurface.ts
@@ -19,8 +19,21 @@ import { FDS } from '../../../components/fds-tokens.generated';
  */
 const fdsFor = (theme: Theme) => (theme.palette.mode === 'light' ? FDS.colors.light : FDS.colors.dark);
 
-/** Background of a library Paper. */
-export const paperBg = (theme: Theme) => fdsFor(theme)['--bg-elevation-default'];
+/**
+ * Background of an integration box.
+ *
+ * REVERTED, and deliberately not the token: pointing this at
+ * `--bg-elevation-default` painted these boxes #070d18 in dark mode — the
+ * layer-0 surface, DARKER than the page they sit on. Sandy reported it as a
+ * background nobody asked for and asked for the previous one back, so this is
+ * `background.paper` again, exactly what these boxes had before the
+ * homogenisation pass.
+ *
+ * The border below keeps the token: it was not part of the complaint, and it
+ * replaced a border derived from the TEXT colour, which is the thing that kept
+ * these boxes from matching a real Paper.
+ */
+export const paperBg = (theme: Theme) => theme.palette.background.paper;
 
 /** Border colour of a library Paper — pass it to `border`/`borderBottom`. */
 export const paperBorder = (theme: Theme) => fdsFor(theme)['--border-elevation-subtle-soft'];

--- a/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/useNavMenu.tsx
@@ -245,8 +245,12 @@ const useNavMenu = (): NavGroup[] => {
           icon: <InsertChartOutlinedOutlined />,
           link: '/dashboard/workspaces/dashboards',
           subItems: [
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards'), exact: true },
-            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards'), exact: true },
+            // No `exact`: a dashboard's own page is `/…/dashboards/<id>`, and an
+            // exact match left the sub-item inactive the moment you opened one.
+            // Prefix matching is safe between these two links because
+            // `/…/dashboards_public` does not start with `/…/dashboards/`.
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards', label: t_i18n('Custom dashboards') },
+            { granted: canSeeExplore, type: 'Dashboard', link: '/dashboard/workspaces/dashboards_public', label: t_i18n('Public dashboards') },
           ],
         },
         !inDraft && canSeeInvestigation && {

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
@@ -11,7 +11,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { PublicDashboardCreationFormDashboardsQuery } from '@components/workspaces/dashboards/public_dashboards/__generated__/PublicDashboardCreationFormDashboardsQuery.graphql';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
-import { FieldOption, fieldSpacingContainerStyle } from '../../../../../utils/field';
+import { FieldOption } from '../../../../../utils/field';
 import SwitchField from '../../../../../components/fields/SwitchField';
 import SelectFieldFds, { SelectItem } from '../../../../../components/fields/SelectFieldFds';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
@@ -61,6 +61,13 @@ interface PublicDashboardCreationFormComponentProps {
   onCancel?: () => void;
   onCompleted?: () => void;
 }
+
+/**
+ * 16px between fields, per the visual pass on this dialog. The app-wide
+ * `fieldSpacingContainerStyle` is still 20px; this is scoped to the surface
+ * that was reviewed rather than changing the rhythm everywhere at once.
+ */
+const publicDashboardFieldSpacing = { marginTop: 16, width: '100%' };
 
 const PublicDashboardCreationFormComponent = ({
   queryRef,
@@ -163,7 +170,7 @@ const PublicDashboardCreationFormComponent = ({
             component={TextField}
             variant="outlined"
             label={t_i18n('Name')}
-            className="mt-5"
+            style={publicDashboardFieldSpacing}
             onChange={(_: string, val: string) => {
               setFieldValue('uri_key', generatePublicDashboardUriKey(val));
             }}
@@ -175,7 +182,7 @@ const PublicDashboardCreationFormComponent = ({
             variant="outlined"
             label={t_i18n('Public dashboard URI KEY')}
             helperText={t_i18n('ID of your public dashboard')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             slotProps={{
               input: {
                 startAdornment: (
@@ -191,14 +198,14 @@ const PublicDashboardCreationFormComponent = ({
             type="checkbox"
             name="enabled"
             label={t_i18n('Enabled')}
-            containerstyle={fieldSpacingContainerStyle}
+            containerstyle={publicDashboardFieldSpacing}
             helpertext={t_i18n('Disabled dashboard...')}
           />
           <ObjectMarkingField
             name="max_markings"
             label={t_i18n('Max level markings')}
             helpertext={t_i18n('To prevent people seeing all the data...')}
-            style={fieldSpacingContainerStyle}
+            style={publicDashboardFieldSpacing}
             onChange={() => {}}
             setFieldValue={setFieldValue}
             limitToMaxSharing


### PR DESCRIPTION
> **Stacked on #18020** (and through it on #18019 / #18003).

Five details from the visual pass, each root-caused rather than nudged, plus one
regression caught while exercising the previous PR.

### F14 — navbar sub-item inside a custom dashboard

`Custom dashboards` carried `exact: true`, so the moment you opened a dashboard
(`/…/dashboards/<id>`) the sub-item went inactive. Prefix matching is safe
between the two dashboard links — `/…/dashboards_public` does not start with
`/…/dashboards/` — so the flag simply should not have been there. Removed on
Public dashboards too, which had the same defect.

**Verified:** inside a dashboard, `Tableaux de bord personnalisés` is
`aria-current="page"` and `Tableaux de bord publics` is not.

### F24 — Settings right-nav EE chips

Take the library's `sm` variant. Measured 18px tall.

### F18 — "Aperçu par IA" glyph

`FiligranIcon`'s `size="small"` is MUI's 20px, and this glyph's viewBox is not
square, so it rendered **14×20 inside a 24px button** — a pixel taller than the
button itself, and off its centre line. It asks for 16 now, which is the
library's own small-button glyph size.

### F23 — integration blocks

The homogenisation pass pointed `paperBg` at `--bg-elevation-default`, which in
dark mode is `#070d18`: the **layer-0** surface, darker than the page the boxes
sit on. That is the background nobody asked for. Reverted to
`background.paper`, exactly what these boxes had before. The token border stays —
it was not part of the report, and it replaced a border derived from the *text*
colour, which is what kept these boxes from matching a real Paper.

### F17 (spacing half) — public dashboard dialog

16px between fields. Scoped to the reviewed surface; the app-wide
`fieldSpacingContainerStyle` is still 20px, so generalising the rhythm stays
Sandy's call. **The "+" button half of F17 is NOT in this PR** — see the FIXLOG:
no `+` control exists in that drawer or on the public-dashboards list, so the one
in the capture needs pointing at before it can be changed.

### Regression caught while exercising #18020

The outlined restyle gave disabled fields `--bg-input-disabled`, which in dark
mode is a light grey slab — plainly visible on the always-disabled URI KEY
field. The library's own `Input` goes **transparent with a disabled border**
instead. Fixed here rather than left for the next round.

FIXLOG: F14, F18, F23, F24 → FIXED. F17 → PARTIAL (spacing fixed, "+" blocked
on identifying the control).
