### PR TITLE
test(chatbot): add an E2E scenario for the Ask Ariane panel (#18049)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../fixtures/baseFixtures';
 import AskArianePageModel from '../model/askAriane.pageModel';
-import { AGENT_DESCRIPTION, AGENT_NAME, PRESENTATION_EXCERPT, QUESTION, WIDGET_ERROR_MESSAGE, getUnstubbedChatbotRequests, mockChatbotBackend } from './chatbotBackendMock';
+import { AGENT_DESCRIPTION, AGENT_NAME, PRESENTATION_EXCERPT, QUESTION, WIDGET_ERROR_MESSAGES, getUnstubbedChatbotRequests, mockChatbotBackend } from './chatbotBackendMock';
 
 /**
  * Content of the test
@@ -29,7 +29,7 @@ test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
   await expect(panel).toContainText(`How can ${AGENT_NAME} help you`);
   await expect(panel).toContainText(AGENT_DESCRIPTION);
   await expect(askAriane.getPromptSuggestion('What are the latest threats?')).toBeVisible();
-  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGES);
   // endregion
 
   // region The agent answers a question
@@ -38,7 +38,7 @@ test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
   await askAriane.getPromptInput().press('Enter');
   await expect(panel).toContainText(QUESTION);
   await expect(panel).toContainText(PRESENTATION_EXCERPT);
-  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGES);
   // endregion
 
   // region Starting a new chat resets the conversation
@@ -46,10 +46,10 @@ test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
   await askAriane.getNewChatButton().click();
   await expect(panel).not.toContainText(QUESTION);
   await expect(panel).toContainText(`How can ${AGENT_NAME} help you`);
-  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGES);
   // endregion
 
   // The scenario must hold without any XTM One reachable, so nothing the panel
   // asked for may have escaped the mock.
-  expect(getUnstubbedChatbotRequests()).toEqual([]);
+  await expect.poll(getUnstubbedChatbotRequests).toEqual([]);
 });

--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '../fixtures/baseFixtures';
+import AskArianePageModel from '../model/askAriane.pageModel';
+import { AGENT_DESCRIPTION, AGENT_NAME, PRESENTATION_EXCERPT, WIDGET_ERROR_MESSAGE, getUnstubbedChatbotRequests, mockChatbotBackend } from './chatbotBackendMock';
+
+/**
+ * Content of the test
+ * -------------------
+ * Open the Ask Ariane panel
+ * Check the agent presentation and that no error is displayed
+ * Ask a question and check the answer is streamed back
+ * Start a new chat and check the conversation is reset
+ */
+test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
+  const askAriane = new AskArianePageModel(page);
+
+  await mockChatbotBackend(page);
+  await page.goto('/dashboard');
+
+  // region Open the chatbot
+  // ----------------------
+  await askAriane.open();
+  await expect(askAriane.getPanel()).toBeVisible();
+  await expect(askAriane.getPromptInput()).toBeVisible();
+  // endregion
+
+  // region The agent presents itself, without any error
+  // --------------------------------------------------
+  const panel = askAriane.getPanel();
+  await expect(panel).toContainText(`How can ${AGENT_NAME} help you`);
+  await expect(panel).toContainText(AGENT_DESCRIPTION);
+  await expect(askAriane.getPromptSuggestion('What are the latest threats?')).toBeVisible();
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  // endregion
+
+  // region The agent answers a question
+  // ----------------------------------
+  await askAriane.getPromptInput().fill('Hello, who are you?');
+  await askAriane.getPromptInput().press('Enter');
+  await expect(panel).toContainText('Hello, who are you?');
+  await expect(panel).toContainText(PRESENTATION_EXCERPT);
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  // endregion
+
+  // region Starting a new chat resets the conversation
+  // -------------------------------------------------
+  await askAriane.getNewChatButton().click();
+  await expect(panel).not.toContainText('Hello, who are you?');
+  await expect(panel).toContainText(`How can ${AGENT_NAME} help you`);
+  await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
+  // endregion
+
+  // The scenario must hold without any XTM One reachable, so nothing the panel
+  // asked for may have escaped the mock.
+  expect(getUnstubbedChatbotRequests()).toEqual([]);
+});

--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbot.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../fixtures/baseFixtures';
 import AskArianePageModel from '../model/askAriane.pageModel';
-import { AGENT_DESCRIPTION, AGENT_NAME, PRESENTATION_EXCERPT, WIDGET_ERROR_MESSAGE, getUnstubbedChatbotRequests, mockChatbotBackend } from './chatbotBackendMock';
+import { AGENT_DESCRIPTION, AGENT_NAME, PRESENTATION_EXCERPT, QUESTION, WIDGET_ERROR_MESSAGE, getUnstubbedChatbotRequests, mockChatbotBackend } from './chatbotBackendMock';
 
 /**
  * Content of the test
@@ -34,9 +34,9 @@ test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
 
   // region The agent answers a question
   // ----------------------------------
-  await askAriane.getPromptInput().fill('Hello, who are you?');
+  await askAriane.getPromptInput().fill(QUESTION);
   await askAriane.getPromptInput().press('Enter');
-  await expect(panel).toContainText('Hello, who are you?');
+  await expect(panel).toContainText(QUESTION);
   await expect(panel).toContainText(PRESENTATION_EXCERPT);
   await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
   // endregion
@@ -44,7 +44,7 @@ test('Ask Ariane chatbot', { tag: ['@ee'] }, async ({ page }) => {
   // region Starting a new chat resets the conversation
   // -------------------------------------------------
   await askAriane.getNewChatButton().click();
-  await expect(panel).not.toContainText('Hello, who are you?');
+  await expect(panel).not.toContainText(QUESTION);
   await expect(panel).toContainText(`How can ${AGENT_NAME} help you`);
   await expect(panel).not.toContainText(WIDGET_ERROR_MESSAGE);
   // endregion

--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
@@ -1,0 +1,130 @@
+import { Page } from '@playwright/test';
+
+/**
+ * The Ask Ariane panel talks to the `/chatbot/*` proxy, which needs an XTM One
+ * instance the CI environment does not have (no `xtm_one_token`, so
+ * `/chatbot/config` reports `xtm_one_configured: false` and the panel never
+ * mounts). The whole REST layer is therefore stubbed with payloads recorded
+ * from a real XTM One session, which keeps the scenario deterministic — a live
+ * agent would paraphrase its own presentation on every run.
+ */
+
+export const AGENT_NAME = 'CTEM Assistant';
+export const AGENT_DESCRIPTION = 'Primary entry point of the XTM One platform.';
+export const AGENT_SLUG = 'ctem-assistant';
+
+// A sentence the presentation answer must contain, short enough to survive
+// markdown rendering (the widget strips the `**` emphasis).
+export const PRESENTATION_EXCERPT = 'What would you like help with today?';
+
+// The only error text the widget renders on its own; anything else it displays
+// comes from the proxy and replaces the assistant message content.
+export const WIDGET_ERROR_MESSAGE = 'Sorry, an error occurred. Please try again.';
+
+const CONVERSATION_ID = '89d60741-81c1-45c8-8d73-ce0ded38bf6f';
+const MESSAGE_ID = '786d810d-34f8-48f6-ad61-f8f18707b79a';
+
+const AGENTS = [
+  {
+    id: '73b39208-e45e-4660-bd43-ff057a12d5dd',
+    name: AGENT_NAME,
+    slug: AGENT_SLUG,
+    description: AGENT_DESCRIPTION,
+  },
+  {
+    id: '54f6d934-3bf1-434e-919c-3605f76c8482',
+    name: 'OpenCTI Assistant',
+    slug: 'opencti-assistant',
+    description: 'Cyber Threat Intelligence analyst for OpenCTI.',
+  },
+];
+
+const PRESENTATION_ANSWER = [
+  `I'm the **${AGENT_NAME}** — your entry point on the XTM One platform.`,
+  '',
+  '## What I do',
+  '- Act as the **central coordinator** across the platform specialists',
+  '- Have **direct access to OpenCTI** so I can look up threats and campaigns myself',
+  '',
+  PRESENTATION_EXCERPT,
+].join('\n');
+
+// Server-sent events, in the order and shape XTM One streams them.
+const MESSAGES_STREAM = [
+  { type: 'status', status: 'preparing', phase: 'memory' },
+  { type: 'status', status: 'preparing', phase: 'integrations' },
+  { type: 'status', status: 'thinking', iteration: 1 },
+  { type: 'status', status: 'streaming' },
+  { type: 'stream', content: PRESENTATION_ANSWER },
+  {
+    type: 'done',
+    content: PRESENTATION_ANSWER,
+    conversation_id: CONVERSATION_ID,
+    message_id: MESSAGE_ID,
+  },
+].map((event) => `data: ${JSON.stringify(event)}\n\n`).join('');
+
+const SESSION = {
+  conversation_id: CONVERSATION_ID,
+  messages: [
+    { role: 'user', content: 'Hello, who are you?' },
+    { role: 'assistant', content: PRESENTATION_ANSWER },
+  ],
+};
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+});
+
+const unstubbedRequests: string[] = [];
+
+/**
+ * Paths the widget asks for that the OpenCTI proxy does not serve: they fall
+ * through to the SPA index in production, so 404 is the faithful answer and the
+ * widget is expected to cope with it.
+ */
+const UNSERVED_BY_PROXY = '**/chatbot/chat/**';
+
+/**
+ * Everything the panel requested during the test that the mock did not expect.
+ * Asserting this stays empty keeps the scenario honest: the day a widget
+ * version calls a new endpoint, the test says so instead of silently relying on
+ * a real XTM One being reachable.
+ */
+export const getUnstubbedChatbotRequests = () => [...unstubbedRequests];
+
+/**
+ * Playwright consults route handlers in reverse registration order, so the
+ * catch-all goes in first and the specific routes below override it.
+ */
+export const mockChatbotBackend = async (page: Page) => {
+  unstubbedRequests.length = 0;
+
+  await page.route('**/chatbot/**', (route) => {
+    unstubbedRequests.push(new URL(route.request().url()).pathname);
+    return route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+  });
+
+  await page.route(UNSERVED_BY_PROXY, (route) => route.fulfill({
+    status: 404,
+    contentType: 'application/json',
+    body: '{}',
+  }));
+
+  await page.route('**/chatbot/config', (route) => route.fulfill(json({
+    xtm_one_url: 'http://localhost:8100',
+    xtm_one_configured: true,
+  })));
+
+  await page.route('**/chatbot/agents**', (route) => route.fulfill(json(AGENTS)));
+
+  await page.route('**/chatbot/sessions', (route) => route.fulfill(json(SESSION)));
+
+  await page.route('**/chatbot/messages', (route) => route.fulfill({
+    status: 200,
+    contentType: 'text/event-stream',
+    body: MESSAGES_STREAM,
+  }));
+};

--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
@@ -17,6 +17,9 @@ export const AGENT_SLUG = 'ctem-assistant';
 // markdown rendering (the widget strips the `**` emphasis).
 export const PRESENTATION_EXCERPT = 'What would you like help with today?';
 
+// Asked by the test, and the title the history menu shows for that conversation.
+export const QUESTION = 'Hello, who are you?';
+
 // The only error text the widget renders on its own; anything else it displays
 // comes from the proxy and replaces the assistant message content.
 export const WIDGET_ERROR_MESSAGE = 'Sorry, an error occurred. Please try again.';
@@ -64,11 +67,26 @@ const MESSAGES_STREAM = [
   },
 ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join('');
 
+// POST resumes a conversation and replays its messages.
 const SESSION = {
   conversation_id: CONVERSATION_ID,
   messages: [
-    { role: 'user', content: 'Hello, who are you?' },
+    { role: 'user', content: QUESTION },
     { role: 'assistant', content: PRESENTATION_ANSWER },
+  ],
+};
+
+// GET lists the conversations, and is requested when the history menu opens.
+const SESSIONS = {
+  conversations: [
+    {
+      conversation_id: CONVERSATION_ID,
+      title: QUESTION,
+      updated_at: '2026-09-01T09:08:20.357532+00:00',
+      message_count: 2,
+      agent_id: AGENTS[0].id,
+      agent_name: AGENT_NAME,
+    },
   ],
 };
 
@@ -120,7 +138,9 @@ export const mockChatbotBackend = async (page: Page) => {
 
   await page.route('**/chatbot/agents**', (route) => route.fulfill(json(AGENTS)));
 
-  await page.route('**/chatbot/sessions', (route) => route.fulfill(json(SESSION)));
+  await page.route('**/chatbot/sessions', (route) => route.fulfill(
+    json(route.request().method() === 'GET' ? SESSIONS : SESSION),
+  ));
 
   await page.route('**/chatbot/messages', (route) => route.fulfill({
     status: 200,

--- a/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
+++ b/opencti-platform/opencti-front/tests_e2e/chatbot/chatbotBackendMock.ts
@@ -20,9 +20,13 @@ export const PRESENTATION_EXCERPT = 'What would you like help with today?';
 // Asked by the test, and the title the history menu shows for that conversation.
 export const QUESTION = 'Hello, who are you?';
 
-// The only error text the widget renders on its own; anything else it displays
-// comes from the proxy and replaces the assistant message content.
-export const WIDGET_ERROR_MESSAGE = 'Sorry, an error occurred. Please try again.';
+/**
+ * Every error the widget can render on its own: a failed turn, a request that
+ * never reached the proxy, and a stream that ended without a `done` event.
+ * Anything else it displays comes from the proxy and replaces the assistant
+ * message content.
+ */
+export const WIDGET_ERROR_MESSAGES = /Sorry, an error occurred|Unable to connect|No response\./;
 
 const CONVERSATION_ID = '89d60741-81c1-45c8-8d73-ce0ded38bf6f';
 const MESSAGE_ID = '786d810d-34f8-48f6-ad61-f8f18707b79a';
@@ -99,11 +103,14 @@ const json = (body: unknown) => ({
 const unstubbedRequests: string[] = [];
 
 /**
- * Paths the widget asks for that the OpenCTI proxy does not serve: they fall
- * through to the SPA index in production, so 404 is the faithful answer and the
- * widget is expected to cope with it.
+ * Paths the widget asks for that the OpenCTI proxy does not serve: `/chat/*`
+ * falls through to the SPA catch-all (`app.get('*any')` in `httpPlatform.js`),
+ * which answers 200 with the index page. Serving HTML rather than a 404 keeps
+ * the widget on the same branch as in production, where `r.ok` holds and the
+ * JSON parse is what fails.
  */
 const UNSERVED_BY_PROXY = '**/chatbot/chat/**';
+const SPA_INDEX = '<!doctype html><html lang="en"><head><title>OpenCTI</title></head><body><div id="root"></div></body></html>';
 
 /**
  * Everything the panel requested during the test that the mock did not expect.
@@ -126,9 +133,9 @@ export const mockChatbotBackend = async (page: Page) => {
   });
 
   await page.route(UNSERVED_BY_PROXY, (route) => route.fulfill({
-    status: 404,
-    contentType: 'application/json',
-    body: '{}',
+    status: 200,
+    contentType: 'text/html',
+    body: SPA_INDEX,
   }));
 
   await page.route('**/chatbot/config', (route) => route.fulfill(json({

--- a/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
@@ -12,8 +12,7 @@ const ICON_SWITCH_VIEW = 'M15 3v18';
 const ICON_CLOSE = 'M18 6 6 18';
 
 export default class AskArianePageModel {
-  constructor(private page: Page) {
-  }
+  constructor(private page: Page) {}
 
   // The top bar button opens the panel. Its accessible name comes from the
   // tooltip, not from the visible 'Ask Ariane' label.

--- a/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
@@ -1,0 +1,87 @@
+import { Page } from '@playwright/test';
+
+/**
+ * The panel is rendered by the external `@filigran/chatbot` package, which
+ * ships no `data-testid` and gives an accessible name to only some of its
+ * controls. The unnamed header buttons are located by their lucide icon path:
+ * an index would break the day a button is added, and the icons are what the
+ * user actually recognises.
+ */
+const ICON_NEW_CHAT = 'M12 20h9';
+const ICON_SWITCH_VIEW = 'M15 3v18';
+const ICON_CLOSE = 'M18 6 6 18';
+
+export default class AskArianePageModel {
+  constructor(private page: Page) {
+  }
+
+  // The top bar button opens the panel. Its accessible name comes from the
+  // tooltip, not from the visible 'Ask Ariane' label.
+  getOpenButton() {
+    return this.page.getByRole('button', { name: 'Open chatbot' });
+  }
+
+  getPanel() {
+    return this.page.locator('#ask-ariane-portal .filigran-chatbot');
+  }
+
+  getPromptInput() {
+    return this.getPanel().getByPlaceholder('Ask a question...');
+  }
+
+  getPromptSuggestion(suggestion: string) {
+    return this.getPanel().getByRole('button', { name: suggestion });
+  }
+
+  getConversationHistoryButton() {
+    return this.getPanel().getByRole('button', { name: 'Conversation history' });
+  }
+
+  getNewChatButton() {
+    return this.getHeaderButton(ICON_NEW_CHAT);
+  }
+
+  getSwitchViewButton() {
+    return this.getHeaderButton(ICON_SWITCH_VIEW);
+  }
+
+  getCloseButton() {
+    return this.getHeaderButton(ICON_CLOSE);
+  }
+
+  private getHeaderButton(iconPath: string) {
+    return this.getPanel().locator(`button:has(svg path[d="${iconPath}"])`);
+  }
+
+  // region Filigran AI terms
+  // The chatbot stays behind a CGU gate until an administrator accepts the
+  // terms, and a fresh platform starts with the status 'pending'. Clicking the
+  // top bar button then opens the acceptance dialog instead of the panel.
+  getTermsDialog() {
+    return this.page.getByRole('dialog').filter({ hasText: 'Validate the Filigran AI Terms' });
+  }
+
+  getTermsAgreeButton() {
+    return this.getTermsDialog().getByRole('button', { name: 'I Agree to Filigran AI Terms' });
+  }
+
+  /**
+   * Opens the panel, accepting the Filigran AI terms first when the platform
+   * has not accepted them yet, so the test does not depend on the CGU status it
+   * starts from. Accepting is a platform-wide setting and is left enabled.
+   */
+  async open() {
+    await this.getOpenButton().click();
+    // Race the two possible outcomes of the click instead of probing for the
+    // dialog, which is not rendered yet at that point.
+    await this.getPanel().or(this.getTermsDialog()).waitFor();
+    if (await this.getTermsDialog().isVisible()) {
+      await this.getTermsDialog().getByRole('checkbox').check();
+      await this.getTermsAgreeButton().click();
+      await this.getTermsDialog().waitFor({ state: 'hidden' });
+      await this.getOpenButton().click();
+      await this.getPanel().waitFor();
+    }
+  }
+  // endregion
+}

--- a/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/askAriane.pageModel.ts
@@ -3,13 +3,13 @@ import { Page } from '@playwright/test';
 /**
  * The panel is rendered by the external `@filigran/chatbot` package, which
  * ships no `data-testid` and gives an accessible name to only some of its
- * controls. The unnamed header buttons are located by their lucide icon path:
- * an index would break the day a button is added, and the icons are what the
- * user actually recognises.
+ * controls. The unnamed header buttons are located by their lucide icon path,
+ * scoped to the tooltip wrappers the header uses: the same icons appear in the
+ * mode menu and in the conversation list, so an unscoped path is ambiguous as
+ * soon as one of those is open.
  */
 const ICON_NEW_CHAT = 'M12 20h9';
-const ICON_SWITCH_VIEW = 'M15 3v18';
-const ICON_CLOSE = 'M18 6 6 18';
+const CGU_STATUS_FIELD = 'filigran_chatbot_ai_cgu_status';
 
 export default class AskArianePageModel {
   constructor(private page: Page) {}
@@ -40,16 +40,8 @@ export default class AskArianePageModel {
     return this.getHeaderButton(ICON_NEW_CHAT);
   }
 
-  getSwitchViewButton() {
-    return this.getHeaderButton(ICON_SWITCH_VIEW);
-  }
-
-  getCloseButton() {
-    return this.getHeaderButton(ICON_CLOSE);
-  }
-
   private getHeaderButton(iconPath: string) {
-    return this.getPanel().locator(`button:has(svg path[d="${iconPath}"])`);
+    return this.getPanel().locator(`span.inline-flex > button:has(svg path[d="${iconPath}"])`);
   }
 
   // region Filigran AI terms
@@ -76,8 +68,12 @@ export default class AskArianePageModel {
     await this.getPanel().or(this.getTermsDialog()).waitFor();
     if (await this.getTermsDialog().isVisible()) {
       await this.getTermsDialog().getByRole('checkbox').check();
+      // The dialog closes on click without waiting for its own mutation, so the
+      // button would still read the old 'pending' status and just reopen it.
+      const cguPatched = this.page.waitForResponse((response) => response.url().includes('/graphql')
+        && (response.request().postData() ?? '').includes(CGU_STATUS_FIELD));
       await this.getTermsAgreeButton().click();
-      await this.getTermsDialog().waitFor({ state: 'hidden' });
+      await cguPatched;
       await this.getOpenButton().click();
       await this.getPanel().waitFor();
     }


### PR DESCRIPTION
### Proposed changes

* New E2E scenario `tests_e2e/chatbot/chatbot.spec.ts` (`@ee`): open the Ask Ariane panel, check the agent presentation and the streamed answer, check no error text is displayed, check the *New chat* button resets the conversation.
* `tests_e2e/chatbot/chatbotBackendMock.ts` stubs the `/chatbot/*` proxy — SSE stream included — with payloads recorded from a real XTM One session.
* `tests_e2e/model/askAriane.pageModel.ts` page model; it also accepts the Filigran AI terms when the platform is still at CGU status `pending`.

### Related issues
* closes #18049

### How to test this PR

```
cd opencti-platform/opencti-front
yarn test:e2e --grep "Ask Ariane"
```

Passes with no XTM One running, and from either CGU status (`pending` or `enabled`).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Why mock instead of talking to XTM One: the panel only mounts when EE is active **and** `/chatbot/config` returns `xtm_one_configured: true`, which needs a non-empty `xtm.xtm_one_token`. The CI workflow has an EE licence but no XTM One, and the default URL (`https://common.xtm1.filigran.io`) 301-redirects everything to www.filigran.io, so there is nothing to point at. Mocking also keeps the assertion stable — a live agent paraphrases its presentation on every run. Only the licence and the CGU status stay real. A final assertion fails the test if the panel requests a `/chatbot/*` endpoint the mock does not know, so a widget version bump cannot silently start depending on a real backend.

Two selector notes for reviewers: the top bar button's accessible name is `Open chatbot` (the MUI tooltip overrides the visible "Ask Ariane" label), and `@filigran/chatbot` ships no `data-testid` and names only some of its controls — the unnamed header buttons are located by their lucide icon path. Test ids upstream in `filigran-ui` would let that go away.

Issue bullet 4 says "Refresh button"; there is no *Refresh* string in `@filigran/chatbot@3.9.1`, so it is read here as the *New chat* header button. Say so if the conversation-history button was meant instead.

Vibe coded.

