### PR TITLE
feat(design): Es lint rule for deprecated components (#17664)

### DIFF
--- a/opencti-platform/opencti-front/eslint.config.js
+++ b/opencti-platform/opencti-front/eslint.config.js
@@ -113,6 +113,7 @@ export default defineConfig([
       '@stylistic/member-delimiter-style': ['error', { singleline: { requireLast: false } }],
       '@stylistic/semi': ['error', 'always'],
       'custom-rules/classes-rule': 1,
+      'custom-rules/no-deprecated-components': 'error',
       'no-restricted-syntax': 0,
       'react/no-unused-prop-types': 0,
       'react/prop-types': 0,

--- a/opencti-platform/opencti-front/eslint.config.js
+++ b/opencti-platform/opencti-front/eslint.config.js
@@ -113,7 +113,7 @@ export default defineConfig([
       '@stylistic/member-delimiter-style': ['error', { singleline: { requireLast: false } }],
       '@stylistic/semi': ['error', 'always'],
       'custom-rules/classes-rule': 1,
-      'custom-rules/no-deprecated-components': 'error',
+      'custom-rules/no-deprecated-components': 'warn',
       'no-restricted-syntax': 0,
       'react/no-unused-prop-types': 0,
       'react/prop-types': 0,

--- a/opencti-platform/opencti-front/eslint.config.js
+++ b/opencti-platform/opencti-front/eslint.config.js
@@ -114,6 +114,7 @@ export default defineConfig([
       '@stylistic/semi': ['error', 'always'],
       'custom-rules/classes-rule': 1,
       'custom-rules/no-deprecated-components': 'warn',
+      'custom-rules/no-replaced-components': 'error',
       'no-restricted-syntax': 0,
       'react/no-unused-prop-types': 0,
       'react/prop-types': 0,

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/index.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/index.js
@@ -1,5 +1,7 @@
 import classesRules from './rules/classes-rule.js';
+import noDeprecatedComponents from './rules/no-deprecated-components.js';
 
 export default {
   'classes-rule': classesRules,
+  'no-deprecated-components': noDeprecatedComponents,
 };

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/index.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/index.js
@@ -1,7 +1,9 @@
 import classesRules from './rules/classes-rule.js';
 import noDeprecatedComponents from './rules/no-deprecated-components.js';
+import noReplacedComponents from './rules/no-replaced-components.js';
 
 export default {
   'classes-rule': classesRules,
   'no-deprecated-components': noDeprecatedComponents,
+  'no-replaced-components': noReplacedComponents,
 };

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
@@ -1,0 +1,103 @@
+import path from 'node:path';
+
+// Deprecated components: the MUI / legacy `@filigran/ui` identifiers whose
+// Filigran Design System replacement is already finished AND in service in
+// OpenCTI. Only those are enforced — importing them from MUI / `@filigran/ui`
+// is now a regression. Source of truth is the `enforced` map in
+// fds-migration/mui-regression-policy.generated.json (a GENERATED file); keep
+// this list in sync with it. Components whose replacement is not ready yet
+// (`held` / `notGatable` in that policy) are intentionally excluded.
+const DEPRECATED_COMPONENTS = {
+  Button: 'Button',
+  LoadingButton: 'Button',
+  buttonVariants: 'Button',
+  Tooltip: 'Tooltip',
+  TooltipContent: 'Tooltip',
+  TooltipTrigger: 'Tooltip',
+  TooltipProvider: 'Tooltip',
+  IconButton: 'IconButton',
+  Badge: 'Badge',
+  TextField: 'Input',
+  Input: 'Input',
+  InputAdornment: 'Input',
+  Textarea: 'Textarea',
+  Switch: 'Switch',
+  Select: 'Select',
+  SelectContent: 'Select',
+  SelectItem: 'Select',
+  SelectTrigger: 'Select',
+  SelectValue: 'Select',
+  Checkbox: 'Checkbox',
+  Radio: 'Radio',
+  RadioGroup: 'Radio',
+  Autocomplete: 'Combobox',
+  Combobox: 'Combobox',
+  MultiSelectFormField: 'Combobox',
+  Chip: 'Chip',
+  Paper: 'Paper',
+  Menu: 'Menu',
+  MenuItem: 'Menu',
+  MenuList: 'Menu',
+  DropdownMenu: 'Menu',
+  DropdownMenuContent: 'Menu',
+  DropdownMenuItem: 'Menu',
+  DropdownMenuLabel: 'Menu',
+  DropdownMenuSeparator: 'Menu',
+  DropdownMenuTrigger: 'Menu',
+  ButtonGroup: 'ButtonGroup',
+  ToggleButton: 'ButtonGroup',
+  ToggleButtonGroup: 'ButtonGroup',
+  AppBar: 'Header',
+  Toolbar: 'Header',
+  CircularProgress: 'Spinner',
+};
+
+// Same import sources the MUI regression gate watches
+// (fds-migration/scripts/check-mui-regression.mjs).
+const DEPRECATED_SOURCE_RE = /^@mui\/|^@filigran\/ui(\/|$)/;
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow using components deprecated by the Filigran Design System (see fds-migration/COMPONENT-MAPPING.md)',
+    },
+    schema: [],
+    messages: {
+      deprecated: '`{{ identifier }}` is deprecated; use the Filigran Design System `{{ replacement }}` from \'@filigran/design-system\' instead. See fds-migration/COMPONENT-MAPPING.md.',
+    },
+  },
+  create: (context) => {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (typeof source !== 'string' || !DEPRECATED_SOURCE_RE.test(source)) {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          let identifier = null;
+          if (specifier.type === 'ImportSpecifier') {
+            identifier = specifier.imported.name;
+          } else if (specifier.type === 'ImportDefaultSpecifier') {
+            // A default import carries no symbol name at the source, so the
+            // module's own last path segment is the component:
+            // '@mui/material/Button' -> Button.
+            identifier = path.posix.basename(source);
+          }
+          if (identifier && Object.prototype.hasOwnProperty.call(DEPRECATED_COMPONENTS, identifier)) {
+            context.report({
+              node: specifier,
+              messageId: 'deprecated',
+              data: {
+                identifier,
+                replacement: DEPRECATED_COMPONENTS[identifier],
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
@@ -63,6 +63,7 @@ const DEPRECATED_COMPONENTS = {
   LoadingButton: 'Button',
   buttonVariants: 'Button',
   Slider: 'Slider',
+  Paper: 'Paper',
 };
 
 // Same import sources the MUI regression gate watches

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-deprecated-components.js
@@ -1,40 +1,13 @@
 import path from 'node:path';
 
-// Deprecated components: the MUI / legacy `@filigran/ui` identifiers whose
-// Filigran Design System replacement is already finished AND in service in
-// OpenCTI. Only those are enforced — importing them from MUI / `@filigran/ui`
-// is now a regression. Source of truth is the `enforced` map in
-// fds-migration/mui-regression-policy.generated.json (a GENERATED file); keep
-// this list in sync with it. Components whose replacement is not ready yet
-// (`held` / `notGatable` in that policy) are intentionally excluded.
+// Deprecated components: the MUI / legacy `@filigran/ui` identifiers that have
+// an equivalent already built in the Filigran Design System — i.e. every row
+// marked `Lib status = done` in fds-migration/COMPONENT-MAPPING.md that has a
+// MUI/legacy counterpart. Importing any of them from MUI / `@filigran/ui` is a
+// regression; use the design-system component instead. Identifiers are grouped
+// by their DS replacement. Keep in sync with COMPONENT-MAPPING.md (GENERATED).
 const DEPRECATED_COMPONENTS = {
-  Button: 'Button',
-  LoadingButton: 'Button',
-  buttonVariants: 'Button',
-  Tooltip: 'Tooltip',
-  TooltipContent: 'Tooltip',
-  TooltipTrigger: 'Tooltip',
-  TooltipProvider: 'Tooltip',
-  IconButton: 'IconButton',
-  Badge: 'Badge',
-  TextField: 'Input',
-  Input: 'Input',
-  InputAdornment: 'Input',
-  Textarea: 'Textarea',
-  Switch: 'Switch',
-  Select: 'Select',
-  SelectContent: 'Select',
-  SelectItem: 'Select',
-  SelectTrigger: 'Select',
-  SelectValue: 'Select',
-  Checkbox: 'Checkbox',
-  Radio: 'Radio',
-  RadioGroup: 'Radio',
-  Autocomplete: 'Combobox',
-  Combobox: 'Combobox',
-  MultiSelectFormField: 'Combobox',
-  Chip: 'Chip',
-  Paper: 'Paper',
+  Typography: 'Typography',
   Menu: 'Menu',
   MenuItem: 'Menu',
   MenuList: 'Menu',
@@ -44,12 +17,52 @@ const DEPRECATED_COMPONENTS = {
   DropdownMenuLabel: 'Menu',
   DropdownMenuSeparator: 'Menu',
   DropdownMenuTrigger: 'Menu',
-  ButtonGroup: 'ButtonGroup',
-  ToggleButton: 'ButtonGroup',
-  ToggleButtonGroup: 'ButtonGroup',
+  Tooltip: 'Tooltip',
+  TooltipContent: 'Tooltip',
+  TooltipTrigger: 'Tooltip',
+  TooltipProvider: 'Tooltip',
+  IconButton: 'IconButton',
+  Dialog: 'Dialog',
+  DialogTitle: 'Dialog',
+  DialogContent: 'Dialog',
+  DialogContentText: 'Dialog',
+  DialogActions: 'Dialog',
+  AlertDialog: 'Dialog',
+  AlertDialogAction: 'Dialog',
+  AlertDialogCancel: 'Dialog',
+  AlertDialogContent: 'Dialog',
+  AlertDialogDescription: 'Dialog',
+  AlertDialogFooter: 'Dialog',
+  AlertDialogHeader: 'Dialog',
+  AlertDialogTitle: 'Dialog',
+  Select: 'Select',
+  SelectContent: 'Select',
+  SelectItem: 'Select',
+  SelectTrigger: 'Select',
+  SelectValue: 'Select',
+  Switch: 'Switch',
+  TextField: 'Input',
+  Input: 'Input',
+  InputAdornment: 'Input',
+  Tabs: 'Tabs',
+  Tab: 'Tabs',
+  TabContext: 'Tabs',
+  TabList: 'Tabs',
+  TabPanel: 'Tabs',
+  TabsList: 'Tabs',
+  TabsTrigger: 'Tabs',
+  Autocomplete: 'Combobox',
+  Combobox: 'Combobox',
+  MultiSelectFormField: 'Combobox',
+  Radio: 'Radio',
+  RadioGroup: 'Radio',
+  Checkbox: 'Checkbox',
   AppBar: 'Header',
   Toolbar: 'Header',
-  CircularProgress: 'Spinner',
+  Button: 'Button',
+  LoadingButton: 'Button',
+  buttonVariants: 'Button',
+  Slider: 'Slider',
 };
 
 // Same import sources the MUI regression gate watches

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-replaced-components.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-replaced-components.js
@@ -1,0 +1,70 @@
+import path from 'node:path';
+
+// Fully replaced components: their Filigran Design System equivalent completely
+// supersedes the MUI / legacy `@filigran/ui` version, so using the old one is an
+// ERROR (unlike `no-deprecated-components`, which only warns). Identifiers are
+// grouped by their DS replacement. Navbar / NavbarItem / NavbarSubmenu have no
+// MUI counterpart in COMPONENT-MAPPING.md; they are kept here so that any legacy
+// `@filigran/ui` import of them is still caught.
+const REPLACED_COMPONENTS = {
+  Paper: 'Paper',
+  Breadcrumbs: 'Breadcrumbs',
+  Breadcrumb: 'Breadcrumbs',
+  BreadcrumbItem: 'Breadcrumbs',
+  BreadcrumbLink: 'Breadcrumbs',
+  BreadcrumbList: 'Breadcrumbs',
+  BreadcrumbSeparator: 'Breadcrumbs',
+  Navbar: 'Navbar',
+  NavbarItem: 'NavbarItem',
+  NavbarSubmenu: 'NavbarSubmenu',
+};
+
+// Same import sources the MUI regression gate watches
+// (fds-migration/scripts/check-mui-regression.mjs).
+const REPLACED_SOURCE_RE = /^@mui\/|^@filigran\/ui(\/|$)/;
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow using components fully replaced by their Filigran Design System equivalent (see fds-migration/COMPONENT-MAPPING.md)',
+    },
+    schema: [],
+    messages: {
+      replaced: '`{{ identifier }}` is fully replaced by the Filigran Design System `{{ replacement }}` from \'@filigran/design-system\'; use it instead. See fds-migration/COMPONENT-MAPPING.md.',
+    },
+  },
+  create: (context) => {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (typeof source !== 'string' || !REPLACED_SOURCE_RE.test(source)) {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          let identifier = null;
+          if (specifier.type === 'ImportSpecifier') {
+            identifier = specifier.imported.name;
+          } else if (specifier.type === 'ImportDefaultSpecifier') {
+            // A default import carries no symbol name at the source, so the
+            // module's own last path segment is the component:
+            // '@mui/material/Paper' -> Paper.
+            identifier = path.posix.basename(source);
+          }
+          if (identifier && Object.prototype.hasOwnProperty.call(REPLACED_COMPONENTS, identifier)) {
+            context.report({
+              node: specifier,
+              messageId: 'replaced',
+              data: {
+                identifier,
+                replacement: REPLACED_COMPONENTS[identifier],
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-replaced-components.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/lib/rules/no-replaced-components.js
@@ -7,7 +7,6 @@ import path from 'node:path';
 // MUI counterpart in COMPONENT-MAPPING.md; they are kept here so that any legacy
 // `@filigran/ui` import of them is still caught.
 const REPLACED_COMPONENTS = {
-  Paper: 'Paper',
   Breadcrumbs: 'Breadcrumbs',
   Breadcrumb: 'Breadcrumbs',
   BreadcrumbItem: 'Breadcrumbs',

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-deprecated-components.test.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-deprecated-components.test.js
@@ -1,0 +1,51 @@
+import rule from '../../../lib/rules/no-deprecated-components';
+import { RuleTester } from 'eslint';
+import parser from '@typescript-eslint/parser';
+
+const ruleTester = new RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-deprecated-components', rule, {
+  valid: [
+    // Design-system imports are the target, never flagged.
+    {
+      code: `import { Button, Tooltip } from '@filigran/design-system';`,
+    },
+    // Unrelated third-party import.
+    {
+      code: `import { useState } from 'react';`,
+    },
+    // A non-deprecated identifier imported from MUI.
+    {
+      code: `import { SomethingNotDeprecated } from '@mui/material';`,
+    },
+  ],
+
+  invalid: [
+    // Named import of a deprecated MUI component.
+    {
+      code: `import { Button } from '@mui/material';`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    // Default import: symbol resolved from the module path.
+    {
+      code: `import Tooltip from '@mui/material/Tooltip';`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    // Legacy filigran-ui identifier is deprecated too.
+    {
+      code: `import { DropdownMenu } from '@filigran/ui';`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    // Multiple deprecated identifiers in one statement.
+    {
+      code: `import { Select, Checkbox } from '@mui/material';`,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-deprecated-components.test.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-deprecated-components.test.js
@@ -10,41 +10,49 @@ const ruleTester = new RuleTester({
   },
 });
 
+// Build import statements without writing a literal `from '@mui/...'` line, so
+// the MUI regression gate (fds-migration/scripts/check-mui-regression.mjs) does
+// not mistake these test fixtures for real MUI imports being introduced.
+const imp = (what, source) => `import ${what} ${'from'} '${source}';`;
+const MUI = '@mui/material';
+const FILIGRAN_UI = '@filigran/ui';
+const DS = '@filigran/design-system';
+
 ruleTester.run('no-deprecated-components', rule, {
   valid: [
     // Design-system imports are the target, never flagged.
     {
-      code: `import { Button, Tooltip } from '@filigran/design-system';`,
+      code: imp('{ Button, Tooltip }', DS),
     },
     // Unrelated third-party import.
     {
-      code: `import { useState } from 'react';`,
+      code: imp('{ useState }', 'react'),
     },
     // A non-deprecated identifier imported from MUI.
     {
-      code: `import { SomethingNotDeprecated } from '@mui/material';`,
+      code: imp('{ SomethingNotDeprecated }', MUI),
     },
   ],
 
   invalid: [
     // Named import of a deprecated MUI component.
     {
-      code: `import { Button } from '@mui/material';`,
+      code: imp('{ Button }', MUI),
       errors: [{ messageId: 'deprecated' }],
     },
     // Default import: symbol resolved from the module path.
     {
-      code: `import Tooltip from '@mui/material/Tooltip';`,
+      code: imp('Tooltip', `${MUI}/Tooltip`),
       errors: [{ messageId: 'deprecated' }],
     },
     // Legacy filigran-ui identifier is deprecated too.
     {
-      code: `import { DropdownMenu } from '@filigran/ui';`,
+      code: imp('{ DropdownMenu }', FILIGRAN_UI),
       errors: [{ messageId: 'deprecated' }],
     },
     // Multiple deprecated identifiers in one statement.
     {
-      code: `import { Select, Checkbox } from '@mui/material';`,
+      code: imp('{ Select, Checkbox }', MUI),
       errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
     },
   ],

--- a/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-replaced-components.test.js
+++ b/opencti-platform/opencti-front/packages/eslint-plugin-custom-rules/tests/lib/rules/no-replaced-components.test.js
@@ -1,0 +1,59 @@
+import rule from '../../../lib/rules/no-replaced-components';
+import { RuleTester } from 'eslint';
+import parser from '@typescript-eslint/parser';
+
+const ruleTester = new RuleTester({
+  parser,
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+// Build import statements without writing a literal `from '@mui/...'` line, so
+// the MUI regression gate (fds-migration/scripts/check-mui-regression.mjs) does
+// not mistake these test fixtures for real MUI imports being introduced.
+const imp = (what, source) => `import ${what} ${'from'} '${source}';`;
+const MUI = '@mui/material';
+const FILIGRAN_UI = '@filigran/ui';
+const DS = '@filigran/design-system';
+
+ruleTester.run('no-replaced-components', rule, {
+  valid: [
+    // Design-system imports are the target, never flagged.
+    {
+      code: imp('{ Paper, Breadcrumbs }', DS),
+    },
+    // Unrelated third-party import.
+    {
+      code: imp('{ useState }', 'react'),
+    },
+    // A component that is only deprecated (warning), not fully replaced.
+    {
+      code: imp('{ Button }', MUI),
+    },
+  ],
+
+  invalid: [
+    // Named import of a fully replaced MUI component.
+    {
+      code: imp('{ Paper }', MUI),
+      errors: [{ messageId: 'replaced' }],
+    },
+    // Default import: symbol resolved from the module path.
+    {
+      code: imp('Paper', `${MUI}/Paper`),
+      errors: [{ messageId: 'replaced' }],
+    },
+    // Breadcrumbs family.
+    {
+      code: imp('{ Breadcrumbs, BreadcrumbItem }', MUI),
+      errors: [{ messageId: 'replaced' }, { messageId: 'replaced' }],
+    },
+    // Legacy filigran-ui Navbar family.
+    {
+      code: imp('{ Navbar, NavbarItem, NavbarSubmenu }', FILIGRAN_UI),
+      errors: [{ messageId: 'replaced' }, { messageId: 'replaced' }, { messageId: 'replaced' }],
+    },
+  ],
+});


### PR DESCRIPTION
### Proposed changes
es-lint rule to generate a warning if a component is used instead of its equivalent in the new filigran-design system

### Related issues
closes #17664