### PR TITLE
test(backend): make the day histogram test independent of the run time (flaky test) (#18100)

### DIFF
--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/elasticSearch-test.js
@@ -233,8 +233,7 @@ describe('Elasticsearch computation', () => {
     // over two days when the run crosses midnight UTC. Assert the total over the buckets
     // instead of reading the count from a single one.
     expect(data.length).toBeGreaterThanOrEqual(1);
-    // noinspection JSUnresolvedVariable
-    data.forEach((bucket) => expect(moment(bucket.date)._f).toEqual('YYYY-MM-DD'));
+    data.forEach((bucket) => expect(moment(bucket.date, 'YYYY-MM-DD', true).isValid(), `Unexpected bucket date "${bucket.date}"`).toBe(true));
     const total = data.reduce((acc, bucket) => acc + bucket.value, 0);
     expect(total).toEqual(34 + TESTING_ORGS.length);
   });

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/elasticSearch-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/elasticSearch-test.js
@@ -229,11 +229,14 @@ describe('Elasticsearch computation', () => {
       READ_INDEX_STIX_DOMAIN_OBJECTS,
       { types: ['Stix-Domain-Object'], field: 'created_at', interval: 'day', startDate: '2019-09-29T00:00:00.000Z', endDate: new Date().toISOString() },
     );
-    expect(data.length).toEqual(1);
+    // created_at is the insertion date, so the dataset lands on the day of the run - split
+    // over two days when the run crosses midnight UTC. Assert the total over the buckets
+    // instead of reading the count from a single one.
+    expect(data.length).toBeGreaterThanOrEqual(1);
     // noinspection JSUnresolvedVariable
-    const storedFormat = moment(R.head(data).date)._f;
-    expect(storedFormat).toEqual('YYYY-MM-DD');
-    expect(R.head(data).value).toEqual(34 + TESTING_ORGS.length);
+    data.forEach((bucket) => expect(moment(bucket.date)._f).toEqual('YYYY-MM-DD'));
+    const total = data.reduce((acc, bucket) => acc + bucket.value, 0);
+    expect(total).toEqual(34 + TESTING_ORGS.length);
   });
   it('should month histogram accurate', async () => {
     const data = await elHistogramCount(


### PR DESCRIPTION
## Proposed changes

- Fix the test `Elasticsearch computation > should day histogram accurate` (`tests/02-dataInjection/01-dataCount/elasticSearch-test.js`), which fails on every run crossing midnight UTC — see #18100 for the full analysis.
- The test aggregates `created_at` with a `day` interval and asserted a single bucket. `created_at` is the insertion date, so the whole dataset is stamped at injection time: the assertion only holds while the injection stays within one UTC day. A run started at 23:53 UTC splits the entities over two days, the histogram returns 2 buckets, and the count read from `R.head(data)` becomes partial as well.
- The test now asserts what it actually means to verify, without depending on the wall clock: every returned bucket is day-formatted (`YYYY-MM-DD`), and the sum of the bucket values equals the expected number of Stix domain objects.

## Related issues

- Closes #18100

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file; integration suite validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
