### PR TITLE
chore(fds): bump the design system pin and restore the two Select widths it moved (#17664)

### DIFF
--- a/fds-migration/IMPLEMENTATION-LOG.md
+++ b/fds-migration/IMPLEMENTATION-LOG.md
@@ -948,3 +948,54 @@ invisible — the control simply swaps engine on interaction.
 It is a static rule, which is exactly the level the information exists at — the
 same reason `check-accessible-names.mjs` had to be static. The sweep that found
 the 20 sites is the rule already; it needs turning into a gate, not inventing.
+
+## 2026-09-01 — The Select width fix, and why the field width is not the wrapper width
+
+Pin bumped bd57527 -> 934dca6 for two library fixes: the collapsed Navbar
+flyout anchor (#204, squash of 287f28a) and the Select trigger wrapper width
+(#203). Diffing the two installed `dist/` trees is what made the sweep
+tractable: the file sets are identical, `index.css` and `tokens/theme.css` are
+byte-identical, and only `select/Select.*` and `navbar-submenu/NavbarSubmenu.*`
+differ. The blast radius is therefore closed by construction — no token moved,
+so no component outside those two can look different.
+
+The Select change is `flex w-full items-center` -> `flex items-center` on the
+trigger's wrapper span. Only a Select whose DIRECT DOM parent is a row-direction
+flex container can move at all; in block and flex-column parents a block-level
+flex box fills its container either way. Static analysis over the 84 library
+`<Select>` sites found 10 such parents. The other 74 are safe by construction,
+and `SelectFieldFds` — ~90 call sites — is safe for all of them because it wraps
+its `<Select>` in its own plain block `<div>`, whatever the outer layout does.
+
+The measurement that mattered: **the wrapper is not the field.** The wrapper
+paints nothing. What a user sees is the trigger `<button>`, and across the six
+flex-row sites whose `<SelectTrigger>` carries no `w-full`, the trigger width is
+identical before and after — only the invisible wrapper shrinks. On
+StixDomainObjectHeader a 58-element neighbourhood diff moved exactly one box: the
+wrapper itself. So "the wrapper shrank" is not "the field shrank", and treating
+the two as the same would have produced a pile of unnecessary width overrides.
+
+The trigger only collapses where the call site put `w-full` ON the trigger: that
+percentage then resolves against a shrink-to-fit box and degenerates to content
+width. Three sites did that — WidgetCreationParameters (868.08 -> 120.52 and
+869.92 -> 80.66) and FeedCreation's Multi-match (638.39 -> 120.23). The first two
+are restored here with the `<FormControl fullWidth style={{ flex: 1 }}>` wrapper
+their own sibling fields two lines below already use.
+
+FeedCreation's is deliberately left alone: pre-bump, that Select's `w-full`
+wrapper drove the sibling "Column name" TextField to **0px** — the field was not
+narrow, it was gone. Restoring the old width would delete it again. Same shape at
+SecretFieldControl, where the two fields stopped wrapping onto separate lines.
+Those are the repair, not the regression.
+
+Simulation method, and its proof: post-bump, setting `width:100%` on a wrapper
+reproduces the pre-bump geometry exactly. Verified against the genuine pre-bump
+build served on :3010 — wrapper 291.73, trigger 197.10, x 258.53, label 86.63,
+matching the simulated numbers to the second decimal. That is what let the whole
+sweep run on one server instead of alternating two builds.
+
+Not covered: StixCoreObjectsSuggestions' entity Select (MUI `ListItem`, a flex
+row). No container in this dataset generates suggestions, so the dialog never
+opens and the site could not be measured. Its trigger carries no `w-full`, which
+in every measured instance of that shape left the field width untouched — but
+that is an inference, not a measurement, and it is recorded as one.

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.9.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=bd57527275ca4149acfd2a79c549952c7dd5062b",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=934dca68473c7cd9a8d4cde7f8e0a78ef2c36fd2",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -516,33 +516,35 @@ const WidgetCreationParameters = () => {
                       marginTop: 20,
                     }}
                   >
-                    <Select
-                      value={dataSelection[i].sort_by ?? 'created_at'}
-                      onValueChange={(value) => handleChangeDataValidationParameter(
-                        i,
-                        'sort_by',
-                        value,
-                      )
-                      }
-                    >
-                      <SelectLabel>{t_i18n('Sort by')}</SelectLabel>
-                      <SelectTrigger className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent aria-label={t_i18n('Sort by')}>
-                        {(isDraftWorkspaceFilterGroup(dataSelection[i].filters)
-                          ? draftWorkspaceSortByValues
-                          : sortByValues.map((v) => ({ value: v, label: capitalizeFirstLetter(v) }))
-                        ).map(({ value, label }) => (
-                          <SelectItem
-                            key={value}
-                            value={value}
-                          >
-                            {t_i18n(label)}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl fullWidth={true} style={{ flex: 1 }}>
+                      <Select
+                        value={dataSelection[i].sort_by ?? 'created_at'}
+                        onValueChange={(value) => handleChangeDataValidationParameter(
+                          i,
+                          'sort_by',
+                          value,
+                        )
+                        }
+                      >
+                        <SelectLabel>{t_i18n('Sort by')}</SelectLabel>
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent aria-label={t_i18n('Sort by')}>
+                          {(isDraftWorkspaceFilterGroup(dataSelection[i].filters)
+                            ? draftWorkspaceSortByValues
+                            : sortByValues.map((v) => ({ value: v, label: capitalizeFirstLetter(v) }))
+                          ).map(({ value, label }) => (
+                            <SelectItem
+                              key={value}
+                              value={value}
+                            >
+                              {t_i18n(label)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
                   </div>
                 )}
 
@@ -845,33 +847,41 @@ const WidgetCreationParameters = () => {
                     {dataSelection[i].perspective === 'entities'
                       && getCurrentSelectedEntityTypes(i).length === 0
                       && (
-                        <Select
-                          value={dataSelection[i].attribute ?? 'entity_type'}
-                          onValueChange={(value) => handleChangeDataValidationParameter(
-                            i,
-                            'attribute',
-                            value,
-                          )
-                          }
+                        <FormControl
+                          fullWidth={true}
+                          style={{
+                            flex: 1,
+                            width: '100%',
+                          }}
                         >
-                          <SelectLabel>{t_i18n('Attribute')}</SelectLabel>
-                          <SelectTrigger className="w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent aria-label={t_i18n('Attribute')}>
-                            {[
-                              'entity_type',
-                              ...ENTITIES_WIDGET_COMMON_ATTRIBUTES,
-                            ].map((value) => (
-                              <SelectItem
-                                key={value}
-                                value={value}
-                              >
-                                {t_i18n(capitalizeFirstLetter(value))}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                          <Select
+                            value={dataSelection[i].attribute ?? 'entity_type'}
+                            onValueChange={(value) => handleChangeDataValidationParameter(
+                              i,
+                              'attribute',
+                              value,
+                            )
+                            }
+                          >
+                            <SelectLabel>{t_i18n('Attribute')}</SelectLabel>
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent aria-label={t_i18n('Attribute')}>
+                              {[
+                                'entity_type',
+                                ...ENTITIES_WIDGET_COMMON_ATTRIBUTES,
+                              ].map((value) => (
+                                <SelectItem
+                                  key={value}
+                                  value={value}
+                                >
+                                  {t_i18n(capitalizeFirstLetter(value))}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
                       )}
 
                     {((dataSelection[i].perspective === 'audits' && getCurrentAvailableParameters(type).includes('attribute'))

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -958,9 +958,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=bd57527275ca4149acfd2a79c549952c7dd5062b":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=934dca68473c7cd9a8d4cde7f8e0a78ef2c36fd2":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=bd57527275ca4149acfd2a79c549952c7dd5062b"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=934dca68473c7cd9a8d4cde7f8e0a78ef2c36fd2"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -981,7 +981,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/b30a9cf8870e8586abf6d3fffd76941ece738cfd82fc66f9245476265df91f78064a1de79dfa3b6e66645ee784a195386d89b69d4c7ba207875748ba1ffad275
+  checksum: 10c0/87a8875138070d34fdc5d5dd7ae4f0df4ad76ff2fb58fb13a769ef5f2652c891317cf1f75117dba121fda3bba65a4b0a412b92907ac27eca0258b5cbb3af54f6
   languageName: node
   linkType: hard
 
@@ -12189,7 +12189,7 @@ __metadata:
     "@faker-js/faker": "npm:10.6.0"
     "@filigran/chatbot": "npm:3.9.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=bd57527275ca4149acfd2a79c549952c7dd5062b"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=934dca68473c7cd9a8d4cde7f8e0a78ef2c36fd2"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
Bumps the `@filigran/design-system` pin from `bd57527` to `934dca6` and restores
the two Select widths that bump moved. One PR, base `design-system/current`.

## What the bump brings

- **#204** (squash of `287f28a`) — the collapsed Navbar flyout is anchored flush
  against the rail: `sideOffset` 8 → 0.
- **#203** — `w-full` is dropped from the Select trigger's wrapper span, so a
  Select used as a direct flex-ROW item hugs its content instead of claiming the
  whole row.

## Blast radius, bounded by construction

Diffing the two installed `dist/` trees: identical file sets, `index.css` and
`tokens/theme.css` **byte-identical**, and only `select/Select.*` and
`navbar-submenu/NavbarSubmenu.*` differ. No token moved, so nothing outside those
two components can render differently. Nothing broke mechanically — no import,
type or snapshot change was needed.

## Navbar, verified in the product

Measured in OpenCTI's own CSS context, not only in the library:

| | value |
|---|---|
| rail right edge | 48.00px |
| flyout panel left edge | 48.00px |
| **gap** | **0.00px** |
| panel width | 179px |

Identical in Filigran Dark and Filigran Light.

## Select sweep

The wrapper change can only move a Select whose **direct DOM parent** is a
row-direction flex container. Of the 84 library `<Select>` sites, 10 have one.
The other 74 are safe by construction — including every `SelectFieldFds` call
site (~90), which wraps its `<Select>` in its own plain block `<div>` whatever
the surrounding layout does.

The wrapper paints nothing, so what a user sees is the trigger `<button>`. Where
the call site left the trigger at its `w-fit` default, the trigger width is
unchanged and only the invisible wrapper shrinks — on `StixDomainObjectHeader` a
58-element neighbourhood diff moves exactly one box, the wrapper itself. The
trigger only collapses where `w-full` sits **on the trigger**, because that
percentage then resolves against a shrink-to-fit box.

| Site | Direct parent | Before | After | Verdict |
|---|---|---|---|---|
| `WidgetCreationParameters` "Sort by" | `div` flex row | **868.08px** | **120.52px** | regression → **restored to 912px** |
| `WidgetCreationParameters` "Attribute" | `div` flex row | **869.92px** | **80.66px** | regression → **restored to 912px** |
| `FeedCreation` "Multi-match" | `Box` flex row | 638.39px | 120.23px | the repair — see below |
| `FeedEdition` (same block) | `Box` flex row | same | same | markup identical to `FeedCreation`, diff verified |
| `DashboardRefreshControl` | `Box` flex row | 85.91px | 85.91px | no change |
| `SecretFieldControl` ×2 | `Box` flex row | 213 / 210.55 / 50px | unchanged | field unchanged |
| `ListCards` "Sort by" | `FormControl` row | 80.28px | 80.28px | field unchanged |
| `StixDomainObjectHeader` | `FormControl` row | 197.10px | 197.10px | nothing visible moves |

Witnesses swept clean as well: Reports list, entity Overview, Create drawer
("Confidence level" 427px), filter popover ("Operator" 77.15px), Settings >
Organisations, and the five profile Selects (850px each) — light and dark.

### What is fixed

The two `WidgetCreationParameters` sites, using the
`<FormControl fullWidth style={{ flex: 1 }}>` wrapper their own sibling fields
two lines below already use. Both now measure 912px and align with those
siblings; their labels move from beside the field to above it, which is what
those siblings already do. Validated by Sandy.

### What is deliberately not "restored"

`FeedCreation`'s Multi-match Select. Before the bump its wrapper drove the
sibling "Column name" TextField to **0px** — the field was not narrow, it was
gone. Putting the old width back would delete it again. Same shape at
`SecretFieldControl`, where two fields stopped wrapping onto separate lines.
Those are the repair, not a regression.

### Method

Post-bump, forcing `width:100%` on a wrapper reproduces the pre-bump geometry
exactly. Verified against the genuine pre-bump build: wrapper 291.73, trigger
197.10, x 258.53, label 86.63 — matching the simulated numbers to the second
decimal. That is what let the sweep run on one server instead of alternating two
builds.

### Not covered

`StixCoreObjectsSuggestions`' entity Select (MUI `ListItem`, a flex row). No
container in the available dataset generates suggestions, so the dialog never
opens and the site could not be measured. Its trigger carries no `w-full`, a
shape that left the field width untouched in all five measured instances — but
that is an inference, not a measurement, and it is recorded as one in
`fds-migration/IMPLEMENTATION-LOG.md` rather than acted on.

## Gates

`fds-conformity`, `mui-regression` (42 symbols watched, 0 held),
`select-conversion` and `accessible-names` all green; `eslint` and `tsc` clean on
the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
