### PR TITLE
test(e2e): fail on the draft exit itself instead of a later step (#18115)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/drafts/restrictedDrafts.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/drafts/restrictedDrafts.spec.ts
@@ -31,6 +31,10 @@ test.describe('Draft Review Tab Navigation', { tag: ['@ce'] }, () => {
     const exitDraftButton = page.getByRole('button', { name: 'Exit draft' });
     await expect(exitDraftButton).toBeVisible();
     await exitDraftButton.click();
+    // The draft toolbar is only rendered while the session is inside a draft. Assert it is
+    // gone before going on: the navigation can reach the drafts list URL while the session
+    // is still in the draft, and every later step then runs against the draft workspace.
+    await expect(exitDraftButton).toBeHidden();
     await expect(page).toHaveURL(/\/dashboard\/data\/import\/draft$/);
 
     const draftRow = Drafts.getDraft(draftName);


### PR DESCRIPTION
## Proposed changes

- Make the e2e test `Draft Review Tab Navigation > should navigate to the draft review tab` (`tests_e2e/drafts/restrictedDrafts.spec.ts`, group0) report the actual failure — see #18115.
- After clicking `Exit draft`, the test only asserted the URL. The navigation can reach the drafts list URL while the session is still inside the draft, so the assertion passed and the test carried on against the draft workspace, dying 200s later on a draft row that could not be there. Nothing in that report pointed at the exit.
- The draft toolbar is only rendered while the session is inside a draft, so the test now asserts that the `Exit draft` button is gone before going on. A failure lands on the exit itself, in seconds, with an unambiguous message.

**Scope**: this changes what the test reports, nothing else. The platform defect it exposes — exiting a draft not always clearing the draft context — is a product bug tracked separately in #18112 and is **not** addressed here.

## Related issues

- Closes #18115
- Exposes #18112

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file, all e2e specs load; e2e group0 validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
