### PR TITLE
test(backend): give the telemetry counters time to land (flaky tests) (#18109)

### DIFF
--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -123,7 +123,7 @@ describe('Telemetry manager test coverage', () => {
         await fetchTelemetryData(filigranTelemetryMeterManager);
         return filigranTelemetryMeterManager.sharedSavedFiltersCount === 1
           && filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount === 1;
-      }, 1000, 5, true, 'Shared saved filters telemetry counters were not updated in time');
+      }, 1000, 60, true, 'Shared saved filters telemetry counters were not updated in time');
 
       expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
       expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
@@ -162,9 +162,6 @@ describe('Telemetry manager test coverage', () => {
       addNotificationSentCount('email');
     }
 
-    const loopCount = 3; // 3' max
-    let loopCurrent = 0;
-
     const isRedisUpdatedCallback = async () => {
       const disseminationGaugeValue = await redisGetTelemetry(TELEMETRY_GAUGE_DISSEMINATION);
       const chatbotGaugeValue = await redisGetTelemetry(TELEMETRY_GAUGE_CHATBOT_MESSAGE);
@@ -175,12 +172,10 @@ describe('Telemetry manager test coverage', () => {
         && askAiGaugeValue === ASK_AI_SUMMARIZE_EVENTS
         && notificationGaugeValue === NOTIFICATION_EMAIL_EVENTS;
     };
-    let isRedisUpdated = await isRedisUpdatedCallback();
-    while (!isRedisUpdated && loopCurrent < loopCount) {
-      await waitInSec(1);
-      isRedisUpdated = await isRedisUpdatedCallback();
-      loopCurrent += 1;
-    }
+    // Those gauges are fed by fire-and-forget helpers, so poll until they land. Giving up
+    // silently here would let the assertions below report a counter mismatch instead of the
+    // actual cause.
+    await awaitUntilCondition(isRedisUpdatedCallback, 1000, 60, true, 'Redis telemetry gauges were not updated in time');
 
     // WHEN data is fetched from elastic (platform wide gauges) and redis (user event gauge)
     await fetchTelemetryData(filigranTelemetryMeterManager);


### PR DESCRIPTION
## Proposed changes

- Fix two flaky tests of `tests/03-integration/04-manager/telemetryManager-test.ts` — see #18109 for the full analysis.
- `shared saved filters count and permission changes are collected` polled its counters for 5 seconds only (`awaitUntilCondition(..., 1000, 5)`), which is not enough on a loaded runner for values fed by a fire-and-forget path. The budget is raised to 60 seconds.
- `Verify that metrics get collected from both elastic and redis` used a hand-rolled loop of 3 seconds that simply exited when exhausted, letting the test carry on to the assertions. The failure then surfaced as `expected +0 to be 8`, which points at a counter instead of the actual cause. The loop is replaced by `awaitUntilCondition` with the same 60 seconds budget, so exhausting it fails with an explicit message.

The polled conditions and every assertion are unchanged: only the waiting budget and the reporting of a timeout differ.

## Related issues

- Closes #18109
- Closes #16057

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file; integration suite validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
