### PR TITLE
fix(fds): compare MUI imports per file instead of per added line (#17664)

### DIFF
--- a/fds-migration/scripts/check-mui-regression.mjs
+++ b/fds-migration/scripts/check-mui-regression.mjs
@@ -8,9 +8,12 @@
  * Scope is deliberately narrow, and that narrowness is what makes the gate
  * safe to make blocking on day one:
  *
- *   - Only lines ADDED against the merge base are read. Every line that
- *     already exists keeps working and is never reported. The ~1000 files
- *     importing MUI today are untouched by construction.
+ *   - Only symbols a file did NOT already import on the merge base are read,
+ *     compared per file, base version against head version. Every import that
+ *     already exists keeps working and is never reported, even when its line
+ *     is edited. The ~1000 files importing MUI today are untouched by
+ *     construction. Reading added LINES instead re-reported every symbol that
+ *     merely survived an edit — including lines that removed MUI imports.
  *   - Only the 14 components the library has actually finished AND that are
  *     already rendering in this product are enforced. The list is generated,
  *     not typed here: fds-migration/mui-regression-policy.generated.json,
@@ -77,37 +80,58 @@ function mergeBase(base) {
   }
 }
 
-/** Added lines per file, with their new-file line numbers. */
-function addedLines(from) {
-  const diff = git(["diff", "--unified=0", "--no-color", `${from}...HEAD`]);
+/** Watched-source symbols a file imports, mapped to the line each sits on. */
+function importsIn(source) {
+  const found = new Map();
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    for (const symbol of importedSymbols(lines[i])) {
+      if (!found.has(symbol)) found.set(symbol, i + 1);
+    }
+  }
+  return found;
+}
+
+/**
+ * Code files touched against the base, each with the path it had there.
+ * `-M` so a renamed file is compared to its old path instead of counting as
+ * new, which would report every import it carries over.
+ */
+function changedFiles(from) {
   const out = [];
-  let file = null;
-  let lineNo = 0;
-  for (const raw of diff.split("\n")) {
-    if (raw.startsWith("+++ b/")) {
-      file = raw.slice(6);
-      continue;
-    }
-    const hunk = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-    if (hunk) {
-      lineNo = Number(hunk[1]);
-      continue;
-    }
-    if (raw.startsWith("+") && !raw.startsWith("+++")) {
-      if (file && CODE_EXT.has(path.extname(file))) {
-        out.push({ file, line: lineNo, text: raw.slice(1) });
+  const raw = git(["diff", "-M", "--name-status", "-z", `${from}...HEAD`]).split("\0");
+  for (let i = 0; i < raw.length; i += 1) {
+    const status = raw[i];
+    if (!status) continue;
+    if (status.startsWith("R")) {
+      const [before, after] = [raw[i + 1], raw[i + 2]];
+      i += 2;
+      if (CODE_EXT.has(path.extname(after ?? ""))) out.push({ file: after, basePath: before });
+    } else if (status.startsWith("D")) {
+      i += 1;
+    } else {
+      const file = raw[i + 1];
+      i += 1;
+      if (CODE_EXT.has(path.extname(file ?? ""))) {
+        out.push({ file, basePath: status.startsWith("A") ? null : file });
       }
-      lineNo += 1;
     }
   }
   return out;
 }
 
-function heldOnLine(file, lineNo, text) {
+function fileAt(ref, file) {
+  try {
+    return git(["show", `${ref}:${file}`]);
+  } catch {
+    return null;
+  }
+}
+
+function heldOnLine(lines, lineNo) {
+  const text = lines[lineNo - 1] ?? "";
   if (text.includes(KEEP_MARKER)) return text.slice(text.indexOf(KEEP_MARKER)).trim();
-  const abs = path.join(REPO_ROOT, file);
-  if (!fs.existsSync(abs)) return null;
-  const above = fs.readFileSync(abs, "utf8").split("\n")[lineNo - 2] ?? "";
+  const above = lines[lineNo - 2] ?? "";
   return above.includes(KEEP_MARKER) ? above.slice(above.indexOf(KEEP_MARKER)).trim() : null;
 }
 
@@ -148,11 +172,20 @@ function main() {
 
   const findings = [];
   let held = 0;
-  for (const { file, line, text } of addedLines(from)) {
-    for (const symbol of importedSymbols(text)) {
+  for (const { file, basePath } of changedFiles(from)) {
+    // The working tree first, so a `fds:keep-mui` added but not yet committed
+    // is honoured locally; CI checks out HEAD, where the two are the same.
+    const onDisk = path.join(REPO_ROOT, file);
+    const headSource = fs.existsSync(onDisk) ? fs.readFileSync(onDisk, "utf8") : fileAt("HEAD", file);
+    if (headSource === null) continue;
+    const baseSource = basePath ? fileAt(from, basePath) : null;
+    const alreadyThere = baseSource === null ? new Set() : new Set(importsIn(baseSource).keys());
+    const lines = headSource.split("\n");
+    for (const [symbol, line] of importsIn(headSource)) {
+      if (alreadyThere.has(symbol)) continue;
       const replacement = policy.enforced[symbol];
       if (!replacement) continue;
-      const hold = heldOnLine(file, line, text);
+      const hold = heldOnLine(lines, line);
       if (hold) {
         held += 1;
         continue;
@@ -160,6 +193,7 @@ function main() {
       findings.push({ file, line, symbol, replacement });
     }
   }
+  findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
 
   const scope = `${from.slice(0, 9)}...HEAD`;
   if (findings.length === 0) {

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid2';
 import IconButton from '@common/button/IconButton';
 import { useTheme } from '@mui/styles';
+// fds:keep-mui the library Tooltip is a compound API; this call site converts with the wider Tooltip wave
 import { Stack, Box, Tooltip } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import NotePopover from './NotePopover';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
@@ -1,6 +1,7 @@
 import Typography from '@mui/material/Typography';
 import StixCoreRelationshipCreationFromEntity, { TargetEntity } from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity';
 import { ViewListOutlined, ViewModuleOutlined } from '@mui/icons-material';
+// fds:keep-mui the library Tooltip is a compound API; this call site converts with the wider Tooltip wave
 import Tooltip from '@mui/material/Tooltip';
 import { ButtonGroup, ButtonGroupItem, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
 import React, { useEffect, useState } from 'react';

--- a/opencti-platform/opencti-front/src/private/components/common/GenerateExportTitle.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/GenerateExportTitle.tsx
@@ -1,5 +1,6 @@
 import { InfoOutlined } from '@mui/icons-material';
 import { Stack } from '@mui/material';
+// fds:keep-mui the library Tooltip is a compound API; this call site converts with the wider Tooltip wave
 import Tooltip from '@mui/material/Tooltip';
 import React, { FunctionComponent } from 'react';
 import { useFormatter } from '../../../components/i18n';


### PR DESCRIPTION
Targets `design-system/final` (#18117), where the MUI regression gate is the only red check.

## What the gate was doing

`check-mui-regression.mjs` read every `+` line of `merge-base...HEAD` and looked for a watched symbol on it. It never asked what the file already imported on the base, so **editing an import line re-reported every symbol that merely survived the edit** — including lines that remove MUI imports:

| file | base | head | reported |
|---|---|---|---|
| `components/common/tag/Tag.tsx` | `{ Chip, ChipProps, SxProps, Theme, Tooltip, alpha, lighten, useTheme }` | `{ Tooltip }` | new `Tooltip` — after 7 symbols were dropped |
| `settings/themes/ThemePopover.tsx` | `{ IconButton, Menu, MenuItem }` | `{ Menu, MenuItem }` | new `Menu` + `MenuItem` — after `IconButton` was dropped |
| `profile/Alerts.tsx` | `{ Badge, Tooltip }` | `{ Badge, Stack, Tooltip }` | new `Badge` + `Tooltip` — only `Stack` was added, and it is not watched |

On this branch that made **41 of 44 findings false**. The flaw is not new; it surfaced now because the branch is rebased on master, so the whole migration sits inside the diff window instead of a few days of work.

## What it does now

Per touched file, the gate compares the watched symbols of the **base** version against the **head** version and reports only `head \ base`.

- a file absent from the base is entirely new, so all of its imports count;
- `-M` keeps a renamed file compared against its old path, instead of counting every import it carries over;
- the working tree is read before `HEAD`, so a `fds:keep-mui` added but not yet committed is honoured locally — in CI the two are the same.

The `fds:keep-mui` escape hatch, the generated policy and the reporting are untouched.

## Verification

- on this branch: **44 → 3**, then PASS with the three markers;
- a MUI `Badge` import added by hand to `GenerateExportTitle.tsx` is **still caught**, at its line, and the gate returns to PASS once removed;
- with the old script on this same tree, 41 findings remain **even with the three markers in place** — the markers alone could never have made it green.

## The three real ones

All MUI `Tooltip`, all genuinely absent from master: the note card, the attack patterns toolbar, and `GenerateExportTitle.tsx` (a file this branch creates).

None is blocked by the library — the product already renders the design system's Tooltip in `TopBar`, `TrashInformation` and `UploadImport`. But that component is a compound API (`Tooltip` / `TooltipTrigger` / `TooltipContent`), so each call site is a JSX rewrite and a visual change, which does not belong in a CI-gate fix. Over 200 files still import the MUI one. The markers record the deferral and stay greppable through `--list-holds`.

Say the word and I convert the three instead.

## Two things noticed, not touched

- `data/forms/FormSchemaEditor.tsx:3` carries `// fds:keep-mui Switch/TextField predate this PR; this line only drops MUI Tab/Tabs.` — a marker written *because of* this bug. It becomes unnecessary once this lands.
- `GlobalWorkflowSettingsCard.test.tsx` fails on `design-system/final` **without this PR** ("does not render the sync workflow status by name switch when the feature flag is disabled"). Verified by checking out the branch head alone. Unrelated to this change, but it is red on the branch.

## Checks run locally

`check-ts` 0 errors · eslint 0 errors on the touched files (5 pre-existing `no-deprecated-components` warnings on the MUI Tooltip imports) · `yarn build` ✅ · the gate PASSes.
