### PR TITLE
test(e2e): apply the report markings one at a time (#18116)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -254,8 +254,14 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce', '@group
   await expect(author).toBeVisible();
 
   await reportDetailsPage.getEditButton().click();
+  // Each selection commits its own relation mutation, and every response carries a full
+  // snapshot of the report. Chaining them lets the response of the first land after the
+  // second and overwrite it, so the added marking never reaches the overview panel.
+  // Wait for each change to be reflected before triggering the next one.
   await reportForm.markingsAutocomplete.selectOption('PAP:CLEAR');
+  await expect(reportForm.markingsAutocomplete.getOption('PAP:CLEAR')).toBeHidden();
   await reportForm.markingsAutocomplete.selectOption('PAP:GREEN');
+  await expect(reportForm.markingsAutocomplete.getOption('PAP:GREEN')).toBeVisible();
   await reportForm.getUpdateTitle().click();
   await reportForm.getCloseButton().click();
   markingClear = reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR');

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -257,11 +257,13 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce', '@group
   // Each selection commits its own relation mutation, and every response carries a full
   // snapshot of the report. Chaining them lets the response of the first land after the
   // second and overwrite it, so the added marking never reaches the overview panel.
-  // Wait for each change to be reflected before triggering the next one.
+  // Wait for each mutation to land before triggering the next one. The chips of the field
+  // only reflect the form state and change before the response arrives, so the wait is on
+  // the Marking panel of the details view, which is driven by the Relay store.
   await reportForm.markingsAutocomplete.selectOption('PAP:CLEAR');
-  await expect(reportForm.markingsAutocomplete.getOption('PAP:CLEAR')).toBeHidden();
+  await expect(reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR')).toBeHidden();
   await reportForm.markingsAutocomplete.selectOption('PAP:GREEN');
-  await expect(reportForm.markingsAutocomplete.getOption('PAP:GREEN')).toBeVisible();
+  await expect(reportDetailsPage.getTextForHeading('Marking', 'PAP:GREEN')).toBeVisible();
   await reportForm.getUpdateTitle().click();
   await reportForm.getCloseButton().click();
   markingClear = reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR');

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -257,13 +257,19 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce', '@group
   // Each selection commits its own relation mutation, and every response carries a full
   // snapshot of the report. Chaining them lets the response of the first land after the
   // second and overwrite it, so the added marking never reaches the overview panel.
-  // Wait for each mutation to land before triggering the next one. The chips of the field
-  // only reflect the form state and change before the response arrives, so the wait is on
-  // the Marking panel of the details view, which is driven by the Relay store.
+  // Wait for each mutation to land before triggering the next one. Nothing in the DOM can
+  // carry that wait: the details view is unmounted while the drawer is open, and the chips
+  // of the field only reflect the form state, so the wait is on the responses themselves.
+  const waitForMarkingMutation = (mutationName: string) => page.waitForResponse(
+    (response) => response.url().includes('/graphql')
+      && (response.request().postData() ?? '').includes(mutationName),
+  );
+  const markingRemoved = waitForMarkingMutation('ReportEditionOverviewRelationDeleteMutation');
   await reportForm.markingsAutocomplete.selectOption('PAP:CLEAR');
-  await expect(reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR')).toBeHidden();
+  await markingRemoved;
+  const markingAdded = waitForMarkingMutation('ReportEditionOverviewRelationAddMutation');
   await reportForm.markingsAutocomplete.selectOption('PAP:GREEN');
-  await expect(reportDetailsPage.getTextForHeading('Marking', 'PAP:GREEN')).toBeVisible();
+  await markingAdded;
   await reportForm.getUpdateTitle().click();
   await reportForm.getCloseButton().click();
   markingClear = reportDetailsPage.getTextForHeading('Marking', 'PAP:CLEAR');


### PR DESCRIPTION
## Proposed changes

- Stop the e2e test `Report CRUD` (`tests_e2e/report/report.spec.ts`, group1) from driving two marking mutations at the same time — see #18116.
- The test removed `PAP:CLEAR` and added `PAP:GREEN` back to back from the edition drawer. Each selection commits its own relation mutation, so both were in flight at once and the assertions depended on the response ordering.
- The test now waits for each mutation to land before triggering the next one, on the `/graphql` responses of `ReportEditionOverviewRelationDeleteMutation` and `ReportEditionOverviewRelationAddMutation`.

Nothing in the DOM can carry that wait, which two earlier attempts on this branch established: the chips of the markings field only reflect the form state and change before the response arrives, and the details view — whose Marking panel is driven by the Relay store — is **unmounted while the drawer is open**. The mutation responses are the only signal available from the test.

**Scope**: this only removes the concurrency introduced by the test. The platform losing an update when two mutations each returning a full snapshot overlap — the history panel reports the marking as added while the Marking panel does not show it — is a product bug tracked separately in #18111 and is **not** addressed here.

## Related issues

- Closes #18116
- Exposes #18111

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file, all e2e specs load; e2e group1 validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
