### PR TITLE
fix(backend): make merge author selection deterministic (flaky test) (#18046)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -2007,7 +2007,22 @@ export const mergeEntities = async (
       throw FunctionalError('Cannot access initial instance', { targetEntityId });
     }
     const target = { ...initialInstance } as BasicStoreEntity;
-    const sources = await storeLoadByIdsWithRefs(context, SYSTEM_USER, sourceEntityIds);
+    const loadedSources = await storeLoadByIdsWithRefs(context, SYSTEM_USER, sourceEntityIds);
+    // storeLoadByIdsWithRefs relies on an unsorted elastic query, so re-align the sources on the requested
+    // ids order: for single meta refs (created-by, ...) the first source wins, the order must be deterministic.
+    const sourcesByIds = new Map<string, StoreObject>();
+    // Sources are indexed in internal_id order with a first-write-wins rule to keep the mapping
+    // deterministic even if several sources share a secondary id (duplicated standard_id, stix ids or aliases).
+    const orderedLoadedSources = R.sortBy((s) => s.internal_id, loadedSources);
+    orderedLoadedSources.forEach((source) => {
+      const sourceIds = [source.internal_id, source.standard_id, ...(source.x_opencti_stix_ids ?? []), ...(source.i_aliases_ids ?? [])];
+      sourceIds.forEach((id) => {
+        if (!sourcesByIds.has(id)) {
+          sourcesByIds.set(id, source);
+        }
+      });
+    });
+    const sources = R.uniqBy((s) => s.internal_id, sourceEntityIds.map((id) => sourcesByIds.get(id)).filter(isNotEmptyField));
     const sourcesDependencies = await loadMergeEntitiesDependencies(context, SYSTEM_USER, sources.map((s) => s.internal_id));
     const targetDependencies = await loadMergeEntitiesDependencies(context, SYSTEM_USER, [initialInstance.internal_id]);
     // - TRANSACTION PART


### PR DESCRIPTION
## Proposed changes

- Fix the flaky integration test `Upsert and merge entities > should multiple createdBy identity merged to empty target` by making the merge behavior deterministic (see #18046 for the full analysis).
- In `mergeEntities`, the sources were loaded through `storeLoadByIdsWithRefs`, which relies on an unsorted ElasticSearch `terms` query: the hits come back in arbitrary shard/index order, not in the requested ids order. Since `filterTargetByExisting` keeps only the **first** relation for single-cardinality meta refs (`created-by`, ...), the author kept on the merged entity depended on the ElasticSearch ordering, which made both the merge result and the test non-deterministic.
- The loaded sources are now re-aligned on the `sourceEntityIds` order (matching on `internal_id`, `standard_id`, `x_opencti_stix_ids` and `i_aliases_ids`) before resolving the merge dependencies, so the "first source wins" rule is stable. This also makes the sources order of the merge stream event deterministic.

## Related issues

- Closes #18046

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (local integration run of `02-dataInjection/01-dataCount/middleware-test.js`: 61 passed, 2 skipped)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
