### PR TITLE
feat(stream): add metrics & logging for stream events offloading (#18102)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis-stream.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis-stream.ts
@@ -18,7 +18,7 @@ import { streamEventId, utcDate } from '../utils/format';
 import { UnsupportedError } from '../config/errors';
 import { asyncMap } from '../utils/data-processing';
 import { roundRate } from '../utils/consumer-metrics';
-import { getFileContent, rawUpload } from './raw-file-storage';
+import { getFileContent, rawListObjects, rawUpload } from './raw-file-storage';
 // Self namespace import: referencing isEventTooLarge through the module namespace (instead of a direct
 // local call) allows it to be spied/mocked in tests (e.g. vi.spyOn(redisStream, 'isEventTooLarge')).
 import * as redisStreamSelf from './redis-stream';
@@ -68,12 +68,13 @@ export const STREAM_FILE_DIRECTORY = `streams/${REDIS_LIVE_STREAM_NAME}/`;
 export const isEventTooLarge = (eventStreamData: any) => {
   const eventStreamDataBlob = new Blob(eventStreamData);
   const totalStreamEventSize = eventStreamDataBlob.size;
-  return streamMaxEventSize > 0 && totalStreamEventSize > streamMaxEventSize;
+  return { isTooLarge: streamMaxEventSize > 0 && totalStreamEventSize > streamMaxEventSize, eventSize: totalStreamEventSize };
 };
 export const rawPushToStream = async <T extends BaseEvent> (event: T) => {
   const redisClient = getClientBase();
   let eventStreamData = mapJSToStream(event);
-  if (redisStreamSelf.isEventTooLarge(eventStreamData)) {
+  const { isTooLarge, eventSize } = redisStreamSelf.isEventTooLarge(eventStreamData);
+  if (isTooLarge) {
     // Add salt to prevent time collision
     const randomSalt = Math.floor(Math.random() * 1000);
     const eventId = streamEventId(null, randomSalt);
@@ -81,12 +82,32 @@ export const rawPushToStream = async <T extends BaseEvent> (event: T) => {
     const fileContent = JSON.stringify(eventStreamData);
     await rawUpload(filePath, fileContent);
     eventStreamData = [streamMaxEventFileKey, filePath];
+    logApp.info('[STREAM] Event too large for redis, offloaded to file storage', {
+      filePath,
+      eventSize,
+      maxEventSize: streamMaxEventSize,
+      eventType: event.type,
+    });
   }
   if (streamTrimming) {
     await redisClient.call('XADD', REDIS_LIVE_STREAM_NAME, 'MAXLEN', '~', streamTrimming, '*', ...eventStreamData);
   } else {
     await redisClient.call('XADD', REDIS_LIVE_STREAM_NAME, '*', ...eventStreamData);
   }
+};
+// Count the stream events that have been offloaded to file storage (events too large for redis).
+// The listing is paginated so the count stays accurate beyond a single S3 page (default 1000 keys).
+export const countOffloadedStreamEvents = async (): Promise<number> => {
+  let count = 0;
+  let truncated = true;
+  let continuationToken: string | undefined;
+  while (truncated) {
+    const response = await rawListObjects(STREAM_FILE_DIRECTORY, true, continuationToken);
+    count += response.KeyCount ?? 0;
+    truncated = response.IsTruncated ?? false;
+    continuationToken = truncated ? response.NextContinuationToken : undefined;
+  }
+  return count;
 };
 export const processStreamData = async ([id, data]: any) => {
   if (data.includes(streamMaxEventFileKey)) {

--- a/opencti-platform/opencti-graphql/src/manager/garbageCollectionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/garbageCollectionManager.ts
@@ -28,7 +28,7 @@ const garbageCollectRedisStreamFiles = async (context: AuthContext) => {
     if (!allRedisLargeEventFiles || !allRedisLargeEventFiles.KeyCount || !allRedisLargeEventFiles.Contents) {
       return;
     }
-    const allFileContents = allRedisLargeEventFiles.Contents.sort();
+    const allFileContents = allRedisLargeEventFiles.Contents.sort((a, b) => (a.Key ?? '').localeCompare(b.Key ?? ''));
     let deletedCount = 0;
     for (let i = 0; i < allFileContents.length; i += 1) {
       const file = allFileContents[i];

--- a/opencti-platform/opencti-graphql/src/manager/garbageCollectionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/garbageCollectionManager.ts
@@ -29,6 +29,7 @@ const garbageCollectRedisStreamFiles = async (context: AuthContext) => {
       return;
     }
     const allFileContents = allRedisLargeEventFiles.Contents.sort();
+    let deletedCount = 0;
     for (let i = 0; i < allFileContents.length; i += 1) {
       const file = allFileContents[i];
       if (!file.Key) {
@@ -37,9 +38,20 @@ const garbageCollectRedisStreamFiles = async (context: AuthContext) => {
       const currentTimestamp = file.Key.slice(STREAM_FILE_DIRECTORY.length).split('-')[0];
       if (currentTimestamp < timestamp) {
         await deleteFileFromStorage(file.Key);
+        deletedCount += 1;
+        logApp.info('[OPENCTI-MODULE] Garbage collection: cleaned up offloaded redis stream event file from storage', {
+          manager: 'GARBAGE_MANAGER',
+          filePath: file.Key,
+        });
       } else {
         break;
       }
+    }
+    if (deletedCount > 0) {
+      logApp.info('[OPENCTI-MODULE] Garbage collection: redis stream event files cleanup complete', {
+        manager: 'GARBAGE_MANAGER',
+        deletedCount,
+      });
     }
   }
 };

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -60,6 +60,7 @@ import { ENTITY_TYPE_MANAGER_CONFIGURATION } from '../modules/managerConfigurati
 import { getSupportedContractsByImage } from '../modules/catalog/catalog-domain';
 import { FilterMode } from '../generated/graphql';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../database/redis';
+import { countOffloadedStreamEvents, rawFetchStreamInfo } from '../database/redis-stream';
 import type { AuthUser } from '../types/user';
 import { ENTITY_TYPE_PIR } from '../modules/pir/pir-types';
 import { ENTITY_TYPE_SECURITY_COVERAGE } from '../modules/securityCoverage/securityCoverage-types';
@@ -691,6 +692,22 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setIsFileIndexingEnabled(fileIndexConfiguration?.manager_running === true ? 1 : 0);
     const indexedFilesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_FILES, {});
     manager.setIndexedFilesCount(indexedFilesCount);
+    // endregion
+
+    try {
+      const streamInfo = await rawFetchStreamInfo();
+      manager.setRedisStreamEventsCount(streamInfo.streamSize ?? 0);
+    } catch (streamErr) {
+      logApp.debug('[TELEMETRY] Could not fetch redis stream info, skipping redis stream events count', { cause: streamErr });
+      manager.setRedisStreamEventsCount(-1);
+    }
+    try {
+      const offloadedStreamEventsCount = await countOffloadedStreamEvents();
+      manager.setOffloadedStreamEventsCount(offloadedStreamEventsCount);
+    } catch (offloadErr) {
+      logApp.debug('[TELEMETRY] Could not count offloaded stream events, skipping offloaded stream events count', { cause: offloadErr });
+      manager.setOffloadedStreamEventsCount(-1);
+    }
     // endregion
 
     // region Telemetry user events

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -321,6 +321,14 @@ export class TelemetryMeterManager {
   ingestionObjectsProcessedCount = 0;
   // endregion Product adoption
 
+  // region Stream storage
+  // Current total number of stream events offloaded to file storage (events too large for redis)
+  offloadedStreamEventsCount = 0;
+
+  // Current total number of events held in the redis live stream
+  redisStreamEventsCount = 0;
+  // endregion Stream storage
+
   constructor(meterProvider: MeterProvider) {
     this.meterProvider = meterProvider;
   }
@@ -641,6 +649,14 @@ export class TelemetryMeterManager {
     this.ingestionObjectsProcessedCount = n;
   }
 
+  setOffloadedStreamEventsCount(n: number) {
+    this.offloadedStreamEventsCount = n;
+  }
+
+  setRedisStreamEventsCount(n: number) {
+    this.redisStreamEventsCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -761,6 +777,10 @@ export class TelemetryMeterManager {
     this.registerDimensionalGauge('notification_sent_count', 'notifications sent broken down by channel (email, webhook, ui)', 'notificationSentItems');
     this.registerGauge('export_generated_count', 'number of export generations requested', 'exportGeneratedCount');
     this.registerGauge('ingestion_objects_processed_count', 'number of objects processed by completed works', 'ingestionObjectsProcessedCount');
+    // endregion
+    // region Stream storage
+    this.registerGauge('offloaded_stream_events_count', 'current total number of stream events offloaded to file storage (too large for redis)', 'offloadedStreamEventsCount');
+    this.registerGauge('redis_stream_events_count', 'current total number of events held in the redis live stream', 'redisStreamEventsCount');
     // endregion
   }
 }

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/administrativeArea-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/administrativeArea-test.js
@@ -108,7 +108,7 @@ describe('AdministrativeArea resolver standard behavior', () => {
     // Force the creation stream event to be considered "too large" so that it is offloaded to S3.
     // We let rawUpload run for real (real minio) so the offloaded event stays readable by the
     // downstream stream tests (its S3 file must exist to be rebuilt).
-    const isEventTooLargeSpy = vi.spyOn(redisStream, 'isEventTooLarge').mockReturnValue(true);
+    const isEventTooLargeSpy = vi.spyOn(redisStream, 'isEventTooLarge').mockReturnValue({ isTooLarge: true, eventSize: 0 });
     const rawUploadSpy = vi.spyOn(rawFileStorage, 'rawUpload');
     try {
       const CREATE_QUERY = gql`


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request enhances the handling, monitoring, and telemetry of Redis stream events, particularly those too large to be stored directly in Redis and are therefore offloaded to file storage. The main improvements include more detailed event size tracking, new metrics and telemetry for offloaded and live stream events, and improved logging and garbage collection for offloaded files.

**Stream Event Offloading and Metrics:**

- Changed `isEventTooLarge` to return both a boolean and the event size, and updated `rawPushToStream` to log detailed information when events are offloaded to file storage. Also introduced a new function `countOffloadedStreamEvents` to accurately count offloaded events, even when paginated in storage. [[1]](diffhunk://#diff-2e11f2fdb57fe2ae6b21e2068bd554e99d5e9f9b6d413d6514d91d1ca965ca12L21-R21) [[2]](diffhunk://#diff-2e11f2fdb57fe2ae6b21e2068bd554e99d5e9f9b6d413d6514d91d1ca965ca12L71-R111)

**Telemetry Enhancements:**

- Updated telemetry collection to include both the total number of events currently in the Redis live stream and the number of events offloaded to file storage, with robust error handling and logging for both metrics. [[1]](diffhunk://#diff-9e4b75344a9122f300bc53bc66ef8d1bd78fe979f1311e6c609f1c25813edaa7R63) [[2]](diffhunk://#diff-9e4b75344a9122f300bc53bc66ef8d1bd78fe979f1311e6c609f1c25813edaa7R697-R712)
- Extended the `TelemetryMeterManager` class to track and expose these new metrics, and registered new gauges for them. [[1]](diffhunk://#diff-042be43c26e6ef574fab4a3402e1d69e2b40ea5d65734e9249421eed7ec62b37R324-R331) [[2]](diffhunk://#diff-042be43c26e6ef574fab4a3402e1d69e2b40ea5d65734e9249421eed7ec62b37R652-R659) [[3]](diffhunk://#diff-042be43c26e6ef574fab4a3402e1d69e2b40ea5d65734e9249421eed7ec62b37R781-R784)

**Garbage Collection Improvements:**

- Improved the garbage collection process for offloaded Redis stream event files by tracking and logging the number of deleted files and providing more detailed cleanup logs. [[1]](diffhunk://#diff-a3037e3fd707b43f9a6fc313941737b493c820597c3c715f09580e8990eb0f6cR32) [[2]](diffhunk://#diff-a3037e3fd707b43f9a6fc313941737b493c820597c3c715f09580e8990eb0f6cR41-R55)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #18102

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
