### PR TITLE
chore(frontend): make frontend port parametric (#18068)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ venv
 
 # Copilot
 thoughts/
+
+# Env local files
+.env.local
+.env.development.local

--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -9,6 +9,12 @@ const monacoEditorPlugin = (monacoEditorPluginImport as unknown as {default: typ
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '');
+  const configuredFrontEndPort = env.FRONT_END_PORT?.trim();
+  const frontEndPort = configuredFrontEndPort ? Number(configuredFrontEndPort) : 3000;
+
+  if (!Number.isInteger(frontEndPort) || frontEndPort < 1 || frontEndPort > 65535) {
+    throw new Error(`FRONT_END_PORT must be an integer between 1 and 65535, got "${env.FRONT_END_PORT}"`);
+  }
 
   // Support APP__BASE_PATH from .env* files (via loadEnv) or from process.env (e.g. set by test scripts).
   // Normalize: ensure leading slash, strip trailing slash.
@@ -66,7 +72,7 @@ export default defineConfig(({ mode, command }) => {
     ],
 
     server: {
-      port: 3000,
+      port: frontEndPort,
       proxy: {
         [`${basePath}/logout`]: backProxy(),
         [`${basePath}/stream`]: backProxy(),

--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -10,9 +10,9 @@ const monacoEditorPlugin = (monacoEditorPluginImport as unknown as {default: typ
 export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const configuredFrontEndPort = env.FRONT_END_PORT?.trim();
-  const frontEndPort = configuredFrontEndPort ? Number(configuredFrontEndPort) : 3000;
+  const frontEndPort = configuredFrontEndPort ? Number.parseInt(configuredFrontEndPort, 10) : 3000;
 
-  if (!Number.isInteger(frontEndPort) || frontEndPort < 1 || frontEndPort > 65535) {
+  if (configuredFrontEndPort && (!/^\d+$/.test(configuredFrontEndPort) || frontEndPort < 1 || frontEndPort > 65535)) {
     throw new Error(`FRONT_END_PORT must be an integer between 1 and 65535, got "${env.FRONT_END_PORT}"`);
   }
 


### PR DESCRIPTION
### Proposed changes

* Re-introduces use of `FRONT_END_PORT` env var to set the frontend port. This allows spawning multiple platforms (frontends included) without changing the code
* Used to be supported, see the `2 - Frontend on test backend.run.xml` file.

### Related issues

* closes #18068 

### How to test this PR

- Create a `.env.local` file with content at the root or in `opencti-front`:

```
FRONT_END_PORT=3080
```

- Launch `yarn dev` at the root

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
