### PR TITLE
test(e2e): stabilize custom view golden path test (flaky test) (#18081)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
@@ -60,8 +60,9 @@ test('Custom View CRUD - golden path', { tag: ['@ce', '@group1'] }, async ({ pag
   await customViewDetailsPage.widgets.openWidgetModal();
   await customViewDetailsPage.widgets.selectWidget('List');
   await customViewDetailsPage.widgets.selectPerspective('Entities');
-  await expect(page.getByText('In regards of')).toBeVisible();
-  await expect(page.getByText('CURRENT ENTITY', { exact: true })).toBeVisible();
+  // Assert the default filter chip through its button role: when the pointer hovers the chip,
+  // a tooltip duplicates the chip text and makes page-wide getByText locators ambiguous.
+  await expect(page.getByRole('button', { name: /In regards of.*CURRENT ENTITY/ })).toBeVisible();
   await customViewDetailsPage.widgets.fillLabel('Malwares');
   await customViewDetailsPage.widgets.validateFilters();
   await customViewDetailsPage.widgets.titleField.fill('Related malwares');
@@ -135,11 +136,16 @@ test('Custom View CRUD - golden path', { tag: ['@ce', '@group1'] }, async ({ pag
   // ─── Cleanup: delete all created views ───────────────────────────────────────
   await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
   for (const name of [viewName, duplicateName, viewName]) {
-    const item = customViewsSettingsPage.getItemFromList(name).nth(0);
+    const items = customViewsSettingsPage.getItemFromList(name);
+    const item = items.nth(0);
     await item.waitFor({ state: 'visible', timeout: 30000 });
+    const countBeforeDelete = await items.count();
     await customViewsSettingsPage.getQuickActionsButton(item).click();
     await customViewsSettingsPage.getDeleteQuickActionButton().click();
     await customViewsSettingsPage.getConfirmButton().click();
+    // Wait for the deletion to be reflected in the list before opening the next popover,
+    // otherwise the next delete menu item anchors to a moving row and is never stable to click.
+    await expect(items).toHaveCount(countBeforeDelete - 1);
   }
   await expect(customViewsSettingsPage.getItemFromList(viewName)).toBeHidden();
 });


### PR DESCRIPTION
## Proposed changes

- Fix the flaky e2e test `Custom View CRUD - golden path` (`tests_e2e/customView/customView.spec.ts`, group1) — see #18081 for the full analysis of the failed master run.
- The default filter chip is now asserted through its button role instead of two page-wide `getByText` locators: when the pointer happens to hover the chip, the MUI tooltip duplicates the chip text and made `getByText('CURRENT ENTITY')` resolve to 2 elements (strict mode violation).
- The cleanup loop now asserts after each confirmation that the list count actually decreased before opening the next popover. Previously the next `Delete` menu item could anchor to a row still moving during the list refetch, making Playwright loop on "element is not stable" until the 200s test timeout. This follows the same assert-the-mutation approach as #18061.

## Related issues

- Closes #18081

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the spec; e2e group1 validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
