### PR TITLE
fix python code to manage case where score does not exist

### DIFF
--- a/client-python/pycti/entities/opencti_security_coverage.py
+++ b/client-python/pycti/entities/opencti_security_coverage.py
@@ -374,15 +374,11 @@ class SecurityCoverage:
                 )
 
             raw_coverages = stix_object["coverage"] if "coverage" in stix_object else []
-            coverage_information = list(
-                map(
-                    lambda cov: {
-                        "coverage_name": cov["name"],
-                        "coverage_score": cov["score"],
-                    },
-                    raw_coverages,
-                )
-            )
+            coverage_information = [
+                {"coverage_name": cov["name"], "coverage_score": cov["score"]}
+                for cov in raw_coverages
+                if "score" in cov
+            ]
 
             return self.create(
                 stix_id=stix_object["id"],

--- a/client-python/pycti/entities/opencti_security_coverage_result.py
+++ b/client-python/pycti/entities/opencti_security_coverage_result.py
@@ -364,15 +364,11 @@ class SecurityCoverageResult:
                 )
 
             raw_coverages = stix_object["coverage"] if "coverage" in stix_object else []
-            coverage_information = list(
-                map(
-                    lambda cov: {
-                        "coverage_name": cov["name"],
-                        "coverage_score": cov["score"],
-                    },
-                    raw_coverages,
-                )
-            )
+            coverage_information = coverage_information = [
+                {"coverage_name": cov["name"], "coverage_score": cov["score"]}
+                for cov in raw_coverages
+                if "score" in cov
+            ]
 
             return self.create(
                 stix_id=stix_object["id"],

--- a/client-python/pycti/entities/opencti_stix_core_relationship.py
+++ b/client-python/pycti/entities/opencti_stix_core_relationship.py
@@ -1396,15 +1396,11 @@ class StixCoreRelationship:
                 if "external_uri" in stix_relation
                 else None
             )
-            coverage_information = list(
-                map(
-                    lambda cov: {
-                        "coverage_name": cov["name"],
-                        "coverage_score": cov["score"],
-                    },
-                    raw_coverages,
-                )
-            )
+            coverage_information = [
+                {"coverage_name": cov["name"], "coverage_score": cov["score"]}
+                for cov in raw_coverages
+                if "score" in cov
+            ]
 
             source_ref = stix_relation["source_ref"]
             target_ref = stix_relation["target_ref"]


### PR DESCRIPTION
### Proposed changes

* In Python code, manage case where score is not defined in the coverage information

### Related issues

### How to test this PR

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality