### PR TITLE
fix(security-coverage): stop enrichment loop on connector (#14716)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -4052,7 +4052,7 @@ export const createEntity = async (
   user: AuthUser,
   input: Record<string, any>,
   type: string,
-  opts: { complete?: boolean } & CreateEntityRawOpts = {},
+  opts: { complete?: boolean; noEnrich?: boolean } & CreateEntityRawOpts = {},
 ) => {
   const isCompleteResult = opts.complete === true;
   // volumes of objects relationships must be controlled
@@ -4063,7 +4063,7 @@ export const createEntity = async (
     if (isFeatureEnabled('ENTITIES_WORKFLOW')) {
       await initializeEntityWorkflow(context, user, data.element as BasicStoreBase);
     }
-  } else if (data.event !== null) { // upsert
+  } else if (data.event !== null && !opts.noEnrich) { // upsert
     await triggerEntityUpdateAutoEnrichment(context, user, data.element);
   }
   return isCompleteResult ? data : data.element;

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -4052,7 +4052,7 @@ export const createEntity = async (
   user: AuthUser,
   input: Record<string, any>,
   type: string,
-  opts: { complete?: boolean; noEnrich?: boolean } & CreateEntityRawOpts = {},
+  opts: { complete?: boolean; noEnrichOnUpdate?: boolean } & CreateEntityRawOpts = {},
 ) => {
   const isCompleteResult = opts.complete === true;
   // volumes of objects relationships must be controlled
@@ -4063,7 +4063,7 @@ export const createEntity = async (
     if (isFeatureEnabled('ENTITIES_WORKFLOW')) {
       await initializeEntityWorkflow(context, user, data.element as BasicStoreBase);
     }
-  } else if (data.event !== null && !opts.noEnrich) { // upsert
+  } else if (data.event !== null && !opts.noEnrichOnUpdate) { // upsert
     await triggerEntityUpdateAutoEnrichment(context, user, data.element);
   }
   return isCompleteResult ? data : data.element;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -45,6 +45,7 @@ import { getAverageCoverageInformation, getMostRecentLastCoverageResult, interna
 import { splitSecurityCoverageInput } from './securityCoverage-utils';
 import { emptyPaginationResult } from '../../database/utils';
 import { createHasCoveredRelTask } from './securityCoverageResult/securityCoverageResult-domain';
+import { isFromConnectorWork } from '../../utils/connector-work';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -89,12 +90,15 @@ export const addSecurityCoverage = async (
     shouldCreateResult,
   } = splitSecurityCoverageInput(input);
 
+  const noEnrich = await isFromConnectorWork(context, user);
+
   // 1. Create the SecurityCoverage entity.
   const createdSecurityCoverage: BasicStoreEntitySecurityCoverage = await createEntity(
     context,
     user,
     securityCoverageInput,
     ENTITY_TYPE_SECURITY_COVERAGE,
+    { noEnrich },
   );
 
   // 2. Create an associated SecurityCoverageResult if we also
@@ -106,7 +110,7 @@ export const addSecurityCoverage = async (
       // Add extra attributes based on created SecurityCoverage
       [INPUT_RESULT_OF]: createdSecurityCoverage.id,
       name: `${securityCoverageResultInput.name ?? ''} Result of ${createdSecurityCoverage.name}`.trim(),
-    });
+    }, noEnrich);
     // Manually add the ref here to be able to resolve dynamic attributes in GraphQL response
     createdSecurityCoverage[RELATION_RESULT_OF] = [result.id];
   }

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -90,7 +90,7 @@ export const addSecurityCoverage = async (
     shouldCreateResult,
   } = splitSecurityCoverageInput(input);
 
-  const noEnrich = await isFromConnectorWork(context, user);
+  const noEnrichOnUpdate = await isFromConnectorWork(context, user);
 
   // 1. Create the SecurityCoverage entity.
   const createdSecurityCoverage: BasicStoreEntitySecurityCoverage = await createEntity(
@@ -98,7 +98,7 @@ export const addSecurityCoverage = async (
     user,
     securityCoverageInput,
     ENTITY_TYPE_SECURITY_COVERAGE,
-    { noEnrich },
+    { noEnrichOnUpdate },
   );
 
   // 2. Create an associated SecurityCoverageResult if we also
@@ -110,7 +110,7 @@ export const addSecurityCoverage = async (
       // Add extra attributes based on created SecurityCoverage
       [INPUT_RESULT_OF]: createdSecurityCoverage.id,
       name: `${securityCoverageResultInput.name ?? ''} Result of ${createdSecurityCoverage.name}`.trim(),
-    }, noEnrich);
+    }, noEnrichOnUpdate);
     // Manually add the ref here to be able to resolve dynamic attributes in GraphQL response
     createdSecurityCoverage[RELATION_RESULT_OF] = [result.id];
   }

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -13,6 +13,7 @@ import type { AuthContext, AuthUser } from '../../../types/user';
 import { ENTITY_TYPE_SECURITY_COVERAGE, type BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
 import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
 import { internalCreateSecurityCoverageResult } from './securityCoverageResult-utils';
+import { isFromConnectorWork } from '../../../utils/connector-work';
 
 /**
  * Find a security coverage results by its ID.
@@ -85,7 +86,8 @@ export const addSecurityCoverageResult = async (
   if (!securityCoverageResultInput.name) {
     input.name = `Result of ${securityCoverage.name}`;
   }
-  const result = await internalCreateSecurityCoverageResult(context, user, input);
+  const noEnrich = await isFromConnectorWork(context, user);
+  const result = await internalCreateSecurityCoverageResult(context, user, input, noEnrich);
   return notify(
     BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].ADDED_TOPIC,
     result,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -86,8 +86,8 @@ export const addSecurityCoverageResult = async (
   if (!securityCoverageResultInput.name) {
     input.name = `Result of ${securityCoverage.name}`;
   }
-  const noEnrich = await isFromConnectorWork(context, user);
-  const result = await internalCreateSecurityCoverageResult(context, user, input, noEnrich);
+  const noEnrichOnUpdate = await isFromConnectorWork(context, user);
+  const result = await internalCreateSecurityCoverageResult(context, user, input, noEnrichOnUpdate);
   return notify(
     BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].ADDED_TOPIC,
     result,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -59,17 +59,20 @@ export const getMostRecentLastCoverageResult = async (results: StoreEntitySecuri
  * @param context
  * @param user user making the request.
  * @param securityCoverageResultInput Input to create the security coverage result.
+ * @param noEnrich skips the auto enrichment trigger on upsert (connector write-back).
  */
 export const internalCreateSecurityCoverageResult = async (
   context: AuthContext,
   user: AuthUser,
   securityCoverageResultInput: SecurityCoverageResultAddInput,
+  noEnrich = false,
 ) => {
   const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
     context,
     user,
     securityCoverageResultInput,
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+    { noEnrich },
   );
   logApp.info(`[SECURITY-COVERAGE-RESULT][${securityCoverageResultInput.resultOf}] SCR created: ${result.standard_id}`);
   return result;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -59,20 +59,20 @@ export const getMostRecentLastCoverageResult = async (results: StoreEntitySecuri
  * @param context
  * @param user user making the request.
  * @param securityCoverageResultInput Input to create the security coverage result.
- * @param noEnrich skips the auto enrichment trigger on upsert (connector write-back).
+ * @param noEnrichOnUpdate skips the auto enrichment trigger on upsert (connector write-back).
  */
 export const internalCreateSecurityCoverageResult = async (
   context: AuthContext,
   user: AuthUser,
   securityCoverageResultInput: SecurityCoverageResultAddInput,
-  noEnrich = false,
+  noEnrichOnUpdate = false,
 ) => {
   const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
     context,
     user,
     securityCoverageResultInput,
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
-    { noEnrich },
+    { noEnrichOnUpdate },
   );
   logApp.info(`[SECURITY-COVERAGE-RESULT][${securityCoverageResultInput.resultOf}] SCR created: ${result.standard_id}`);
   return result;

--- a/opencti-platform/opencti-graphql/src/utils/connector-work.ts
+++ b/opencti-platform/opencti-graphql/src/utils/connector-work.ts
@@ -1,0 +1,18 @@
+import { getEntitiesListFromCache } from '../database/cache';
+import { ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
+import type { BasicStoreEntityConnector } from '../types/connector';
+import type { AuthContext, AuthUser } from '../types/user';
+import { SYSTEM_USER } from './access';
+
+/**
+ * @param context Context of the write, carrying the work id when it comes from a worker.
+ * @param user User performing the write.
+ * @returns True if the write comes from a worker running as a connector user.
+ */
+export const isFromConnectorWork = async (context: AuthContext, user: AuthUser) => {
+  if (!context.workId) {
+    return false;
+  }
+  const connectors = await getEntitiesListFromCache<BasicStoreEntityConnector>(context, SYSTEM_USER, ENTITY_TYPE_CONNECTOR);
+  return connectors.some((connector) => connector.connector_user_id === user.id);
+};

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-enrichment-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-enrichment-test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import * as rabbitmq from '../../../../src/database/rabbitmq';
+import { ADMIN_USER, getUserIdByEmail, testContext, USER_CONNECTOR } from '../../../utils/testQuery';
+import { addSecurityCoverage, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
+import { addIntrusionSet } from '../../../../src/domain/intrusionSet';
+import { connectorDelete, registerConnector } from '../../../../src/domain/connector';
+import { resetCacheForEntity } from '../../../../src/database/cache';
+import { deleteElementById } from '../../../../src/database/middleware';
+import { resolveUserByIdFromCache } from '../../../../src/domain/user';
+import { ENTITY_TYPE_INTRUSION_SET } from '../../../../src/schema/stixDomainObject';
+import { ENTITY_TYPE_CONNECTOR } from '../../../../src/schema/internalObject';
+import { ENTITY_TYPE_SECURITY_COVERAGE } from '../../../../src/modules/securityCoverage/securityCoverage-types';
+import { ConnectorType } from '../../../../src/generated/graphql';
+import type { AuthUser } from '../../../../src/types/user';
+
+const CONNECTOR_A = '11111111-1111-1111-1111-111111111111';
+const CONNECTOR_B = '22222222-2222-2222-2222-222222222222';
+
+describe('SecurityCoverage enrichment', () => {
+  let connectorUser: AuthUser;
+  let covered: { id: string; internal_id: string; standard_id: string };
+  let coverageId: string;
+  let pushToConnector: MockInstance;
+
+  const enrichmentsFor = (connectorId: string) => pushToConnector.mock.calls.filter((call) => call[0] === connectorId).length;
+
+  const securityCoverageAdd = async (user: AuthUser, input = {}, context = testContext) => addSecurityCoverage(context, user, {
+    name: 'coverage of the intrusion set',
+    objectCovered: covered.standard_id,
+    auto_enrichment_disable: false,
+    ...input,
+  });
+
+  const workerContext = { ...testContext, workId: 'work_openaev' };
+  const connectorResult = {
+    external_uri: 'http://openaev.local/tenant-a',
+    coverage_information: [{ coverage_name: 'detection', coverage_score: 50 }],
+  };
+
+  beforeAll(async () => {
+    connectorUser = await resolveUserByIdFromCache(testContext, await getUserIdByEmail(USER_CONNECTOR.email)) as AuthUser;
+    for (const [id, name] of [[CONNECTOR_A, 'OpenAEV coverage A'], [CONNECTOR_B, 'OpenAEV coverage B']]) {
+      await registerConnector(testContext, ADMIN_USER, {
+        id,
+        name,
+        type: ConnectorType.InternalEnrichment,
+        scope: [ENTITY_TYPE_SECURITY_COVERAGE],
+        auto: true,
+        auto_update: true,
+      }, { active: true, connector_user_id: connectorUser.id });
+    }
+    resetCacheForEntity(ENTITY_TYPE_CONNECTOR);
+  });
+
+  afterAll(async () => {
+    await connectorDelete(testContext, ADMIN_USER, CONNECTOR_A);
+    await connectorDelete(testContext, ADMIN_USER, CONNECTOR_B);
+    resetCacheForEntity(ENTITY_TYPE_CONNECTOR);
+  });
+
+  beforeEach(async () => {
+    covered = await addIntrusionSet(testContext, ADMIN_USER, { name: `Intrusion-Set ${Date.now()}` });
+    pushToConnector = vi.spyOn(rabbitmq, 'pushToConnector').mockResolvedValue(undefined as never);
+    return async () => {
+      vi.restoreAllMocks();
+      await securityCoverageDelete(testContext, ADMIN_USER, coverageId);
+      await deleteElementById(testContext, ADMIN_USER, covered.id, ENTITY_TYPE_INTRUSION_SET);
+    };
+  });
+
+  it('should enrich each connector once when a user creates a coverage', async () => {
+    ({ id: coverageId } = await securityCoverageAdd(ADMIN_USER));
+
+    expect(enrichmentsFor(CONNECTOR_A)).toEqual(1);
+    expect(enrichmentsFor(CONNECTOR_B)).toEqual(1);
+  });
+
+  it('should not enrich again when a connector writes its own result back', async () => {
+    ({ id: coverageId } = await securityCoverageAdd(ADMIN_USER));
+    pushToConnector.mockClear();
+
+    await securityCoverageAdd(connectorUser, connectorResult, workerContext);
+
+    expect(enrichmentsFor(CONNECTOR_A)).toEqual(0);
+    expect(enrichmentsFor(CONNECTOR_B)).toEqual(0);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
@@ -36,7 +36,7 @@ testCreatedCounter.imsi = 1;
 testCreatedCounter.incident = 3;
 testCreatedCounter.indicator = 56;
 testCreatedCounter.infrastructure = 1;
-testCreatedCounter['intrusion-set'] = 4;
+testCreatedCounter['intrusion-set'] = 6;
 testCreatedCounter['ipv4-addr'] = 1;
 testCreatedCounter['kill-chain-phase'] = 3;
 testCreatedCounter.label = 15;
@@ -63,8 +63,8 @@ testCreatedCounter.tool = 5;
 testCreatedCounter['tracking-number'] = 1;
 testCreatedCounter.vocabulary = VOCABULARY_NUMBERS;
 testCreatedCounter.vulnerability = 10;
-testCreatedCounter['security-coverage'] = 18;
-testCreatedCounter['security-coverage-result'] = 17;
+testCreatedCounter['security-coverage'] = 20;
+testCreatedCounter['security-coverage-result'] = 18;
 
 export const testUpdatedCounter: Record<string, number> = {};
 testUpdatedCounter['marking-definition'] = 2;
@@ -104,6 +104,7 @@ testUpdatedCounter.vulnerability = 3;
 testUpdatedCounter.iccid = 1;
 testUpdatedCounter.imei = 1;
 testUpdatedCounter.imsi = 1;
+testUpdatedCounter['security-coverage'] = 1;
 
 export const testMergedCounter: Record<string, number> = {};
 testMergedCounter['threat-actor'] = 1;
@@ -135,7 +136,7 @@ testDeletedCounter.incident = 2;
 testDeletedCounter.report = 37;
 testDeletedCounter.indicator = 28;
 testDeletedCounter.infrastructure = 1;
-testDeletedCounter['intrusion-set'] = 3;
+testDeletedCounter['intrusion-set'] = 5;
 testDeletedCounter['ipv4-addr'] = 1;
 testDeletedCounter.label = 2;
 testDeletedCounter.language = 1;
@@ -161,8 +162,8 @@ testDeletedCounter.software = 1;
 testDeletedCounter.iccid = 4;
 testDeletedCounter.imei = 3;
 testDeletedCounter.imsi = 1;
-testDeletedCounter['security-coverage'] = 16;
-testDeletedCounter['security-coverage-result'] = 15;
+testDeletedCounter['security-coverage'] = 18;
+testDeletedCounter['security-coverage-result'] = 16;
 
 export const doTotal = (eventCounter: Record<string, number>) => {
   const allRecordKeys = Object.keys(eventCounter);


### PR DESCRIPTION
### Proposed changes

When an OpenAEV enrichment connector writes back its result on a Security Coverage, the write is treated as a regular update and re-triggers enrichment on every connector. With one connector per OpenAEV tenant, each connector therefore runs N times (N = number of connectors).

  * Add `isFromConnectorWork` to detect writes authored by a connector technical user.
  * Add a `noEnrich` option on `createEntity` (already available on `updateAttribute`).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* #14716 

### How to test this PR
OpenAEV enrichment connectors registered (one per tenant), create a Security Coverage and check that only one work is created per connector

### Test counters changes

`tests/utils/syncCountHelper.ts`

| Counter | Before | After |
|---|---|---|
| created `intrusion-set` | 4 | 6 |
| created `security-coverage` | 18 | 20 |
| created `security-coverage-result` | 17 | 18 |
| updated `security-coverage` | — | 1 |
| deleted `intrusion-set` | 3 | 5 |
| deleted `security-coverage` | 16 | 18 |
| deleted `security-coverage-result` | 15 | 16 |

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality
