### PR TITLE
test(e2e): type dates from the first section of the field (flaky test) (#16071)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/model/field/DateField.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/field/DateField.pageModel.ts
@@ -27,6 +27,10 @@ export default class DateFieldPageModel {
 
   async fill(input: string) {
     await this.inputLocator.click();
-    return this.page.keyboard.type(input, { delay: 100 });
+    // The field is split in date sections and a click puts the caret on the section under
+    // the pointer, so the typing would start on an arbitrary one. Selecting every section
+    // first makes it always start on the first section, whatever the locale order.
+    await this.page.keyboard.press('ControlOrMeta+A');
+    await this.page.keyboard.type(input, { delay: 100 });
   }
 }


### PR DESCRIPTION
## Proposed changes

- Fix the flaky e2e test `Dashboard CRUD` (`tests_e2e/dashboard/dashboard.spec.ts`, group1) — see #16071.
- The failure screenshot shows the root cause: the start date field holds `MM/17/2023` instead of `12/17/2023`, and the widget still displays the unfiltered count `46` instead of `43`. The date was only partially applied, so the filter never changed and the assertion waited 60s on a value that could not appear.
- `DateFieldPageModel.fill()` clicked the input then typed. The field is split in month / day / year sections and a click puts the caret on the section under the pointer, so the typing started on an arbitrary section depending on where the click landed. Every section is now selected first, so the typing always starts on the first one.

The fix is in the shared date field page model, so every date input driven by the e2e suite benefits from it. No assertion is added on the resulting value: `fill()` is also used on purpose to type only part of a date-time field (`report.spec.ts`), and the field normalises what it receives (`18:00 PM` becomes `08:00 PM`), so no generic check on the value can hold.

Note: #16071 also reports a `MuiBackdrop` intercepting clicks in `backgroundTask.spec.ts` on the retry. That one is a distinct mechanism (drawer not closed between tests of the same describe) and is not addressed here.

## Related issues

- Closes #16071

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file, all e2e specs load; e2e group1 validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
