### PR TITLE
test(e2e): drive shared platform state via API and assert mutations instead of sleeping (#18061)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/dashboard/dashboard.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dashboard/dashboard.spec.ts
@@ -139,7 +139,8 @@ test('Dashboard CRUD', { tag: ['@ce', '@group1'] }, async ({ page }) => {
   // -------------------------
 
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000); // After delete need to wait a bit
+  // Being back on the list proves the delete mutation completed (deletion redirects there)
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
   await leftBarPage.clickOnMenu('Dashboards', 'Custom dashboards');
   await expect(dashboardPage.getPageTitle()).toBeVisible();
   await expect(dashboardPage.getItemFromList(duplicateDashboardName)).toBeHidden();
@@ -169,7 +170,8 @@ test('Dashboard CRUD', { tag: ['@ce', '@group1'] }, async ({ page }) => {
   await expect(dashboardDetailsPage.getDashboardDetailsPage()).toBeVisible();
   await expect(dashboardDetailsPage.getTitle(updateDashboardName)).toBeVisible();
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000);// After delete need to wait a bit
+  // Being back on the list proves the delete mutation completed (deletion redirects there)
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
 
   // Import dashboard with exhaustive list of widgets
   await leftBarPage.clickOnMenu('Dashboards', 'Custom dashboards');
@@ -206,7 +208,8 @@ test('Dashboard CRUD', { tag: ['@ce', '@group1'] }, async ({ page }) => {
 
   // Delete imported dashboard
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000); // After delete need to wait a bit
+  // Being back on the list proves the delete mutation completed (deletion redirects there)
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
   // ---------
   // endregion
 
@@ -224,7 +227,8 @@ test('Dashboard CRUD', { tag: ['@ce', '@group1'] }, async ({ page }) => {
   await widgetsPage.getActionsWidgetsPopover().click();
   await widgetsPage.getActionButton('Delete').click();
   await widgetsPage.getConfirmButton().click();
-  await page.waitForTimeout(1000);// After delete need to wait a bit
+  // The widget disappearing proves the delete mutation completed
+  await expect(widgetsPage.getItemFromWidgetList(malwareName)).toBeHidden();
 
   await widgetsPage.createTimelineOfMalwaresWidget();
   await widgetsPage.getItemFromWidgetTimeline(malwareName).click();
@@ -301,5 +305,8 @@ test('Dashboard CRUD', { tag: ['@ce', '@group1'] }, async ({ page }) => {
   await leftBarPage.clickOnMenu('Dashboards', 'Custom dashboards');
   await dashboardPage.getItemFromList(updateDashboardName).click();
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000);// After delete need to wait a bit
+  // Wait for the redirect to the list before ending the test: closing the page
+  // right after the click could abort the in-flight delete mutation
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
+  await expect(dashboardPage.getItemFromList(updateDashboardName)).toBeHidden();
 });

--- a/opencti-platform/opencti-front/tests_e2e/dashboard/dashboardRestriction.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dashboard/dashboardRestriction.spec.ts
@@ -111,7 +111,8 @@ test('Dashboard restriction access', { tag: ['@ce', '@group1'] }, async ({ page 
   await expect(dashboardPage.getItemFromList(`${dashboardName} - copy`)).toBeVisible();
   await dashboardPage.getItemFromList(`${dashboardName} - copy`).click();
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000);// After delete need to wait a bit
+  // Being back on the list proves the delete mutation completed (deletion redirects there)
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
 
   // Try to export
   await dashboardPage.getItemFromList(dashboardName).click();
@@ -151,7 +152,8 @@ test('Dashboard restriction access', { tag: ['@ce', '@group1'] }, async ({ page 
   await accessRestriction.save();
   await goToDashboardAsJeanMichel(dashboardName);
   await dashboardDetailsPage.delete();
-  await page.waitForTimeout(1000);// After delete need to wait a bit
+  // Being back on the list proves the delete mutation completed (deletion redirects there)
+  await expect(dashboardPage.getPageTitle()).toBeVisible();
   await expect(dashboardPage.getItemFromList(dashboardName)).toBeHidden();
 
   // ---------

--- a/opencti-platform/opencti-front/tests_e2e/dataForTesting/entitySetting.data.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dataForTesting/entitySetting.data.ts
@@ -1,0 +1,42 @@
+import { APIRequestContext } from '@playwright/test';
+import { graphqlQuery } from './query-utils';
+
+const entitySettingByTypeQuery = (targetType: string) => `
+  query {
+    entitySettingByType(targetType: "${targetType}") {
+      id
+    }
+  }
+`;
+
+const patchEntitySettingMutation = (id: string, key: string, value: string) => `
+  mutation {
+    entitySettingsFieldPatch(ids: ["${id}"], input: [{ key: "${key}", value: "${value}" }]) {
+      id
+    }
+  }
+`;
+
+/**
+ * Set an explicit value on an entity setting (idempotent, unlike clicking
+ * a UI toggle which inverts the current state).
+ */
+export const patchEntitySetting = async (
+  request: APIRequestContext,
+  targetType: string,
+  key: string,
+  value: string | boolean,
+) => {
+  const settingResponse = await graphqlQuery(request, entitySettingByTypeQuery(targetType));
+  const settingData = await settingResponse.json();
+  const settingId = settingData.data?.entitySettingByType?.id;
+  if (!settingId) {
+    throw new Error(`Cannot find entity setting for type ${targetType}: ${JSON.stringify(settingData.errors ?? settingData)}`);
+  }
+  const patchResponse = await graphqlQuery(request, patchEntitySettingMutation(settingId, key, String(value)));
+  const patchData = await patchResponse.json();
+  if (patchData.errors || !patchData.data?.entitySettingsFieldPatch) {
+    throw new Error(`Cannot patch entity setting ${key} for type ${targetType}: ${JSON.stringify(patchData.errors ?? patchData)}`);
+  }
+  return patchData;
+};

--- a/opencti-platform/opencti-front/tests_e2e/dataForTesting/retentionRule.data.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dataForTesting/retentionRule.data.ts
@@ -1,0 +1,39 @@
+import { APIRequestContext } from '@playwright/test';
+import { graphqlQuery } from './query-utils';
+
+const retentionRulesQuery = (search: string) => `
+  query {
+    retentionRules(search: "${search}") {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+const deleteRetentionRuleMutation = (id: string) => `
+  mutation {
+    retentionRuleEdit(id: "${id}") {
+      delete
+    }
+  }
+`;
+
+/**
+ * Delete every retention rule whose name starts with the given prefix.
+ * Used as a guaranteed test cleanup: an active leaked retention rule
+ * applies platform-wide and would be picked up by the retention manager.
+ */
+export const deleteRetentionRulesByName = async (request: APIRequestContext, namePrefix: string) => {
+  const response = await graphqlQuery(request, retentionRulesQuery(namePrefix));
+  const data = await response.json();
+  const rules = (data.data?.retentionRules?.edges ?? [])
+    .map((e: { node: { id: string; name: string } }) => e.node)
+    .filter((node: { id: string; name: string }) => node.name.startsWith(namePrefix));
+  for (const rule of rules) {
+    await graphqlQuery(request, deleteRetentionRuleMutation(rule.id));
+  }
+};

--- a/opencti-platform/opencti-front/tests_e2e/dataForTesting/settings.data.ts
+++ b/opencti-platform/opencti-front/tests_e2e/dataForTesting/settings.data.ts
@@ -1,0 +1,77 @@
+import { APIRequestContext } from '@playwright/test';
+import { graphqlQuery } from './query-utils';
+
+const settingsQuery = () => `
+  query {
+    settings {
+      id
+      platform_theme {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const getSettings = async (request: APIRequestContext) => {
+  const response = await graphqlQuery(request, settingsQuery());
+  const data = await response.json();
+  const settings = data.data?.settings;
+  if (!settings?.id) {
+    throw new Error(`Cannot fetch platform settings: ${JSON.stringify(data.errors ?? data)}`);
+  }
+  return settings;
+};
+
+const patchSettingsMutation = (id: string, key: string, value: string) => `
+  mutation {
+    settingsEdit(id: "${id}") {
+      fieldPatch(input: [{ key: "${key}", value: "${value}" }]) {
+        id
+      }
+    }
+  }
+`;
+
+/**
+ * Set an explicit value on the platform settings (idempotent, unlike UI
+ * interactions which depend on the current state).
+ */
+export const patchSettings = async (
+  request: APIRequestContext,
+  settingsId: string,
+  key: string,
+  value: string,
+) => {
+  const response = await graphqlQuery(request, patchSettingsMutation(settingsId, key, value));
+  const data = await response.json();
+  if (data.errors || !data.data?.settingsEdit?.fieldPatch) {
+    throw new Error(`Cannot patch settings ${key}: ${JSON.stringify(data.errors ?? data)}`);
+  }
+  return data;
+};
+
+const themesQuery = (search: string) => `
+  query {
+    themes(search: "${search}") {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const getThemeIdByName = async (request: APIRequestContext, name: string) => {
+  const response = await graphqlQuery(request, themesQuery(name));
+  const data = await response.json();
+  const edges = data.data?.themes?.edges ?? [];
+  const theme = edges.map((e: { node: { id: string; name: string } }) => e.node)
+    .find((node: { id: string; name: string }) => node.name === name);
+  if (!theme) {
+    throw new Error(`Cannot find theme named ${name}: ${JSON.stringify(data.errors ?? data)}`);
+  }
+  return theme.id;
+};

--- a/opencti-platform/opencti-front/tests_e2e/enableReferences/addReportObservable.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/enableReferences/addReportObservable.spec.ts
@@ -15,9 +15,8 @@ import GroupFormPage from '../model/form/groupForm.pageModel';
 import UsersSettingsPage from '../model/usersSettings.pageModel';
 import UserPage from '../model/user.pageModel';
 import UserFormPage from '../model/form/userForm.pageModel';
-import LeftBarPage from '../model/menu/leftBar.pageModel';
 import LoginFormPageModel from '../model/form/loginForm.pageModel';
-import SearchPageModel from '../model/search.pageModel';
+import { patchEntitySetting } from '../dataForTesting/entitySetting.data';
 
 const noBypassUserAuthFile = 'tests_e2e/.setup/.auth/no-bypass-ref-user.json';
 const nowTime = `${new Date().getTime()}`;
@@ -107,17 +106,18 @@ test.describe('Authenticate no bypass user', { tag: ['@ce'] }, () => {
   });
 });
 
-test('Add and remove observable from Observables tab of a Report as Admin user', { tag: ['@ce'] }, async ({ page }) => {
+test('Add and remove observable from Observables tab of a Report as Admin user', { tag: ['@ce'] }, async ({ page, request }) => {
   const reportPage = new ReportPage(page);
   const reportDetailsPage = new ReportDetailsPage(page);
   const reportForm = new ReportFormPage(page);
   const containerObservablesPage = new ContainerObservablesPage(page);
   const containerAddObservablesPage = new ContainerAddObservablesPage(page);
-  const leftBarPage = new LeftBarPage(page);
+
+  // Make sure references are not enforced on reports, in case a previous run leaked the setting
+  await patchEntitySetting(request, 'Report', 'enforce_reference', false);
 
   // Create a report and check that adding an observable is possible
   await page.goto('/dashboard/analyses/reports');
-  await leftBarPage.open();
 
   const reportName = `Test add observable e2e ${nowTime}`;
 
@@ -135,44 +135,43 @@ test('Add and remove observable from Observables tab of a Report as Admin user',
   await containerAddObservablesPage.getCloseObservablesListButton().click();
   await expect(containerObservablesPage.getObservableInContainer('IPv4 address 8.8.8.8')).toBeVisible();
 
-  // Enable report references and check that removing observable is still possible as admin user
-  await leftBarPage.clickOnMenu('Settings', 'Customization');
-  const search = new SearchPageModel(page);
-  await search.addSearch('report');
-  await page.getByRole('link', { name: 'Report' }).click();
-  await page.locator('span').filter({ hasText: 'Enforce references' }).click();
+  try {
+    // Enable report references and check that removing observable is still possible as admin user
+    await patchEntitySetting(request, 'Report', 'enforce_reference', true);
+    // Entity settings are fetched on full page load only, so reload instead of navigating from the menu
+    await page.goto('/dashboard/analyses/reports');
 
-  await leftBarPage.clickOnMenu('Analyses', 'Reports');
-  await reportPage.getItemFromList(reportName).click();
-  await reportDetailsPage.tabs.goToObservablesTab();
-  await expect(containerObservablesPage.getPage()).toBeVisible();
-  await containerObservablesPage.getAddObservableListButton().click();
-  await expect(containerAddObservablesPage.getObservable('IPv4 address 8.8.8.8')).toBeVisible();
-  await containerAddObservablesPage.getObservable('IPv4 address 8.8.8.8').click();
-  await containerAddObservablesPage.getCloseObservablesListButton().click();
-  await expect(containerObservablesPage.getObservableInContainer('IPv4 address 8.8.8.8')).toBeHidden();
-
-  // Clean up report "enable references" configuration
-  await leftBarPage.clickOnMenu('Settings', 'Customization');
-  await page.getByRole('link', { name: 'Report' }).click();
-  await page.locator('span').filter({ hasText: 'Enforce references' }).click();
+    await reportPage.getItemFromList(reportName).click();
+    await reportDetailsPage.tabs.goToObservablesTab();
+    await expect(containerObservablesPage.getPage()).toBeVisible();
+    await containerObservablesPage.getAddObservableListButton().click();
+    await expect(containerAddObservablesPage.getObservable('IPv4 address 8.8.8.8')).toBeVisible();
+    await containerAddObservablesPage.getObservable('IPv4 address 8.8.8.8').click();
+    await containerAddObservablesPage.getCloseObservablesListButton().click();
+    await expect(containerObservablesPage.getObservableInContainer('IPv4 address 8.8.8.8')).toBeHidden();
+  } finally {
+    // Clean up report "enforce references" configuration through the API: an awaited call
+    // cannot be aborted by the page closing at the end of the test, unlike a UI click
+    await patchEntitySetting(request, 'Report', 'enforce_reference', false);
+  }
 });
 
 test.describe('Add and remove observable from Observables tab of a Report as noBypass user', { tag: ['@ce'] }, () => {
   test.use({ storageState: noBypassUserAuthFile });
-  test('Run test as noBypass user', async ({ page }) => {
+  test('Run test as noBypass user', async ({ page, request }) => {
     const reportPage = new ReportPage(page);
     const reportDetailsPage = new ReportDetailsPage(page);
     const reportForm = new ReportFormPage(page);
     const containerObservablesPage = new ContainerObservablesPage(page);
     const containerAddObservablesPage = new ContainerAddObservablesPage(page);
     const commitMessagePage = new CommitMessagePage(page);
-    const leftBarPage = new LeftBarPage(page);
+
+    // Make sure references are not enforced on reports, in case a previous run leaked the setting
+    await patchEntitySetting(request, 'Report', 'enforce_reference', false);
 
     // Create a report and check that adding an observable is possible
     const reportName = `Test add observable e2e 2 ${nowTime}`;
     await reportPage.goto();
-    await page.getByTestId('ChevronRightIcon').click();
     await reportPage.openNewReportForm();
     await reportForm.nameField.fill(reportName);
     await reportPage.getCreateReportButton().click();
@@ -187,32 +186,30 @@ test.describe('Add and remove observable from Observables tab of a Report as noB
     await containerAddObservablesPage.getCloseObservablesListButton().click();
     await expect(containerObservablesPage.getObservableInContainer('IPv4 address 9.9.9.9')).toBeVisible();
 
-    // Enable report references and check that removing observable asks for an external reference
-    await leftBarPage.clickOnMenu('Settings', 'Customization');
-    const search = new SearchPageModel(page);
-    await search.addSearch('report');
-    await page.getByRole('link', { name: 'Report' }).click();
-    await page.locator('span').filter({ hasText: 'Enforce references' }).click();
+    try {
+      // Enable report references and check that removing observable asks for an external reference
+      await patchEntitySetting(request, 'Report', 'enforce_reference', true);
+      // Entity settings are fetched on full page load only, so reload instead of navigating from the menu
+      await reportPage.goto();
 
-    await leftBarPage.clickOnMenu('Analyses', 'Reports');
-    await reportPage.getItemFromList(reportName).click();
-    await reportDetailsPage.tabs.goToObservablesTab();
-    await expect(containerObservablesPage.getPage()).toBeVisible();
-    await containerObservablesPage.getAddObservableListButton().click();
-    await expect(containerAddObservablesPage.getObservable('IPv4 address 9.9.9.9')).toBeVisible();
-    await containerAddObservablesPage.getObservable('IPv4 address 9.9.9.9').click();
-    await expect(commitMessagePage.getPage()).toBeVisible();
-    await commitMessagePage.getAddNewReferenceButton().click();
-    await commitMessagePage.fillNewReferenceSourceNameInput('SourceTest');
-    await commitMessagePage.fillNewReferenceExternalIDInput('SourceTest');
-    await commitMessagePage.getNewReferenceCreateButton().click();
-    await commitMessagePage.getValidateButton().click();
-    await containerAddObservablesPage.getCloseObservablesListButton().click();
-    await expect(containerObservablesPage.getObservableInContainer('IPv4 address 9.9.9.9')).toBeHidden();
-
-    // Clean up report "enable references" configuration
-    await leftBarPage.clickOnMenu('Settings', 'Customization');
-    await page.getByRole('link', { name: 'Report' }).click();
-    await page.locator('span').filter({ hasText: 'Enforce references' }).click();
+      await reportPage.getItemFromList(reportName).click();
+      await reportDetailsPage.tabs.goToObservablesTab();
+      await expect(containerObservablesPage.getPage()).toBeVisible();
+      await containerObservablesPage.getAddObservableListButton().click();
+      await expect(containerAddObservablesPage.getObservable('IPv4 address 9.9.9.9')).toBeVisible();
+      await containerAddObservablesPage.getObservable('IPv4 address 9.9.9.9').click();
+      await expect(commitMessagePage.getPage()).toBeVisible();
+      await commitMessagePage.getAddNewReferenceButton().click();
+      await commitMessagePage.fillNewReferenceSourceNameInput('SourceTest');
+      await commitMessagePage.fillNewReferenceExternalIDInput('SourceTest');
+      await commitMessagePage.getNewReferenceCreateButton().click();
+      await commitMessagePage.getValidateButton().click();
+      await containerAddObservablesPage.getCloseObservablesListButton().click();
+      await expect(containerObservablesPage.getObservableInContainer('IPv4 address 9.9.9.9')).toBeHidden();
+    } finally {
+      // Clean up report "enforce references" configuration through the API: an awaited call
+      // cannot be aborted by the page closing at the end of the test, unlike a UI click
+      await patchEntitySetting(request, 'Report', 'enforce_reference', false);
+    }
   });
 });

--- a/opencti-platform/opencti-front/tests_e2e/settings/entitySettings.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/entitySettings.spec.ts
@@ -2,8 +2,12 @@ import LeftBarPage from '../model/menu/leftBar.pageModel';
 import ReportPage from '../model/report.pageModel';
 import { expect, test } from '../fixtures/baseFixtures';
 import SearchPageModel from '../model/search.pageModel';
+import { patchEntitySetting } from '../dataForTesting/entitySetting.data';
 
-test('Testing content customization for Report', { tag: ['@ce'] }, async ({ page }) => {
+test('Testing content customization for Report', { tag: ['@ce'] }, async ({ page, request }) => {
+  // Make sure no attribute customization is set on reports, in case a previous run leaked it
+  await patchEntitySetting(request, 'Report', 'attributes_configuration', '[]');
+
   await page.goto('/');
   const leftBarPage = new LeftBarPage(page);
   const reportPage = new ReportPage(page);
@@ -17,31 +21,30 @@ test('Testing content customization for Report', { tag: ['@ce'] }, async ({ page
   await expect(page.getByText(/^Content from customization$/)).toBeHidden();
   await reportPage.closeNewreport();
 
-  // Opening customization in settings
-  await leftBarPage.clickOnMenu('Settings', 'Customization');
+  try {
+    // Opening customization in settings
+    await leftBarPage.clickOnMenu('Settings', 'Customization');
 
-  // Don't know why but report is the first item we can't click on directly
-  await search.addSearch('report');
+    // Don't know why but report is the first item we can't click on directly
+    await search.addSearch('report');
 
-  // Opening Report configuration
-  await page.getByRole('link', { name: 'Report' }).click();
-  await page.getByRole('tab', { name: 'Attributes' }).click();
-  await page.getByRole('button', { name: 'Content' }).click();
-  // Update the default value for content
-  await page.getByLabel('Editing area: main').fill('Content from customization');
-  await page.getByRole('button', { name: 'Update' }).click();
+    // Opening Report configuration
+    await page.getByRole('link', { name: 'Report' }).click();
+    await page.getByRole('tab', { name: 'Attributes' }).click();
+    await page.getByRole('button', { name: 'Content' }).click();
+    // Update the default value for content
+    await page.getByLabel('Editing area: main').fill('Content from customization');
+    await page.getByRole('button', { name: 'Update' }).click();
 
-  // Go back to the Report page
-  await leftBarPage.clickOnMenu('Analyses', 'Reports');
-  await reportPage.openNewReportForm();
-  await expect(page.getByText(/^Content from customization$/)).toBeVisible();
-  await reportPage.closeNewreport();
-
-  // Revert changes
-  await leftBarPage.clickOnMenu('Settings', 'Customization');
-  await page.getByRole('link', { name: 'Report' }).click();
-  await page.getByRole('tab', { name: 'Attributes' }).click();
-  await page.getByRole('button', { name: 'Content' }).click();
-  await page.getByLabel('Editing area: main').fill('');
-  await page.getByRole('button', { name: 'Update' }).click();
+    // Go back to the Report page
+    await leftBarPage.clickOnMenu('Analyses', 'Reports');
+    await reportPage.openNewReportForm();
+    await expect(page.getByText(/^Content from customization$/)).toBeVisible();
+    await reportPage.closeNewreport();
+  } finally {
+    // Revert the customization through the API: an awaited call cannot be aborted by the
+    // page closing at the end of the test, unlike a UI click, and it also runs when an
+    // assertion failed mid-test
+    await patchEntitySetting(request, 'Report', 'attributes_configuration', '[]');
+  }
 });

--- a/opencti-platform/opencti-front/tests_e2e/settings/retention.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/retention.spec.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { expect, test } from '../fixtures/baseFixtures';
 import RetentionPage from '../model/retention.pageModel';
+import { deleteRetentionRulesByName } from '../dataForTesting/retentionRule.data';
 
 /**
  * Content of the test
@@ -13,105 +14,111 @@ import RetentionPage from '../model/retention.pageModel';
  * 5. Deactivate then reactivate the policy via the popover menu.
  * 6. Delete the policy via the popover menu and confirm deletion.
  */
-test('Retention policy CRUD', { tag: ['@ce'] }, async ({ page }) => {
+test('Retention policy CRUD', { tag: ['@ce'] }, async ({ page, request }) => {
   const retentionPage = new RetentionPage(page);
   const retentionName = `Test Retention - ${uuid()}`;
 
-  // ─── Navigate ────────────────────────────────────────────────────────────────
-  await retentionPage.goto();
-  await expect(retentionPage.getPage()).toBeVisible();
+  try {
+    // ─── Navigate ────────────────────────────────────────────────────────────────
+    await retentionPage.goto();
+    await expect(retentionPage.getPage()).toBeVisible();
 
-  // ─── Open creation form ───────────────────────────────────────────────────────
-  await retentionPage.getCreateButton().click();
-  await expect(page.getByText('Create a retention policy')).toBeVisible();
+    // ─── Open creation form ───────────────────────────────────────────────────────
+    await retentionPage.getCreateButton().click();
+    await expect(page.getByText('Create a retention policy')).toBeVisible();
 
-  // ─── Verify form validation ───────────────────────────────────────────────────
-  // The Create button should be disabled before Verify is called
-  await expect(retentionPage.getCreateFormButton()).toBeDisabled();
+    // ─── Verify form validation ───────────────────────────────────────────────────
+    // The Create button should be disabled before Verify is called
+    await expect(retentionPage.getCreateFormButton()).toBeDisabled();
 
-  // Fill in the name field
-  await page.getByRole('textbox', { name: 'Name' }).fill(retentionName);
+    // Fill in the name field
+    await page.getByRole('textbox', { name: 'Name' }).fill(retentionName);
 
-  // Fill max_retention
-  await page.getByRole('textbox', { name: 'Maximum retention' }).fill('90');
+    // Fill max_retention
+    await page.getByRole('textbox', { name: 'Maximum retention' }).fill('90');
 
-  // ─── Click Verify (required to enable the Create button) ─────────────────────
-  await retentionPage.getVerifyButton().click();
+    // ─── Click Verify (required to enable the Create button) ─────────────────────
+    await retentionPage.getVerifyButton().click();
 
-  // Wait for the Create button to become enabled after Verify completes
-  await expect(retentionPage.getCreateFormButton()).toBeEnabled({ timeout: 15000 });
+    // Wait for the Create button to become enabled after Verify completes
+    await expect(retentionPage.getCreateFormButton()).toBeEnabled({ timeout: 15000 });
 
-  // ─── Create the retention policy ─────────────────────────────────────────────
-  await retentionPage.getCreateFormButton().click();
+    // ─── Create the retention policy ─────────────────────────────────────────────
+    await retentionPage.getCreateFormButton().click();
 
-  // ─── Verify the rule appears in the list ────────────────────────────────────
-  const retentionItem = retentionPage.getItemFromList(retentionName);
-  await expect(retentionItem).toBeVisible();
+    // ─── Verify the rule appears in the list ────────────────────────────────────
+    const retentionItem = retentionPage.getItemFromList(retentionName);
+    await expect(retentionItem).toBeVisible();
 
-  // Verify it shows "Active" status
-  await expect(retentionItem.getByText('Active')).toBeVisible();
+    // Verify it shows "Active" status
+    await expect(retentionItem.getByText('Active')).toBeVisible();
 
-  // Verify the retention unit is visible (days by default)
-  await expect(retentionItem.getByText(/90 days/)).toBeVisible();
+    // Verify the retention unit is visible (days by default)
+    await expect(retentionItem.getByText(/90 days/)).toBeVisible();
 
-  // ─── Open popover and test Deactivate ────────────────────────────────────────
-  await retentionPage.getPopoverButton(retentionItem).click();
-  await expect(retentionPage.getDeactivateMenuItem()).toBeVisible();
-  await retentionPage.getDeactivateMenuItem().click();
+    // ─── Open popover and test Deactivate ────────────────────────────────────────
+    await retentionPage.getPopoverButton(retentionItem).click();
+    await expect(retentionPage.getDeactivateMenuItem()).toBeVisible();
+    await retentionPage.getDeactivateMenuItem().click();
 
-  // Verify the status changed to "Inactive"
-  await expect(retentionItem.getByText('Inactive')).toBeVisible();
+    // Verify the status changed to "Inactive"
+    await expect(retentionItem.getByText('Inactive')).toBeVisible();
 
-  // ─── Open popover and test Activate ──────────────────────────────────────────
-  await retentionPage.getPopoverButton(retentionItem).click();
-  await expect(retentionPage.getActivateMenuItem()).toBeVisible();
-  await retentionPage.getActivateMenuItem().click();
+    // ─── Open popover and test Activate ──────────────────────────────────────────
+    await retentionPage.getPopoverButton(retentionItem).click();
+    await expect(retentionPage.getActivateMenuItem()).toBeVisible();
+    await retentionPage.getActivateMenuItem().click();
 
-  // Verify the status is back to "Active"
-  await expect(retentionItem.getByText('Active')).toBeVisible();
+    // Verify the status is back to "Active"
+    await expect(retentionItem.getByText('Active')).toBeVisible();
 
-  // ─── Open popover and test Update ────────────────────────────────────────────
-  await retentionPage.getPopoverButton(retentionItem).click();
-  await retentionPage.getUpdateMenuItem().click();
+    // ─── Open popover and test Update ────────────────────────────────────────────
+    await retentionPage.getPopoverButton(retentionItem).click();
+    await retentionPage.getUpdateMenuItem().click();
 
-  // Verify the edition drawer opens
-  await expect(page.getByText('Update a retention policy')).toBeVisible();
+    // Verify the edition drawer opens
+    await expect(page.getByText('Update a retention policy')).toBeVisible();
 
-  // Update the name and max_retention
-  const updatedName = `${retentionName} Updated`;
-  const nameInput = page.getByRole('textbox', { name: 'Name' });
-  await nameInput.fill(updatedName);
-  await page.getByRole('textbox', { name: 'Maximum retention' }).fill('60');
+    // Update the name and max_retention
+    const updatedName = `${retentionName} Updated`;
+    const nameInput = page.getByRole('textbox', { name: 'Name' });
+    await nameInput.fill(updatedName);
+    await page.getByRole('textbox', { name: 'Maximum retention' }).fill('60');
 
-  // Verify is required before Update for all scopes
-  await retentionPage.getVerifyButton().click();
-  await expect(retentionPage.getDrawerUpdateButton()).toBeEnabled({ timeout: 15000 });
+    // Verify is required before Update for all scopes
+    await retentionPage.getVerifyButton().click();
+    await expect(retentionPage.getDrawerUpdateButton()).toBeEnabled({ timeout: 15000 });
 
-  // Submit the update
-  await retentionPage.getDrawerUpdateButton().click();
+    // Submit the update
+    await retentionPage.getDrawerUpdateButton().click();
 
-  // ─── Verify the updated rule is in the list ──────────────────────────────────
-  const updatedRetentionItem = retentionPage.getItemFromList(updatedName);
-  await expect(updatedRetentionItem).toBeVisible();
-  await expect(updatedRetentionItem.getByText(/60 days/)).toBeVisible();
+    // ─── Verify the updated rule is in the list ──────────────────────────────────
+    const updatedRetentionItem = retentionPage.getItemFromList(updatedName);
+    await expect(updatedRetentionItem).toBeVisible();
+    await expect(updatedRetentionItem.getByText(/60 days/)).toBeVisible();
 
-  // ─── Open popover and test Delete ────────────────────────────────────────────
-  await retentionPage.getPopoverButton(updatedRetentionItem).click();
-  await retentionPage.getDeleteMenuItem().click();
+    // ─── Open popover and test Delete ────────────────────────────────────────────
+    await retentionPage.getPopoverButton(updatedRetentionItem).click();
+    await retentionPage.getDeleteMenuItem().click();
 
-  // Verify the confirmation dialog appears
-  await expect(page.getByText('Do you want to delete this retention policy?')).toBeVisible();
+    // Verify the confirmation dialog appears
+    await expect(page.getByText('Do you want to delete this retention policy?')).toBeVisible();
 
-  // Cancel first to verify the rule is still there
-  await retentionPage.getCancelDialogButton().click();
-  await expect(updatedRetentionItem).toBeVisible();
+    // Cancel first to verify the rule is still there
+    await retentionPage.getCancelDialogButton().click();
+    await expect(updatedRetentionItem).toBeVisible();
 
-  // Delete for real
-  await retentionPage.getPopoverButton(updatedRetentionItem).click();
-  await retentionPage.getDeleteMenuItem().click();
-  await retentionPage.getConfirmButton().click();
+    // Delete for real
+    await retentionPage.getPopoverButton(updatedRetentionItem).click();
+    await retentionPage.getDeleteMenuItem().click();
+    await retentionPage.getConfirmButton().click();
 
-  // Verify the rule is gone from the list
-  await expect(retentionPage.getItemFromList(updatedName)).not.toBeVisible();
+    // Verify the rule is gone from the list
+    await expect(retentionPage.getItemFromList(updatedName)).not.toBeVisible();
+  } finally {
+    // Guaranteed cleanup: an active leaked retention rule applies platform-wide and would
+    // be picked up by the retention manager, so delete any rule left behind whatever
+    // happened above (the API call also cannot be aborted by the page closing)
+    await deleteRetentionRulesByName(request, retentionName);
+  }
 });
-

--- a/opencti-platform/opencti-front/tests_e2e/settings/themes.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/themes.spec.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test';
 import { expect, test } from '../fixtures/baseFixtures';
 import LeftBarPage from '../model/menu/leftBar.pageModel';
 import { awaitUntilCondition } from 'tests_e2e/utils';
+import { getSettings, getThemeIdByName, patchSettings } from '../dataForTesting/settings.data';
 
 const openThemeEditMenu = async (themeName: string, page: Page) => {
   await page
@@ -38,7 +39,7 @@ const editThemeLogo = async (themeName: string, page: Page, logoUrl: string) => 
  * MUST change custom theme logo.
  * MUST delete custom theme.
  */
-test('Custom theme creation, logo edition, and deletion', { tag: ['@ce'] }, async ({ page }) => {
+test('Custom theme creation, logo edition, and deletion', { tag: ['@ce'] }, async ({ page, request }) => {
   const THEME = {
     name: `${new Date().toISOString()} Test Theme`,
     theme_background: '#e72a2a',
@@ -50,6 +51,11 @@ test('Custom theme creation, logo edition, and deletion', { tag: ['@ce'] }, asyn
     theme_text_color: '#353131',
     theme_logo: 'https://www.google.com/images/branding/googlelogo/1x/googlelogo_light_color_272x92dp.png',
   };
+
+  // Capture the current default theme to restore it whatever happens to the test:
+  // the platform theme is a platform-wide state shared with every other test
+  const settings = await getSettings(request);
+  const initialThemeId = settings.platform_theme?.id ?? await getThemeIdByName(request, 'Filigran Dark');
 
   // Navigate to Settings
   const leftBarPage = new LeftBarPage(page);
@@ -69,69 +75,63 @@ test('Custom theme creation, logo edition, and deletion', { tag: ['@ce'] }, asyn
   await page.getByRole('button', { name: 'Create' }).click();
 
   // Assert exists on screen
-  expect(await page.getByText(THEME.name).count() > 0);
+  await expect(page.getByText(THEME.name).first()).toBeVisible();
 
-  // Select system default
-  await page.locator('#mui-component-select-platform_theme').click();
-  await page.getByTestId(`${THEME.name}-li`).click();
-  await page.waitForTimeout(1000);
-  let logoSrc = await page
-    .getByRole('link', { name: 'logo' })
-    .locator('img').getAttribute('src');
-  expect(logoSrc).toContain('googlelogo');
+  const logoImage = page.getByRole('link', { name: 'logo' }).locator('img');
 
-  // Edit theme
-  // edit the logo url by removing the url
-  await editThemeLogo(THEME.name, page, '');
-  await page.waitForTimeout(1000);
+  try {
+    // Select system default
+    await page.locator('#mui-component-select-platform_theme').click();
+    await page.getByTestId(`${THEME.name}-li`).click();
+    // The logo swap also proves the settings mutation completed
+    await expect(logoImage).toHaveAttribute('src', /googlelogo/);
 
-  // expect to have the default dark logo
-  logoSrc = await page
-    .getByRole('link', { name: 'logo' })
-    .locator('img').getAttribute('src');
-  expect(logoSrc).toContain('logo_text_dark');
+    // Edit theme
+    // edit the logo url by removing the url, expect to be back on the default dark logo
+    await editThemeLogo(THEME.name, page, '');
+    await expect(logoImage).toHaveAttribute('src', /logo_text_dark/);
 
-  // Set theme logo to the Google logo
-  await editThemeLogo(THEME.name, page, THEME.theme_logo);
-  const isLogoChanged = async () => {
-    await page.reload();
-    const logoSrcChangedToGoogle = await page.getByRole('link', { name: 'logo' }).locator('img').getAttribute('src');
-    if (logoSrcChangedToGoogle) {
-      return logoSrcChangedToGoogle.includes('googlelogo');
-    }
-    return false;
-  };
-  await awaitUntilCondition(isLogoChanged);
+    // Set theme logo to the Google logo
+    await editThemeLogo(THEME.name, page, THEME.theme_logo);
+    const isLogoChanged = async () => {
+      await page.reload();
+      const logoSrcChangedToGoogle = await logoImage.getAttribute('src');
+      if (logoSrcChangedToGoogle) {
+        return logoSrcChangedToGoogle.includes('googlelogo');
+      }
+      return false;
+    };
+    await awaitUntilCondition(isLogoChanged);
+    await expect(logoImage).toHaveAttribute('src', /googlelogo/);
 
-  logoSrc = await page.getByRole('link', { name: 'logo' }).locator('img').getAttribute('src');
-  expect(logoSrc).toContain('googlelogo');
+    // Reset logo
+    await editThemeLogo(THEME.name, page, '');
+    const isLogoBackToDefault = async () => {
+      await page.reload();
+      const logoSrcChangedToDefault = await logoImage.getAttribute('src');
+      if (logoSrcChangedToDefault) {
+        return logoSrcChangedToDefault.includes('logo_text_dark');
+      }
+      return false;
+    };
+    await awaitUntilCondition(isLogoBackToDefault);
+    await expect(logoImage).toHaveAttribute('src', /logo_text_dark/);
+  } finally {
+    // Restore the default theme through the API: an awaited call cannot be aborted by the
+    // page closing at the end of the test, and it also runs when an assertion failed
+    // mid-test, so the platform theme cannot leak to other tests
+    await patchSettings(request, settings.id, 'platform_theme', initialThemeId);
+  }
 
-  // Reset logo
-  await editThemeLogo(THEME.name, page, '');
-  await page.waitForTimeout(1000);
-
-  const isLogoBackToDefault = async () => {
-    await page.reload();
-    const logoSrcChangedToDefault = await page.getByRole('link', { name: 'logo' }).locator('img').getAttribute('src');
-    if (logoSrcChangedToDefault) {
-      return logoSrcChangedToDefault.includes('logo_text_dark');
-    }
-    return false;
-  };
-  await awaitUntilCondition(isLogoBackToDefault);
-  logoSrc = await page.getByRole('link', { name: 'logo' }).locator('img').getAttribute('src');
-  expect(logoSrc).toContain('logo_text_dark');
-
-  // Select Dark theme again to delete custom theme
-  await page.locator('#mui-component-select-platform_theme').click();
-  await page.getByTestId('Filigran Dark-li').click();
-  await page.waitForTimeout(1000);
+  // Reload so the UI is back on the restored theme before deleting the custom one
+  await page.reload();
 
   // Delete custom theme
   await page.getByTestId(`${THEME.name}-popover`).click();
   await page.getByLabel('Delete').click();
   await page.getByRole('button', { name: 'Confirm' }).click();
-  expect(await page.getByText('Theme successfully deleted').count() > 0);
+  // The snackbar also keeps the page open until the delete mutation completes
+  await expect(page.getByText('Theme successfully deleted')).toBeVisible();
 });
 
 /**
@@ -146,6 +146,8 @@ test('Cannot delete or update system theme', { tag: ['@ce'] }, async ({ page }) 
   await leftBarPage.clickOnMenu('Settings', 'Parameters');
 
   await page.getByTestId('Filigran Light-popover').click();
-  expect(await page.getByLabel('Delete').count() === 0);
-  expect(await page.getByLabel('Update').count() === 0);
+  // A built-in theme only offers View and Export in its popover
+  await expect(page.getByRole('menuitem', { name: 'View' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'Update' })).toHaveCount(0);
+  await expect(page.getByRole('menuitem', { name: 'Delete' })).toHaveCount(0);
 });


### PR DESCRIPTION
## Proposed changes

Fixes the flaky e2e failure and the sibling defects analyzed in #18061: shared platform state was mutated through the UI with fire-and-forget clicks (abortable when Playwright closes the page), cleanups were not guaranteed on mid-test failure, and several waits were fixed sleeps or no-op assertions.

### New `dataForTesting` helpers

- `entitySetting.data.ts` — `patchEntitySetting(request, targetType, key, value)`: resolves the entity setting via `entitySettingByType` and patches it with `entitySettingsFieldPatch`, setting an explicit value (idempotent, unlike a toggle click that inverts whatever state leaked in). Throws on GraphQL errors.
- `settings.data.ts` — `getSettings` (id + current `platform_theme`), `patchSettings` (settings `fieldPatch`), `getThemeIdByName`.
- `retentionRule.data.ts` — `deleteRetentionRulesByName`: finds rules by name prefix and deletes them.

All awaited API calls: they cannot be aborted by the page closing, and they throw on error instead of failing silently.

### Spec changes

- **`enableReferences/addReportObservable.spec.ts`** — both report tests now enable/disable `enforce_reference` through the API instead of navigating to Settings > Customization and clicking the toggle. Each test resets the setting to `false` before starting (a leak from a previous run self-heals), enables it mid-test then does a full page load (entity settings are fetched by `RootPrivateQuery` on load only, no live subscription), and disables it in a `finally` block. The now-unused Settings navigation, `SearchPageModel` and `LeftBarPage` usages are removed.
- **`settings/entitySettings.spec.ts`** — resets the Report `attributes_configuration` through the API before the test and in a `finally` block. The UI flow under test (set a default value, see it applied in the creation form) is unchanged; the unasserted UI revert at the end is replaced by the guaranteed API cleanup.
- **`settings/themes.spec.ts`** — captures the current default theme up front and restores it through the API in a `finally` block, then deletes the custom theme via the UI. The four `waitForTimeout(1000)` are replaced by auto-waiting assertions (logo swap proves the settings mutation completed; the delete snackbar keeps the page open until the delete mutation completes). The four no-matcher `expect(...)` (which asserted nothing) become real assertions — the `Cannot delete or update system theme` test now anchors on the built-in popover's `View` item before checking that `Update`/`Delete` are absent.
- **`settings/retention.spec.ts`** — the CRUD flow is wrapped in `try`/`finally` with an API cleanup deleting any leftover rule, since an active leaked rule applies platform-wide (retention manager ticks every 30s in the e2e stack).
- **`dashboard/dashboard.spec.ts`**, **`dashboard/dashboardRestriction.spec.ts`** — every `delete + waitForTimeout(1000)` is replaced by an assertion on the mutation's observable effect: dashboard deletion redirects to the list (`onCompleted` in `WorkspacePopover`), widget deletion removes the widget from the DOM. The last deletion of `dashboard.spec.ts` was the final test action and is now asserted too, so the page can no longer close on an in-flight mutation.

Net effect: 11 fixed 1-second sleeps removed, 8 previously silent failure modes (aborted mutations, no-op expects) now assert, and no e2e test leaves shared platform state behind on failure — except a hard test timeout inside an enabled-setting window, which the initial resets self-heal on retry.

## Related issues

- Closes #18061 (observed on #18057)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
