### PR TITLE
fix(fds): convert the associated-file field to the design system (#17664)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.9.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.9.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=b6eb035e98f9bc29e7288c0fbc1c2653e4f38630",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -40,7 +40,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.9.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=2e384c892e9e872ecf2de92f41f6b19a8e18a363",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/private/components/common/files/CustomFileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/CustomFileUploader.tsx
@@ -1,14 +1,9 @@
-import React, { FormEvent, FunctionComponent, useEffect, useState } from 'react';
-import Box from '@mui/material/Box';
-import Button from '@common/button/Button';
-import { Theme } from '@mui/material/styles/createTheme';
-import makeStyles from '@mui/styles/makeStyles';
-import classNames from 'classnames';
-import InputLabel from '@mui/material/InputLabel';
+import React, { FunctionComponent, useState } from 'react';
+import { FileSelect } from '@filigran/design-system';
+import type { FileRejection } from '@filigran/design-system';
 import { FieldProps } from 'formik';
-import VisuallyHiddenInput from '../VisuallyHiddenInput';
 import { useFormatter } from '../../../../components/i18n';
-import { splitAndTrim, truncate } from '../../../../utils/String';
+import { truncate } from '../../../../utils/String';
 
 interface CustomFileUploadProps extends Partial<FieldProps<File | null | undefined>> {
   setFieldValue: (
@@ -30,41 +25,6 @@ interface CustomFileUploadProps extends Partial<FieldProps<File | null | undefin
   onChange?: (key: string, value: File | undefined) => void;
 }
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  box: {
-    width: '100%',
-    marginTop: '0.2rem',
-    paddingBottom: '0.35rem',
-    borderBottom: `0.1rem solid ${theme.palette.grey['400']}`,
-    cursor: 'default',
-    '&:hover': {
-      borderBottom: '0.1rem solid white',
-    },
-    '&:active': {
-      borderBottom: `0.1rem solid ${theme.palette.primary.main}`,
-    },
-  },
-  boxError: {
-    borderBottom: `0.1rem solid ${theme.palette.error.main}`,
-  },
-  button: {
-    lineHeight: '0.65rem',
-  },
-  div: {
-    marginTop: 20,
-    width: '100%',
-  },
-  error: {
-    color: theme.palette.error.main,
-  },
-  span: {
-    marginLeft: 5,
-    verticalAlign: 'bottom',
-  },
-}));
-
 const CustomFileUploader: FunctionComponent<CustomFileUploadProps> = ({
   setFieldValue,
   isEmbeddedInExternalReferenceCreation,
@@ -80,108 +40,54 @@ const CustomFileUploader: FunctionComponent<CustomFileUploadProps> = ({
   onChange,
 }) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
-  const [fileNameForDisplay, setFileNameForDisplay] = useState('');
-  const [errorText, setErrorText] = useState('');
+  // Rendered without a Formik <Field> at 21 of the 44 call sites, so there is no
+  // form-side value to read back — track the selection locally in that case.
+  const [internalValue, setInternalValue] = useState<File | null>(null);
 
-  useEffect(() => {
-    if (field) {
-      const fileName = field.value?.name ?? '';
-      if (fileName !== fileNameForDisplay) {
-        setFileNameForDisplay(fileName);
-      }
+  const selectedFile = field ? (field.value ?? null) : internalValue;
+
+  const commitValue = async (file: File | null) => {
+    if (!field) {
+      setInternalValue(file);
     }
-  }, [field, fileNameForDisplay, setFileNameForDisplay]);
+    await setFieldValue('file', file ?? undefined);
+    onChange?.('file', file ?? undefined);
 
-  useEffect(() => {
-    if (formikErrors?.file) {
-      setErrorText(formikErrors?.file);
-    } else {
-      setErrorText('');
-    }
-  }, [formikErrors]);
-
-  const internalOnChange = async (event: FormEvent) => {
-    const inputElement = event.target as HTMLInputElement;
-    const eventTargetValue = inputElement.value as string;
-    const file = inputElement.files?.[0];
-    const fileSize = file?.size || 0;
-
-    const newFileName = eventTargetValue.substring(
-      eventTargetValue.lastIndexOf('\\') + 1,
-    );
-    setFileNameForDisplay(truncate(newFileName, 60));
-    setErrorText('');
-
-    // check the file type; user might still provide something bypassing 'accept'
-    // this will work only if accept is using MIME types only
-    const acceptedList = splitAndTrim(acceptMimeTypes);
-    if (
-      acceptedList.length > 0
-      && !!file?.type
-      && !acceptedList.includes(file?.type)
-    ) {
-      setErrorText(`${t_i18n('This file is not in the specified format')} : ${acceptMimeTypes}`);
-      return;
-    }
-
-    // check the size limit if any set; if file is too big it is not set as value
-    if (fileSize > 0 && sizeLimit > 0 && fileSize > sizeLimit) {
-      setErrorText(t_i18n('This file is too large'));
-      return;
-    }
-
-    await setFieldValue('file', inputElement.files?.[0]);
-    onChange?.('file', inputElement.files?.[0]);
-
-    if (isEmbeddedInExternalReferenceCreation) {
+    if (file && isEmbeddedInExternalReferenceCreation) {
       const externalIdValue = (
-        document.getElementById('external_id') as HTMLInputElement
-      ).value;
+        document.getElementById('external_id') as HTMLInputElement | null
+      )?.value;
       if (!externalIdValue) {
-        await setFieldValue('external_id', truncate(newFileName, 60));
+        await setFieldValue('external_id', truncate(file.name, 60));
       }
     }
   };
 
-  const noFileLabel = noFileSelectedLabel ?? t_i18n('No file selected.');
+  // Translates the library's own in-field rejection message. Local state cannot
+  // hold it: Formik hands back a new `formikErrors` identity on every render, so
+  // any effect syncing it would clear the rejection before it is read.
+  const rejectionMessage = (rejections: FileRejection[]) => (
+    rejections[0].reason === 'accept'
+      ? `${t_i18n('This file is not in the specified format')} : ${acceptMimeTypes}`
+      : t_i18n('This file is too large')
+  );
 
   return (
-    <div className={classes.div} style={noMargin ? { margin: 0 } : {}}>
-      <InputLabel shrink={true} variant="outlined" className={classNames({ [classes.error]: !!errorText })}>
-        {label ? t_i18n(label) : t_i18n('Associated file')} {required && '*'}
-      </InputLabel>
-      <Box
-        className={classNames({
-          [classes.box]: true,
-          [classes.boxError]: !!errorText,
-        })}
-      >
-        <Button
-          size="small"
-          component="label"
-          onChange={internalOnChange}
-          className={classes.button}
-          disabled={disabled}
-        >
-          {t_i18n('Select your file')}
-          <VisuallyHiddenInput type="file" accept={acceptMimeTypes} />
-        </Button>
-        <span
-          title={fileNameForDisplay || noFileLabel}
-          className={classNames({
-            [classes.span]: true,
-            [classes.error]: !!errorText,
-          })}
-        >
-          {fileNameForDisplay || noFileLabel}
-        </span>
-      </Box>
-      {!!errorText && (
-        <div>
-          <span className={classes.error}>{t_i18n(errorText)}</span>
-        </div>
-      )}
+    <div style={{ width: '100%', marginTop: noMargin ? 0 : 20 }}>
+      <FileSelect
+        label={label ? t_i18n(label) : t_i18n('Associated file')}
+        required={required}
+        value={selectedFile}
+        onValueChange={(value) => commitValue((value as File | null) ?? null)}
+        rejectionMessage={rejectionMessage}
+        triggerLabel={t_i18n('Select your file')}
+        placeholder={noFileSelectedLabel ?? t_i18n('No file selected.')}
+        accept={acceptMimeTypes}
+        maxSize={sizeLimit > 0 ? sizeLimit : undefined}
+        error={formikErrors?.file ? t_i18n(formikErrors.file) : undefined}
+        disabled={disabled}
+        clearLabel={t_i18n('Remove file')}
+      />
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormFieldRenderer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormFieldRenderer.tsx
@@ -414,6 +414,8 @@ const FormFieldRenderer: FunctionComponent<FormFieldRendererProps> = ({
         );
 
       case 'files': {
+        // Stays MUI: this value is a base64 payload ({ name, data, mime_type, size }), not a File,
+        // so FileSelect cannot represent it — convert once the library accepts a stored-file value.
         // multiple defaults to false (single file mode)
         // Set multiple=true explicitly to allow multiple files
         const allowMultipleFiles = field.multiple === true;

--- a/opencti-platform/opencti-front/src/private/components/nav/NavBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/NavBar.tsx
@@ -87,16 +87,15 @@ export const NavBarView: React.FC<NavBarViewProps> = ({
     navStyle['--color-filigran-brand-primary-transparency-55'] = `color-mix(in srgb, ${accentColor} 55%, transparent)`;
   }
 
-  // FDS-WORKAROUND #2: submenu icons composed product-side — remove when a slotted child keeps icon handling — see fds-migration/LIBRARY-FEEDBACK.md #2
   const renderSubItem = (sub: NavSubItem) => (
-    <NavbarSubmenuItem key={sub.link} asChild>
-      <Link
-        to={sub.link}
-        aria-current={isRouteSelected(pathname, sub.link, sub.exact) ? 'page' : undefined}
-      >
-        {submenuShowIcons && sub.icon}
-        <span>{sub.label}</span>
-      </Link>
+    <NavbarSubmenuItem
+      key={sub.link}
+      to={sub.link}
+      linkComponent={Link}
+      icon={sub.icon}
+      aria-current={isRouteSelected(pathname, sub.link, sub.exact) ? 'page' : undefined}
+    >
+      {sub.label}
     </NavbarSubmenuItem>
   );
 

--- a/opencti-platform/opencti-front/tests_e2e/model/field/FileField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/FileField.pageModel.ts
@@ -10,7 +10,12 @@ export default class FileFieldPageModel {
     readonly rootLocator?: Locator,
   ) {
     this.inputLocator = (rootLocator ?? page).getByText(label);
-    this.parentLocator = this.inputLocator.locator('..');
+    // Nearest ancestor that actually holds the file input, rather than a fixed
+    // number of '..' hops: the FDS field puts the label in its own row, so the
+    // input sits one level higher than it did under MUI.
+    this.parentLocator = this.inputLocator.locator(
+      'xpath=ancestor::*[.//input[@type="file"]][1]',
+    );
   }
 
   async uploadContentFile(filePath: string) {

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -958,9 +958,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=2e384c892e9e872ecf2de92f41f6b19a8e18a363":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=2e384c892e9e872ecf2de92f41f6b19a8e18a363"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -981,7 +981,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/a59731969675477e66ac9f765016d1c90b68031243e0074d984776416fe740ab41c78caeb694d57f1d22e84656a1151bc8fb73d11cd47c05e7cd3d7f5b2492da
+  checksum: 10c0/97e11e03ba3af58e43792919837e22943ada3fdcd913fc72339c0689656d16c9e7a8c930c39b09daa6ccd722c2980331fcfc5638ce77b96a592e37604124329c
   languageName: node
   linkType: hard
 
@@ -12189,7 +12189,7 @@ __metadata:
     "@faker-js/faker": "npm:10.6.0"
     "@filigran/chatbot": "npm:3.9.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=2e384c892e9e872ecf2de92f41f6b19a8e18a363"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -958,9 +958,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=b6eb035e98f9bc29e7288c0fbc1c2653e4f38630":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=b6eb035e98f9bc29e7288c0fbc1c2653e4f38630"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -981,7 +981,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/77820c0723879f46c3b3ad3b2922416b42e210a67d9e2d95da94c9f64c5daae03902ca89e2cc4e8c5b99792d1e147c279f42ae689a558b475a19743bb961ff6b
+  checksum: 10c0/1d176fdedb9ccb2dda116a5d371e0e90b1ea1279e5a588b38ef909ffb9a65125ce693a2759ed6f0dbe9eb587c43b2cbe491692f1773d5481eea000bcdffe4c4b
   languageName: node
   linkType: hard
 
@@ -12189,7 +12189,7 @@ __metadata:
     "@faker-js/faker": "npm:10.6.0"
     "@filigran/chatbot": "npm:3.9.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=b6eb035e98f9bc29e7288c0fbc1c2653e4f38630"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -958,9 +958,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445":
   version: 1.0.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.20"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -981,7 +981,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/97e11e03ba3af58e43792919837e22943ada3fdcd913fc72339c0689656d16c9e7a8c930c39b09daa6ccd722c2980331fcfc5638ce77b96a592e37604124329c
+  checksum: 10c0/77820c0723879f46c3b3ad3b2922416b42e210a67d9e2d95da94c9f64c5daae03902ca89e2cc4e8c5b99792d1e147c279f42ae689a558b475a19743bb961ff6b
   languageName: node
   linkType: hard
 
@@ -12189,7 +12189,7 @@ __metadata:
     "@faker-js/faker": "npm:10.6.0"
     "@filigran/chatbot": "npm:3.9.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=3a544728f122d333ff1d88a9c0ddc6401946bc31"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=8b99c79dfcf245f28624b8b1adc1061f60c62445"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
Converts OpenCTI's file-select family to the library `FileSelect`, bumps the design-system pin four times, and finishes the navbar link wiring. One PR, as asked.

## 1. Pin — `2e384c89 → b6eb035e`, four bumps

The four library commits this diff actually pulls in:

| | |
|---|---|
| #209 | tabs: `panels="external"` — opt-in, **not passed here**, inert (`panels=` appears nowhere in this repo) |
| #210 | navbar-submenu-item: `linkComponent` on child rows |
| #211 | file-select: draw the in-field trigger as a primary Button |
| #212 | navbar-submenu: keep a focus-opened collapsed flyout from dismissing itself |

`#205` (textarea `resize`), `#206`/`#207` (navbar-submenu + product-switcher `linkComponent`) and `#208` (file-select trigger beside the selection) are **already in the base pin** `2e384c89` — they are in `b6eb035e`'s history but are not part of this diff.

Each bump was bounded by diffing the two installed `dist/` before measuring anything: **no runtime symbol was added or removed** across the four. Only additive props (`panels`) and two new type exports (`TabsPanels`, `TabsProps`); `index.css` byte-identical on three of the four bumps. #211 is a pure repaint, proven to have landed by comparing the built FileSelect chunk itself (`priority: "secondary"` → `"primary"` in both CJS and ESM output).

## 2. Navbar wiring — the bumps alone left it dormant

`linkComponent={Link}` now goes to `NavbarSubmenu` (collapsed parent rows), `ProductSwitcher` (logo) and `NavbarSubmenuItem` (child rows). **FDS-WORKAROUND #2 is removed** — child rows no longer re-implement the row body behind `asChild`, so the library owns the icon and label again. `aria-current` still rides through: it is not destructured by the component, so it stays in the props spread onto the row element.

The local `submenuShowIcons &&` guard could be dropped because the library ANDs each row's `showIcon` with the ambient `Navbar`'s `submenuShowIcons`, which `NavBar.tsx` already passes from `me.submenu_show_icons`.

**What this change is and is not.** It is a change of *ownership of the row body*, not a routing fix: the old `asChild` + `<Link>` form and the new `to`/`linkComponent` form both end at the same react-router `Link` rendering a real `<a href>`. Routing and modifier-click behaviour are mechanically identical before and after — which is why the two tests written for it were deleted rather than kept: both passed against the unfixed code too. The existing coverage in `NavBar.test.tsx` is shape-invariant for the same reason and keeps passing — it asserts the child row is a real link with the right `href`, and that the icon follows the user preference.

Workarounds #1, #6, #7, #10, #11 stay: separate surfaces this release does not touch.

## 3. FileSelect — one component, 44 sites, zero call-site churn

`CustomFileUploader` composes `FileSelect` instead of MUI `InputLabel` + `Button` + `makeStyles`, staying the thin Formik-binding wrapper the FileSelect RFC prescribes (RULE-11). All **44 sites** convert without touching one: 21 direct JSX, 23 Formik `<Field component={…}>` (all 23 bound to `name="file"`, which is the name the wrapper commits to). The prop API is preserved exactly.

`FormFieldRenderer` (dynamic-form `files`) **stays MUI** with the reason in code: its value is a base64 payload (`{name, data, mime_type, size}`) from `FileReader.readAsDataURL`, not a `File`, so `FileSelect`'s `File | File[] | null` cannot represent it.

**One deliberate behaviour change.** The old accept check ran only when the browser reported a MIME type, so a file with an empty `type` bypassed it and was accepted. The library enforces `accept` for every pick, so such a file is now rejected. This affects the 5 of 44 sites that pass `acceptMimeTypes`, and only when a user defeats the native picker filter; it brings the field in line with what the prop already documented.

## 4. One e2e fix, and why it was needed

`FileFieldPageModel` did `getByText(label).locator('..')` then looked for the file input inside that single parent. Under MUI the label's parent wrapped the whole field; the FDS field puts the label in its own row, moving the input one level up — measured on the running build. It now resolves the nearest ancestor that actually holds the input, which works against both shapes, so the fields still on MUI keep working.

That was the cause of the e2e group0/group1 failures on the first push; both groups pass now.

## Trap worth knowing

Rejection messages route through the library's `rejectionMessage` hook, not local state: Formik hands back a **new `formikErrors` identity on every render**, so an effect syncing it clears the rejection before it is read and the library's English fallback leaks into a translated UI. Invisible to tsc, eslint and the build — all three were green while it was happening.

## What the gates do and do not cover here

Worth stating plainly, since four gates are green: none of them covers the FileSelect conversion. `migration-state.json` declares no FileSelect motif and does not list `CustomFileUploader.tsx`, so **FDS conformity** says nothing about it; **accessible-names** implements rules for `Select` and `Combobox` only; **select-conversion** is not a CI gate at all (pre-commit script only); **MUI regression** green confirms MUI left and did not return, which is orthogonal. The automated proof of this conversion is the **e2e** path — `FileFieldPageModel` drives the externalReference, report and incident-response forms in group0 and group1, both green.

Registering a FileSelect motif in `migration-state.json` is the follow-up so the next wave cannot regress it silently.

## Verified live

FileSelect: empty / selected / cleared on both binding paths (the Formik path's name round-trips through the injected `field.value`); `accept` rejection shows the app's own message with **no English leak**, does not commit the file, and a valid pick recovers and clears the error; filename renders as plain text with `truncate` and no native `title`; the trigger stays beside the selection instead of being replaced by it. Light **and** dark, across the three site shapes the 44 consumers take — direct JSX, direct JSX with `accept` + `sizeLimit`, and the Formik Field path (#42caff on #18191b dark, 9.32:1; #0015a8 on #f2f2f3 light, 11.22:1).

Navbar: submenu child rows are real anchors carrying `aria-current`; a plain click routes in-app with no document load (asserted with a marker that survives, not `defaultPrevented`); a modified click is **not** intercepted — `shouldProcessLinkClick` in the installed react-router requires `button === 0` and no modifier key, so the browser performs the real load that produces a new tab.

## Left out on purpose

Library #213 (tabs focus indicator + strip alignment) merged after this pin. It changes **default** Tabs rendering with no opt-in prop, on a strip its own description notes is shared by 41 screens, so it belongs to a wave with its own visual checkpoint rather than a fifth bump here.