### PR TITLE
feat(export): export panel according to the files creators (#15498)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -636,6 +636,12 @@ class ListenQueue(threading.Thread):
             work_id = internal_data["work_id"]
             draft_id = internal_data.get("draft_id", "")
             self.helper.work_id = work_id
+            # Expose the work context to the API clients so calls made while processing the
+            # message (e.g. pushing an export file back) are attributed to the originating work,
+            # allowing the platform to record the requesting user as the file creator.
+            if work_id:
+                self.helper.api.set_work_id(work_id)
+                self.helper.api_impersonate.set_work_id(work_id)
 
             self.helper.validation_mode = validation_mode
             self.helper.force_validation = force_validation
@@ -758,6 +764,11 @@ class ListenQueue(threading.Thread):
                     self.helper.connector_logger.error(
                         "Failing reporting the processing"
                     )
+        finally:
+            # Clear the work context so it does not leak to subsequent messages.
+            if work_id:
+                self.helper.api.set_work_id("")
+                self.helper.api_impersonate.set_work_id("")
 
     def is_token_valid(self, token):
         """

--- a/opencti-platform/opencti-front/src/components/ItemCreators.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCreators.tsx
@@ -18,9 +18,10 @@ interface ItemCreatorsProps {
     readonly id: string;
     readonly name: string;
   }[];
+  maxWidth?: number | string;
 }
 
-const ItemCreators = ({ creators }: ItemCreatorsProps) => {
+const ItemCreators = ({ creators, maxWidth }: ItemCreatorsProps) => {
   const navigate = useNavigate();
 
   return (
@@ -31,15 +32,16 @@ const ItemCreators = ({ creators }: ItemCreatorsProps) => {
             key={creator.id}
             needs={[SETTINGS_SETACCESSES]}
             placeholder={(
-              <Tag label={creator.name} />
+              <Tag label={creator.name} maxWidth={maxWidth} />
             )}
           >
             {systemUsers.includes(creator.id) ? (
-              <Tag label={creator.name} />
+              <Tag label={creator.name} maxWidth={maxWidth} />
             ) : (
               <Tag
                 key={creator.id}
                 label={creator.name}
+                maxWidth={maxWidth}
                 onClick={() => navigate(`/dashboard/settings/accesses/users/${creator.id}`)}
               />
             )}

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -15,6 +15,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { PopoverProps } from '@mui/material/Popover';
 import Slide, { SlideProps } from '@mui/material/Slide';
 import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import type { OverridableStringUnion } from '@mui/types';
@@ -35,10 +36,13 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
 import Box from '@mui/material/Box';
-import { KNOWLEDGE_KNASKIMPORT } from '../../../../utils/hooks/useGranted';
+import { isBypassUser, KNOWLEDGE_KNASKIMPORT } from '../../../../utils/hooks/useGranted';
 import { isNotEmptyField } from '../../../../utils/utils';
 import FileWork from './FileWork';
 import { FileLine_file$data } from './__generated__/FileLine_file.graphql';
+import FieldOrEmpty from 'src/components/FieldOrEmpty';
+import { Truncate } from 'src/components/dataGrid/dataTableUtils';
+import ItemCreators from 'src/components/ItemCreators';
 
 const Transition = React.forwardRef(({ children, ...otherProps }: SlideProps, ref) => (
   <Slide direction="up" ref={ref} {...otherProps}>{children}</Slide>
@@ -285,6 +289,12 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
                   limit={1}
                 />
               </Box>
+            )}
+            {!isProgress && !isFail && !isOutdated && isBypassUser(me) && (
+              <ItemCreators
+                creators={[file?.metaData?.creator]}
+              >
+              </ItemCreators>
             )}
             {!disableImport && (
               <Tooltip title={t_i18n('Launch an import of this file')}>

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -290,8 +290,8 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
             {!isProgress && !isFail && !isOutdated && isBypassUser(me) && (
               <ItemCreators
                 creators={file?.metaData?.creator ? [file?.metaData?.creator] : []}
-              >
-              </ItemCreators>
+                maxWidth={60}
+              />
             )}
             {!disableImport && (
               <Tooltip title={t_i18n('Launch an import of this file')}>

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -15,7 +15,6 @@ import MenuItem from '@mui/material/MenuItem';
 import { PopoverProps } from '@mui/material/Popover';
 import Slide, { SlideProps } from '@mui/material/Slide';
 import Tooltip from '@mui/material/Tooltip';
-import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import type { OverridableStringUnion } from '@mui/types';
@@ -40,8 +39,6 @@ import { isBypassUser, KNOWLEDGE_KNASKIMPORT } from '../../../../utils/hooks/use
 import { isNotEmptyField } from '../../../../utils/utils';
 import FileWork from './FileWork';
 import { FileLine_file$data } from './__generated__/FileLine_file.graphql';
-import FieldOrEmpty from 'src/components/FieldOrEmpty';
-import { Truncate } from 'src/components/dataGrid/dataTableUtils';
 import ItemCreators from 'src/components/ItemCreators';
 
 const Transition = React.forwardRef(({ children, ...otherProps }: SlideProps, ref) => (
@@ -292,7 +289,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
             )}
             {!isProgress && !isFail && !isOutdated && isBypassUser(me) && (
               <ItemCreators
-                creators={[file?.metaData?.creator]}
+                creators={file?.metaData?.creator ? [file?.metaData?.creator] : []}
               >
               </ItemCreators>
             )}

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -521,6 +521,11 @@ const FileLine = createFragmentContainer(FileLineComponent, {
       lastModified
       lastModifiedSinceMin
       metaData {
+        creator_id
+        creator {
+          id
+          name
+        }
         mimetype
         list_filters
         external_reference_id

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -656,7 +656,12 @@ export const upload = async (
     }
   }
 
-  const creatorId = (currentFile?.metaData as FileMetadata)?.creator_id ? (currentFile.metaData as FileMetadata).creator_id : user.id;
+  // Determine the file creator id:
+  // - Preserve the creator of an already existing file
+  // - Otherwise, honor an explicitly provided creator_id (e.g. an export pushed back on behalf of the user who requested it)
+  // - And finally fall back to the uploading user.
+  const existingCreatorId = (currentFile?.metaData as FileMetadata)?.creator_id;
+  const creatorId = existingCreatorId || metadata.creator_id || user.id;
 
   // Upload the data from the buffered content
   const uploadReadStream = createReadStream();

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -661,7 +661,7 @@ export const upload = async (
   // - Otherwise, honor an explicitly provided creator_id (e.g. an export pushed back on behalf of the user who requested it)
   // - And finally fall back to the uploading user.
   const existingCreatorId = (currentFile?.metaData as FileMetadata)?.creator_id;
-  const creatorId = existingCreatorId || metadata.creator_id || user.id;
+  const creatorId = existingCreatorId ?? metadata.creator_id ?? user.id;
 
   // Upload the data from the buffered content
   const uploadReadStream = createReadStream();
@@ -672,7 +672,7 @@ export const upload = async (
     mimetype: fileMime,
     encoding,
     sha256,
-    creator_id: creatorId as string,
+    creator_id: creatorId,
     entity_id: (entity as BasicStoreEntity)?.internal_id,
   };
   await rawUpload(key, uploadReadStream);

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -54,7 +54,7 @@ import {
   isStixDomainObjectContainer,
 } from '../schema/stixDomainObject';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE, ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
-import { createWork, worksForSource, workToExportFile } from './work';
+import { createWork, loadWorkById, worksForSource, workToExportFile } from './work';
 import { pushToConnector } from '../database/rabbitmq';
 import { minutesAgo, monthsAgo, now, utcDate } from '../utils/format';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
@@ -552,8 +552,31 @@ export const stixCoreObjectExportAsk = async (context, user, stixCoreObjectId, i
   return works.map((w) => workToExportFile(w));
 };
 
+/**
+ * Resolves the id of the user who originally requested an export.
+ *
+ * When an export file is pushed back by a connector, the request is authenticated as the
+ * connector user (typically the admin who registered it), not as the user who asked for the
+ * export. The requester is persisted on the export Work (`user_id`), so when the current request
+ * is associated with a work (via the `opencti-work-id` header, exposed as `context.workId`) we
+ * load that work and return its `user_id` to be used as the file `creator_id`.
+ *
+ * @param {AuthContext} context - The request context; `context.workId` holds the originating work id when present.
+ * @param {AuthUser} user - The user performing the upload (the connector user in the export push-back case).
+ * @returns {Promise<string | undefined>} The requesting user's id, or `undefined` when no work is
+ * associated with the request or the work cannot be loaded.
+ */
+const resolveExportCreatorId = async (context, user) => {
+  if (!context.workId) {
+    return undefined;
+  }
+  const work = await loadWorkById(context, user, context.workId).catch(() => null);
+  return work?.user_id;
+};
+
 export const stixCoreObjectsExportPush = async (context, user, entity_id, entity_type, file, file_markings, listFilters) => {
-  const meta = { list_filters: listFilters };
+  const creatorId = await resolveExportCreatorId(context, user);
+  const meta = { list_filters: listFilters, creator_id: creatorId };
   const entity = entity_id ? await internalLoadById(context, user, entity_id) : undefined;
   const opts = { entity, meta, file_markings };
   await uploadToStorage(context, user, `export/${entity_type}${entity_id ? `/${entity_id}` : ''}`, file, opts);
@@ -566,7 +589,9 @@ export const stixCoreObjectExportPush = async (context, user, entityId, args) =>
     throw UnsupportedError('Cant upload a file an none existing element', { entityId });
   }
   const path = `export/${previous.entity_type}/${entityId}`;
-  const { upload: up } = await uploadToStorage(context, user, path, args.file, { entity: previous, file_markings: args.file_markings });
+  const creatorId = await resolveExportCreatorId(context, user);
+  const meta = creatorId ? { creator_id: creatorId } : {};
+  const { upload: up } = await uploadToStorage(context, user, path, args.file, { entity: previous, meta, file_markings: args.file_markings });
   const contextData = buildContextDataForFile(previous, path, up.name);
   await publishUserAction({
     user,

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -60,7 +60,7 @@ import { minutesAgo, monthsAgo, now, utcDate } from '../utils/format';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
 import { defaultValidationMode, deleteFile, loadFile, storeFileConverter, uploadToStorage } from '../database/file-storage';
 import { getFileContent } from '../database/raw-file-storage';
-import { findById as documentFindById, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { findById as documentFindById, paginatedForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { elCount, elFindByIds, elUpdateElement } from '../database/engine';
 import { generateStandardId, getInstanceIds } from '../schema/identifier';
 import { askEntityExport, askListExport, exportTransformFilters } from './stix';
@@ -527,9 +527,7 @@ export const stixCoreObjectsMultiDistribution = (context, user, args) => {
 // region export
 export const stixCoreObjectsExportFiles = async (context, user, exportContext, args) => {
   const { first } = args;
-  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+  return paginatedForExportContext(context, user, exportContext, { first });
 };
 
 export const stixCoreObjectsExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -60,7 +60,7 @@ import { minutesAgo, monthsAgo, now, utcDate } from '../utils/format';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
 import { defaultValidationMode, deleteFile, loadFile, storeFileConverter, uploadToStorage } from '../database/file-storage';
 import { getFileContent } from '../database/raw-file-storage';
-import { findById as documentFindById, paginatedForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { findById as documentFindById, paginatedExportFilesForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { elCount, elFindByIds, elUpdateElement } from '../database/engine';
 import { generateStandardId, getInstanceIds } from '../schema/identifier';
 import { askEntityExport, askListExport, exportTransformFilters } from './stix';
@@ -525,11 +525,35 @@ export const stixCoreObjectsMultiDistribution = (context, user, args) => {
 // endregion
 
 // region export
-export const stixCoreObjectsExportFiles = async (context, user, exportContext, args) => {
-  const { first } = args;
-  return paginatedForExportContext(context, user, exportContext, { first });
+export const stixCoreObjectsExportFiles = async (context, user, exportContext, { first }) => {
+  return paginatedExportFilesForExportContext(context, user, exportContext, { first });
 };
 
+/**
+ * Starts a list/selection export by requesting its generation asynchronously.
+ *
+ * This is the "ask" side of the export lifecycle: it does not produce a file. It transforms the
+ * provided filtering arguments, then delegates to {@link askListExport}, which creates an export
+ * Work (persisting the requesting user as `user_id`) and pushes a job onto the connector queue for
+ * the export connector to process. The returned works are exposed to the UI as pending export
+ * files. The generated file is later uploaded back through {@link stixCoreObjectsExportPush}.
+ *
+ * @param {AuthContext} context - The request context.
+ * @param {AuthUser} user - The user requesting the export.
+ * @param {object} args - Export request arguments.
+ * @param {object} args.exportContext - Export context (entity type, optional entity id, visible columns...).
+ * @param {string} args.format - Target export mime type/format.
+ * @param {string} args.exportType - Export type (e.g. simple or full).
+ * @param {string[]} args.contentMaxMarkings - Maximum content markings the export can include.
+ * @param {string[]} [args.selectedIds] - Ids selected via checkboxes (selection export); absent for a full-query export.
+ * @param {string[]} args.fileMarkings - Markings to apply on the resulting file.
+ * @param {string} [args.search] - Optional full-text search applied to the exported list.
+ * @param {string} [args.orderBy] - Optional ordering field.
+ * @param {string} [args.orderMode] - Optional ordering direction.
+ * @param {object} [args.filters] - Optional filter group applied to the exported list.
+ * @returns {Promise<object[]>} The pending export works mapped to export file descriptors.
+ * @throws {UnsupportedError} When called within a draft context.
+ */
 export const stixCoreObjectsExportAsk = async (context, user, args) => {
   if (getDraftContext(context, user)) {
     throw UnsupportedError('Cannot ask for export in draft');
@@ -574,6 +598,24 @@ const resolveExportCreatorId = async (context, user) => {
   return work?.user_id;
 };
 
+/**
+ * Uploads a generated list/selection export file back to storage.
+ *
+ * This is the "push" side of the export lifecycle, counterpart to {@link stixCoreObjectsExportAsk}:
+ * it is called by the export connector once it has produced the STIX bundle. Because the request is
+ * authenticated as the connector user (not the original requester), the true requester is resolved
+ * from the export Work via {@link resolveExportCreatorId} and passed as `creator_id` so the stored
+ * file is attributed to the user who asked for the export.
+ *
+ * @param {AuthContext} context - The request context; `context.workId` links the push-back to its export Work.
+ * @param {AuthUser} user - The user performing the upload (the connector user in the push-back case).
+ * @param {string} [entity_id] - Optional id of the entity the export is hosted on; when absent the export is global.
+ * @param {string} entity_type - The exported entity type, used to build the storage path.
+ * @param {FileUploadData} file - The generated export file to upload.
+ * @param {string[]} file_markings - Markings to apply on the uploaded file.
+ * @param {string} [listFilters] - The filters used for the export, stored as file metadata.
+ * @returns {Promise<boolean>} `true` once the file has been uploaded.
+ */
 export const stixCoreObjectsExportPush = async (context, user, entity_id, entity_type, file, file_markings, listFilters) => {
   const creatorId = await resolveExportCreatorId(context, user);
   const meta = { list_filters: listFilters, creator_id: creatorId };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -525,6 +525,13 @@ export const stixCoreObjectsMultiDistribution = (context, user, args) => {
 // endregion
 
 // region export
+export const stixCoreObjectsExportFiles = async (context, user, exportContext, args) => {
+  const { first } = args;
+  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
+  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
+  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+};
+
 export const stixCoreObjectsExportAsk = async (context, user, args) => {
   if (getDraftContext(context, user)) {
     throw UnsupportedError('Cannot ask for export in draft');

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -17,7 +17,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { addDynamicFromAndToToFilters, addFilter } from '../utils/filtering/filtering-utils';
 import { stixRelationshipsDistribution } from './stixRelationship';
 import { elRemoveElementFromDraft } from '../database/draft-engine';
-import { paginatedForExportContext } from '../modules/internal/document/document-domain';
+import { paginatedExportFilesForExportContext } from '../modules/internal/document/document-domain';
 
 export const findStixCoreRelationshipsPaginated = async (context, user, args) => {
   const filters = addDynamicFromAndToToFilters(args);
@@ -81,7 +81,7 @@ export const stixCoreRelationshipsMultiTimeSeries = async (context, user, args) 
 
 // region export
 export const stixCoreRelationshipsExportFiles = async (context, user, exportContext, { first }) => {
-  return paginatedForExportContext(context, user, exportContext, { first });
+  return paginatedExportFilesForExportContext(context, user, exportContext, { first });
 };
 
 export const stixCoreRelationshipsExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -17,6 +17,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { addDynamicFromAndToToFilters, addFilter } from '../utils/filtering/filtering-utils';
 import { stixRelationshipsDistribution } from './stixRelationship';
 import { elRemoveElementFromDraft } from '../database/draft-engine';
+import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain.ts';
 
 export const findStixCoreRelationshipsPaginated = async (context, user, args) => {
   const filters = addDynamicFromAndToToFilters(args);
@@ -79,6 +80,12 @@ export const stixCoreRelationshipsMultiTimeSeries = async (context, user, args) 
 // endregion
 
 // region export
+export const stixCoreRelationshipsExportFiles = async (context, user, exportContext, { first }) => {
+  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
+  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
+  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+};
+
 export const stixCoreRelationshipsExportAsk = async (context, user, args) => {
   const { exportContext, format, exportType, contentMaxMarkings, selectedIds, fileMarkings } = args;
   const { fromOrToId, elementWithTargetTypes, fromId, fromRole, fromTypes, toId, toRole, toTypes, relationship_type } = args;

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -17,7 +17,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { addDynamicFromAndToToFilters, addFilter } from '../utils/filtering/filtering-utils';
 import { stixRelationshipsDistribution } from './stixRelationship';
 import { elRemoveElementFromDraft } from '../database/draft-engine';
-import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain.ts';
+import { paginatedForExportContext } from '../modules/internal/document/document-domain';
 
 export const findStixCoreRelationshipsPaginated = async (context, user, args) => {
   const filters = addDynamicFromAndToToFilters(args);
@@ -81,9 +81,7 @@ export const stixCoreRelationshipsMultiTimeSeries = async (context, user, args) 
 
 // region export
 export const stixCoreRelationshipsExportFiles = async (context, user, exportContext, { first }) => {
-  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+  return paginatedForExportContext(context, user, exportContext, { first });
 };
 
 export const stixCoreRelationshipsExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -45,7 +45,7 @@ import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { uploadToStorage } from '../database/file-storage';
 import { isNumericAttribute } from '../schema/schema-attributes';
-import { paginatedForExportContext } from '../modules/internal/document/document-domain';
+import { paginatedExportFilesForExportContext } from '../modules/internal/document/document-domain';
 
 export const findById = (context, user, stixCyberObservableId) => {
   return storeLoadById(context, user, stixCyberObservableId, ABSTRACT_STIX_CYBER_OBSERVABLE);
@@ -348,7 +348,7 @@ export const stixCyberObservableEditContext = async (context, user, stixCyberObs
 
 // region export
 export const stixCyberObservablesExportFiles = async (context, user, exportContext, { first }) => {
-  return paginatedForExportContext(context, user, exportContext, { first });
+  return paginatedExportFilesForExportContext(context, user, exportContext, { first });
 };
 
 export const stixCyberObservablesExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -45,7 +45,7 @@ import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { uploadToStorage } from '../database/file-storage';
 import { isNumericAttribute } from '../schema/schema-attributes';
-import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { paginatedForExportContext } from '../modules/internal/document/document-domain';
 
 export const findById = (context, user, stixCyberObservableId) => {
   return storeLoadById(context, user, stixCyberObservableId, ABSTRACT_STIX_CYBER_OBSERVABLE);
@@ -348,9 +348,7 @@ export const stixCyberObservableEditContext = async (context, user, stixCyberObs
 
 // region export
 export const stixCyberObservablesExportFiles = async (context, user, exportContext, { first }) => {
-  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+  return paginatedForExportContext(context, user, exportContext, { first });
 };
 
 export const stixCyberObservablesExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -45,6 +45,7 @@ import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { controlUserConfidenceAgainstElement } from '../utils/confidence-level';
 import { uploadToStorage } from '../database/file-storage';
 import { isNumericAttribute } from '../schema/schema-attributes';
+import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 
 export const findById = (context, user, stixCyberObservableId) => {
   return storeLoadById(context, user, stixCyberObservableId, ABSTRACT_STIX_CYBER_OBSERVABLE);
@@ -346,6 +347,12 @@ export const stixCyberObservableEditContext = async (context, user, stixCyberObs
 // endregion
 
 // region export
+export const stixCyberObservablesExportFiles = async (context, user, exportContext, { first }) => {
+  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
+  const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
+  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+};
+
 export const stixCyberObservablesExportAsk = async (context, user, args) => {
   const { exportContext, format, exportType, contentMaxMarkings, selectedIds, fileMarkings } = args;
   const { search, orderBy, orderMode, filters, types } = args;

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -51,7 +51,7 @@ import { isUserHasCapability, SETTINGS_SET_ACCESSES, validateMarking } from '../
 import { editAuthorizedMembers } from '../utils/authorizedMembers';
 import { getPirWithAccessCheck } from '../modules/pir/pir-checkPirAccess';
 import { isEnterpriseEdition } from '../enterprise-edition/ee';
-import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { paginatedForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { ENTITY_TYPE_FINTEL_TEMPLATE } from '../modules/fintelTemplate/fintelTemplate-types';
 
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../modules/grouping/grouping-types';
@@ -176,9 +176,7 @@ export const getFintelTemplates = async (context, user, stixDomainObject) => {
 
 // region export
 export const stixDomainObjectsExportFiles = async (context, user, exportContext, { first }) => {
-  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-  const opts = { first, entity_type: exportContext.entity_type };
-  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+  return paginatedForExportContext(context, user, exportContext, { first });
 };
 
 export const stixDomainObjectsExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -51,7 +51,7 @@ import { isUserHasCapability, SETTINGS_SET_ACCESSES, validateMarking } from '../
 import { editAuthorizedMembers } from '../utils/authorizedMembers';
 import { getPirWithAccessCheck } from '../modules/pir/pir-checkPirAccess';
 import { isEnterpriseEdition } from '../enterprise-edition/ee';
-import { paginatedForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
+import { paginatedExportFilesForExportContext, paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { ENTITY_TYPE_FINTEL_TEMPLATE } from '../modules/fintelTemplate/fintelTemplate-types';
 
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../modules/grouping/grouping-types';
@@ -176,7 +176,7 @@ export const getFintelTemplates = async (context, user, stixDomainObject) => {
 
 // region export
 export const stixDomainObjectsExportFiles = async (context, user, exportContext, { first }) => {
-  return paginatedForExportContext(context, user, exportContext, { first });
+  return paginatedExportFilesForExportContext(context, user, exportContext, { first });
 };
 
 export const stixDomainObjectsExportAsk = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixDomainObject.js
@@ -175,6 +175,12 @@ export const getFintelTemplates = async (context, user, stixDomainObject) => {
 };
 
 // region export
+export const stixDomainObjectsExportFiles = async (context, user, exportContext, { first }) => {
+  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
+  const opts = { first, entity_type: exportContext.entity_type };
+  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, opts);
+};
+
 export const stixDomainObjectsExportAsk = async (context, user, args) => {
   const { exportContext, format, exportType, contentMaxMarkings, selectedIds, fileMarkings } = args;
   const { search, orderBy, orderMode, filters } = args;

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -218,3 +218,15 @@ export const paginatedForPathWithEnrichment = async (context: AuthContext, user:
   // endregion
   return pagination;
 };
+
+// Get export files paginated for a given export context (entity_type + optional entity_id)
+export const paginatedForExportContext = async (
+  context: AuthContext,
+  user: AuthUser,
+  exportContext: { entity_type: string; entity_id?: string },
+  opts?: FilesOptions<BasicStoreEntityDocument>,
+) => {
+  const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
+  const listOpts = { ...opts, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
+  return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, listOpts);
+};

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -228,7 +228,7 @@ export const paginatedForPathWithEnrichment = async (context: AuthContext, user:
  * @param opts - Optional file listing options (e.g. `first`) merged into the query.
  * @returns A paginated connection of export files for the resolved path.
  */
-export const paginatedForExportContext = async (
+export const paginatedExportFilesForExportContext = async (
   context: AuthContext,
   user: AuthUser,
   exportContext: { entity_type: string; entity_id?: string },

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -13,7 +13,7 @@ import type { BasicStoreCommon } from '../../../types/store';
 import { type File, FilterMode, FilterOperator, OrderingMode, State } from '../../../generated/graphql';
 import { loadExportWorksAsProgressFiles } from '../../../domain/work';
 import { elSearchFiles } from '../../../database/file-search';
-import { SYSTEM_USER } from '../../../utils/access';
+import { isBypassUser, SYSTEM_USER } from '../../../utils/access';
 import { FROM_START_STR } from '../../../utils/format';
 import { RELATION_OBJECT_MARKING } from '../../../schema/stixRefRelationship';
 import { buildRefRelationKey } from '../../../schema/general';
@@ -21,6 +21,7 @@ import { getDraftContext } from '../../../utils/draftContext';
 import { DRAFT_OPERATION_CREATE } from '../../draftWorkspace/draftOperations';
 import { getDraftFilePrefix } from '../../../database/draft-utils';
 import { EMBEDDED_STORAGE_PATH, EXPORT_STORAGE_PATH, FROM_TEMPLATE_STORAGE_PATH, IMPORT_STORAGE_PATH, SUPPORT_STORAGE_PATH } from './document-types';
+import { addFilter } from '../../../utils/filtering/filtering-utils';
 
 export { SUPPORT_STORAGE_PATH, IMPORT_STORAGE_PATH, EMBEDDED_STORAGE_PATH, EXPORT_STORAGE_PATH, FROM_TEMPLATE_STORAGE_PATH };
 
@@ -220,7 +221,7 @@ export const paginatedForPathWithEnrichment = async (context: AuthContext, user:
 };
 
 /**
- * Retrieve export files paginated for a given export context.
+ * Retrieve export files created by a given user and paginated for a given export context.
  *
  * @param context - The current authentication context.
  * @param user - The user performing the request.
@@ -235,6 +236,16 @@ export const paginatedExportFilesForExportContext = async (
   opts?: FilesOptions<BasicStoreEntityDocument>,
 ) => {
   const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-  const listOpts = { ...opts, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
+  // Users should only see their own exports & Bypass users should see all the exports
+  const filters = isBypassUser(user)
+    ? undefined
+    : addFilter(undefined, 'metaData.creator_id', [user.id]);
+
+  const listOpts = {
+    ...opts,
+    entity_id: exportContext.entity_id,
+    entity_type: exportContext.entity_type,
+    filters,
+  };
   return paginatedForPathWithEnrichment(context, user, path, exportContext.entity_id, listOpts);
 };

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -219,7 +219,15 @@ export const paginatedForPathWithEnrichment = async (context: AuthContext, user:
   return pagination;
 };
 
-// Get export files paginated for a given export context (entity_type + optional entity_id)
+/**
+ * Retrieve export files paginated for a given export context.
+ *
+ * @param context - The current authentication context.
+ * @param user - The user performing the request.
+ * @param exportContext - The export target, defining the entity type and an optional entity id.
+ * @param opts - Optional file listing options (e.g. `first`) merged into the query.
+ * @returns A paginated connection of export files for the resolved path.
+ */
 export const paginatedForExportContext = async (
   context: AuthContext,
   user: AuthUser,

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
@@ -47,6 +47,7 @@ import {
   stixCoreRelationshipsPaginated,
   findUnknownStixCoreObjects,
   cleanInconsistency,
+  stixCoreObjectsExportFiles,
 } from '../domain/stixCoreObject';
 import { fetchEditContext } from '../database/redis';
 import { distributionRelations, stixLoadByIdStringify } from '../database/middleware';
@@ -88,11 +89,7 @@ const stixCoreObjectResolvers = {
       return stixCoreObjectsDistribution(context, context.user, args);
     },
     stixCoreObjectsMultiDistribution: (_, args, context) => stixCoreObjectsMultiDistribution(context, context.user, args),
-    stixCoreObjectsExportFiles: (_, { exportContext, first }, context) => {
-      const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-      const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-      return paginatedForPathWithEnrichment(context, context.user, path, exportContext.entity_id, opts);
-    },
+    stixCoreObjectsExportFiles: (_, { exportContext, first }, context) => stixCoreObjectsExportFiles(context, context.user, exportContext, { first }),
     stixCoreObjectAnalysis: (_, { id, contentSource, contentType }, context) => stixCoreAnalysis(context, context.user, id, contentSource, contentType),
     stixCoreObjectAskAiActivity: (_, args, context) => aiActivity(context, context.user, args),
     stixCoreObjectAskAiForecast: (_, args, context) => aiForecast(context, context.user, args),
@@ -100,7 +97,7 @@ const stixCoreObjectResolvers = {
   },
   StixCoreObjectsOrdering: stixCoreObjectOptions.StixCoreObjectsOrdering,
   StixCoreObject: {
-    // eslint-disable-next-line
+
     __resolveType(obj) {
       if (obj.entity_type) {
         return obj.entity_type.replace(/(?:^|-|_)(\w)/g, (matches, letter) => letter.toUpperCase());

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreRelationship.js
@@ -16,6 +16,7 @@ import {
   stixCoreRelationshipsExportAsk,
   stixCoreRelationshipsMultiTimeSeries,
   stixCoreRelationshipsNumber,
+  stixCoreRelationshipsExportFiles,
 } from '../domain/stixCoreRelationship';
 import { fetchEditContext } from '../database/redis';
 import { subscribeToInstanceEvents } from '../graphql/subscriptionWrapper';
@@ -35,7 +36,6 @@ import {
   stixCoreObjectsExportPush,
 } from '../domain/stixCoreObject';
 import { numberOfContainersForObject } from '../domain/container';
-import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { loadThroughDenormalized } from './stix';
 import { loadCreators } from '../database/members';
 
@@ -47,11 +47,7 @@ const stixCoreRelationshipResolvers = {
     stixCoreRelationshipsMultiTimeSeries: (_, args, context) => stixCoreRelationshipsMultiTimeSeries(context, context.user, args),
     stixCoreRelationshipsDistribution: (_, args, context) => stixCoreRelationshipsDistribution(context, context.user, args),
     stixCoreRelationshipsNumber: (_, args, context) => stixCoreRelationshipsNumber(context, context.user, args),
-    stixCoreRelationshipsExportFiles: (_, { exportContext, first }, context) => {
-      const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-      const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-      return paginatedForPathWithEnrichment(context, context.user, path, exportContext.entity_id, opts);
-    },
+    stixCoreRelationshipsExportFiles: (_, { exportContext, first }, context) => stixCoreRelationshipsExportFiles(context, context.user, exportContext, { first }),
   },
   StixCoreRelationshipsOrdering: stixCoreRelationshipOptions.StixCoreRelationshipsOrdering,
   StixCoreRelationship: {

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCyberObservable.js
@@ -21,6 +21,7 @@ import {
   stixCyberObservablesTimeSeries,
   stixFileObsArtifact,
   vulnerabilitiesPaginated,
+  stixCyberObservablesExportFiles,
 } from '../domain/stixCyberObservable';
 import { subscribeToInstanceEvents } from '../graphql/subscriptionWrapper';
 import { stixCoreObjectExportPush, stixCoreObjectImportPush, stixCoreObjectsExportPush, stixCoreRelationshipsPaginated } from '../domain/stixCoreObject';
@@ -48,11 +49,7 @@ const stixCyberObservableResolvers = {
       }
       return stixCyberObservableDistribution(context, context.user, args);
     },
-    stixCyberObservablesExportFiles: (_, { exportContext, first }, context) => {
-      const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-      const opts = { first, entity_id: exportContext.entity_id, entity_type: exportContext.entity_type };
-      return paginatedForPathWithEnrichment(context, context.user, path, exportContext.entity_id, opts);
-    },
+    stixCyberObservablesExportFiles: (_, { exportContext, first }, context) => stixCyberObservablesExportFiles(context, context.user, exportContext, { first }),
   },
   StixCyberObservablesOrdering: stixCyberObservableOptions.StixCyberObservablesOrdering,
   HashedObservable: {

--- a/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
@@ -22,13 +22,13 @@ import {
   stixDomainObjectsTimeSeriesByAuthor,
   getFilesFromTemplate,
   getFintelTemplates,
+  stixDomainObjectsExportFiles,
 } from '../domain/stixDomainObject';
 import { findById as findStatusById, findByType } from '../domain/status';
 import { subscribeToInstanceEvents } from '../graphql/subscriptionWrapper';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { stixDomainObjectOptions as StixDomainObjectsOptions } from '../schema/stixDomainObjectOptions';
 import { stixCoreObjectExportPush, stixCoreObjectImportPush, stixCoreObjectsExportPush } from '../domain/stixCoreObject';
-import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { loadAssignees } from '../database/members';
 
 const stixDomainObjectResolvers = {
@@ -48,11 +48,7 @@ const stixDomainObjectResolvers = {
       }
       return [];
     },
-    stixDomainObjectsExportFiles: (_, { exportContext, first }, context) => {
-      const path = `export/${exportContext.entity_type}${exportContext.entity_id ? `/${exportContext.entity_id}` : ''}`;
-      const opts = { first, entity_type: exportContext.entity_type };
-      return paginatedForPathWithEnrichment(context, context.user, path, exportContext.entity_id, opts);
-    },
+    stixDomainObjectsExportFiles: (_, { exportContext, first }, context) => stixDomainObjectsExportFiles(context, context.user, exportContext, { first }),
   },
   StixDomainObjectsOrdering: StixDomainObjectsOptions.StixDomainObjectsOrdering,
   StixDomainObject: {


### PR DESCRIPTION
The export panels should only contains files whose creator is the current user, except for bypass users.

### Proposed changes
- Fix: Export files metadata contain the id of the creator of the export (instead of the admin id)
- Export panels (relationships and objects) should only contains files whose creator is the current user, except for bypass users (who see all the export files).
- Bypass users now also see the creator name for each export file line

<img width="1901" height="761" alt="image" src="https://github.com/user-attachments/assets/497bc0fb-b99a-46a5-bf65-1675cbe3177a" />

- Backend tests for generating an export and listing export files


### Related issues
fixes #15498