### PR TITLE
test(backend): set the wait budgets from measured timings (#18133)

### DIFF
--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -32,6 +32,7 @@ import {
   setEditContext,
 } from '../../../src/database/redis';
 import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
+import { awaitUntilCondition } from '../../utils/testQueryHelper';
 
 const ingestionHistoryKey = (feedId) => `ingestion-${feedId}-history`;
 
@@ -408,13 +409,11 @@ describe('Redis publishCacheResetEvent', () => {
     try {
       await publishCacheResetEvent('User');
 
-      const timeout = 5000;
-      const start = Date.now();
-      while (!receivedEvents.some((e) => e.entityType === 'User') && Date.now() - start < timeout) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, 10);
-        });
-      }
+      await awaitUntilCondition(
+        async () => receivedEvents.some((e) => e.entityType === 'User'),
+        5000,
+        { intervalMs: 10, message: 'No cache reset event received for User' },
+      );
 
       expect(receivedEvents.length).toBeGreaterThanOrEqual(1);
       const userEvent = receivedEvents.find((e) => e.entityType === 'User');
@@ -435,16 +434,11 @@ describe('Redis publishCacheResetEvent', () => {
       await publishCacheResetEvent('User');
       await publishCacheResetEvent('Settings');
 
-      const timeout = 5000;
-      const start = Date.now();
-      while (
-        (!receivedEvents.some((e) => e.entityType === 'User') || !receivedEvents.some((e) => e.entityType === 'Settings'))
-        && Date.now() - start < timeout
-      ) {
-        await new Promise((resolve) => {
-          setTimeout(resolve, 10);
-        });
-      }
+      await awaitUntilCondition(
+        async () => receivedEvents.some((e) => e.entityType === 'User') && receivedEvents.some((e) => e.entityType === 'Settings'),
+        5000,
+        { intervalMs: 10, message: 'Cache reset events not received for both User and Settings' },
+      );
 
       expect(receivedEvents.length).toBeGreaterThanOrEqual(2);
       expect(receivedEvents.some((e) => e.entityType === 'User')).toBe(true);

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -411,7 +411,7 @@ describe('Redis publishCacheResetEvent', () => {
 
       await awaitUntilCondition(
         async () => receivedEvents.some((e) => e.entityType === 'User'),
-        5000,
+        3000,
         { intervalMs: 10, message: 'No cache reset event received for User' },
       );
 
@@ -436,7 +436,7 @@ describe('Redis publishCacheResetEvent', () => {
 
       await awaitUntilCondition(
         async () => receivedEvents.some((e) => e.entityType === 'User') && receivedEvents.some((e) => e.entityType === 'Settings'),
-        5000,
+        3000,
         { intervalMs: 10, message: 'Cache reset events not received for both User and Settings' },
       );
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/audit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/audit-test.ts
@@ -155,7 +155,7 @@ describe('audits query', () => {
       });
       foundEdges = queryResult.data.audits.edges;
       return foundEdges.length > 0;
-    }, 20000, { message: 'No searchable startup Activity events found' });
+    }, 3000, { message: 'No searchable startup Activity events found' });
 
     expect(searchTerm).toBeDefined();
     expect(foundEdges.length).toBeGreaterThan(0);
@@ -186,7 +186,7 @@ describe('audits query', () => {
         });
         foundEdges = queryResult.data.audits.edges;
         return foundEdges.some((edge) => edge.node.entity_type === 'History');
-      }, 20000, { message: 'No searchable generated History event found' });
+      }, 3000, { message: 'No searchable generated History event found' });
 
       expect(foundEdges.some((edge) => edge.node.entity_type === 'History')).toBe(true);
     } finally {
@@ -222,7 +222,7 @@ describe('audits distribution query', () => {
         });
         distribution = queryResult.data.auditsDistribution ?? [];
         return distribution.some((item) => item?.entity?.id === report.id && item?.entity?.representative?.main === reportName);
-      }, 20000, { message: 'No auditsDistribution result found for created report' });
+      }, 10000, { message: 'No auditsDistribution result found for created report' });
 
       const reportDistribution = distribution.find((item) => item?.entity?.id === report.id);
       expect(reportDistribution).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/audit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/audit-test.ts
@@ -155,7 +155,7 @@ describe('audits query', () => {
       });
       foundEdges = queryResult.data.audits.edges;
       return foundEdges.length > 0;
-    }, 1000, 20, true, 'No searchable startup Activity events found');
+    }, 20000, { message: 'No searchable startup Activity events found' });
 
     expect(searchTerm).toBeDefined();
     expect(foundEdges.length).toBeGreaterThan(0);
@@ -186,7 +186,7 @@ describe('audits query', () => {
         });
         foundEdges = queryResult.data.audits.edges;
         return foundEdges.some((edge) => edge.node.entity_type === 'History');
-      }, 1000, 20, true, 'No searchable generated History event found');
+      }, 20000, { message: 'No searchable generated History event found' });
 
       expect(foundEdges.some((edge) => edge.node.entity_type === 'History')).toBe(true);
     } finally {
@@ -222,7 +222,7 @@ describe('audits distribution query', () => {
         });
         distribution = queryResult.data.auditsDistribution ?? [];
         return distribution.some((item) => item?.entity?.id === report.id && item?.entity?.representative?.main === reportName);
-      }, 1000, 20, true, 'No auditsDistribution result found for created report');
+      }, 20000, { message: 'No auditsDistribution result found for created report' });
 
       const reportDistribution = distribution.find((item) => item?.entity?.id === report.id);
       expect(reportDistribution).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
@@ -18,7 +18,9 @@ const TEST_COMPOSER_PUBLIC_KEY = '-----BEGIN RSA PUBLIC KEY-----\nMIICCgKCAgEAk8
 // Test configuration
 // The goal is to achieve a 1:1 behavior match between XTMComposerMock and XTMComposer.
 // This enables authentic integration testing (assuming the XTM Composer is available in the CI) without the need to rewrite the test suite.
-const FORCE_POLLING = true; // Set to true for faster tests, false for realistic XTM Composer behavior
+// Set to true for faster tests, false for realistic XTM Composer behavior.
+// The wait budgets of the else branches are unverified: they never run while this is true.
+const FORCE_POLLING = true;
 
 // Mutations
 const REGISTER_CONNECTORS_MANAGER_MUTATION = gql`
@@ -399,7 +401,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started'; // Wait connector to be started
-        }, 1500);
+        }, 10000);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -438,7 +440,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { input: startRequestInput },
           });
           return startResult.data?.updateConnectorRequestedStatus.manager_requested_status === 'starting';
-        }, 2000);
+        }, 10000);
       }
 
       const startResult = await queryAsAdminWithSuccess({
@@ -459,7 +461,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 1500);
+        }, 10000);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -495,7 +497,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'stopped';
-        }, 1500);
+        }, 10000);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -528,7 +530,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'stopped';
-        }, 1500);
+        }, 10000);
       }
 
       let connectorResult = await queryAsAdminWithSuccess({
@@ -559,7 +561,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 1500);
+        }, 10000);
       }
 
       // Verify status
@@ -644,7 +646,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: logLevelConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 1500);
+        }, 10000);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -688,7 +690,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logs = logsResult.data?.connector.manager_connector_logs || [];
           const logStrings = logs.join('\n');
           return logStrings.includes('[XTM-Composer] Connector redeployed successfully'); // Wait for configuration change detection
-        }, 2000);
+        }, 10000);
       }
 
       // Query the connector logs to verify the redeploy happened
@@ -749,7 +751,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logStrings = logs.join('\n');
           const redeployCount = (logStrings.match(/Connector redeployed successfully/g) || []).length;
           return redeployCount === 2; // Wait for configuration change detection
-        }, 2000);
+        }, 10000);
       }
 
       // Query logs again
@@ -800,7 +802,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logStrings = logs.join('\n');
           const deployCount = (logStrings.match(/Connector deployed successfully/g) || []).length;
           return deployCount === 2; // Wait for configuration change detection
-        }, 2000);
+        }, 10000);
       }
 
       // Query logs one more time
@@ -839,7 +841,7 @@ describe('Connector Composer and Managed Connectors', () => {
           variables: { id: deploymentConnectorId },
         });
         return deleteResult.data?.deleteConnector === deploymentConnectorId;
-      }, 1500);
+      }, 3000);
 
       expect(deleteResult.data).toBeDefined();
       expect(deleteResult.data?.deleteConnector).toEqual(deploymentConnectorId);
@@ -1019,7 +1021,7 @@ describe('Connector Composer and Managed Connectors', () => {
               variables: { id },
             });
             return connectorResult.data?.connector.manager_current_status === 'started'; // Wait for each connector to start
-          }, 2000);
+          }, 3000);
 
           const finalResult = await queryAsAdminWithSuccess({
             query: GET_CONNECTOR_QUERY_CURRENT_STATUS,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
@@ -399,7 +399,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started'; // Wait connector to be started
-        }, 300, 5);
+        }, 1500);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -438,7 +438,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { input: startRequestInput },
           });
           return startResult.data?.updateConnectorRequestedStatus.manager_requested_status === 'starting';
-        }, 400, 5);
+        }, 2000);
       }
 
       const startResult = await queryAsAdminWithSuccess({
@@ -459,7 +459,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 300, 5);
+        }, 1500);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -495,7 +495,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'stopped';
-        }, 300, 5);
+        }, 1500);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -528,7 +528,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'stopped';
-        }, 300, 5);
+        }, 1500);
       }
 
       let connectorResult = await queryAsAdminWithSuccess({
@@ -559,7 +559,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: deploymentConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 300, 5);
+        }, 1500);
       }
 
       // Verify status
@@ -644,7 +644,7 @@ describe('Connector Composer and Managed Connectors', () => {
             variables: { id: logLevelConnectorId },
           });
           return connectorResult.data?.connector.manager_current_status === 'started';
-        }, 300, 5);
+        }, 1500);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -688,7 +688,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logs = logsResult.data?.connector.manager_connector_logs || [];
           const logStrings = logs.join('\n');
           return logStrings.includes('[XTM-Composer] Connector redeployed successfully'); // Wait for configuration change detection
-        }, 400, 5);
+        }, 2000);
       }
 
       // Query the connector logs to verify the redeploy happened
@@ -749,7 +749,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logStrings = logs.join('\n');
           const redeployCount = (logStrings.match(/Connector redeployed successfully/g) || []).length;
           return redeployCount === 2; // Wait for configuration change detection
-        }, 400, 5);
+        }, 2000);
       }
 
       // Query logs again
@@ -800,7 +800,7 @@ describe('Connector Composer and Managed Connectors', () => {
           const logStrings = logs.join('\n');
           const deployCount = (logStrings.match(/Connector deployed successfully/g) || []).length;
           return deployCount === 2; // Wait for configuration change detection
-        }, 400, 5);
+        }, 2000);
       }
 
       // Query logs one more time
@@ -839,7 +839,7 @@ describe('Connector Composer and Managed Connectors', () => {
           variables: { id: deploymentConnectorId },
         });
         return deleteResult.data?.deleteConnector === deploymentConnectorId;
-      }, 300, 5);
+      }, 1500);
 
       expect(deleteResult.data).toBeDefined();
       expect(deleteResult.data?.deleteConnector).toEqual(deploymentConnectorId);
@@ -1019,7 +1019,7 @@ describe('Connector Composer and Managed Connectors', () => {
               variables: { id },
             });
             return connectorResult.data?.connector.manager_current_status === 'started'; // Wait for each connector to start
-          }, 400, 5);
+          }, 2000);
 
           const finalResult = await queryAsAdminWithSuccess({
             query: GET_CONNECTOR_QUERY_CURRENT_STATUS,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/draft-organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/draft-organization-sharing-test.ts
@@ -215,8 +215,7 @@ describe.skip('Draft organization sharing', () => {
           });
           return tRes.data?.backgroundTask.completed;
         },
-        1000,
-        10000,
+        10000000,
       );
 
       // 7. Test removing the restriction in Draft

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/draft-organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/draft-organization-sharing-test.ts
@@ -206,7 +206,7 @@ describe.skip('Draft organization sharing', () => {
       expect(taskRes.data?.queryTaskAdd).toBeDefined();
       expect(taskRes.errors).toBeUndefined();
 
-      // Wait for task completion
+      // Wait for task completion. Budget unverified: this describe is skipped.
       await awaitUntilCondition(
         async () => {
           const tRes = await queryAsAdmin({
@@ -215,7 +215,7 @@ describe.skip('Draft organization sharing', () => {
           });
           return tRes.data?.backgroundTask.completed;
         },
-        10000000,
+        10000,
       );
 
       // 7. Test removing the restriction in Draft

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/log-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/log-test.ts
@@ -67,7 +67,7 @@ describe('Log resolver standard behavior', async () => {
         },
       });
       return queryResult?.data?.logs.edges.length > 1; // we need create and update
-    }, 2000, 20);
+    }, 40000);
 
     const queryResult = await queryAsAdminWithSuccess({
       query: READ_QUERY,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/log-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/log-test.ts
@@ -67,7 +67,7 @@ describe('Log resolver standard behavior', async () => {
         },
       });
       return queryResult?.data?.logs.edges.length > 1; // we need create and update
-    }, 40000);
+    }, 10000);
 
     const queryResult = await queryAsAdminWithSuccess({
       query: READ_QUERY,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/organization-sharing-test.ts
@@ -125,7 +125,7 @@ describe('oganization-sharing-test', () => {
         return queryResult.data?.report !== null && queryResult.data?.report.objects.edges.length === 8;
       };
       // wait for task manager & worker to handle organization sharing
-      await awaitUntilCondition(condition, 10000, { message: 'Please check that you have a test worker running' });
+      await awaitUntilCondition(condition, 5000, { message: 'Please check that you have a test worker running' });
       const queryResult = await queryAsUserWithSuccess(USER_EDITOR, {
         query: REPORT_STIX_DOMAIN_ENTITIES,
         variables: { id: reportInternalId },

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/organization-sharing-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/organization-sharing-test.ts
@@ -125,7 +125,7 @@ describe('oganization-sharing-test', () => {
         return queryResult.data?.report !== null && queryResult.data?.report.objects.edges.length === 8;
       };
       // wait for task manager & worker to handle organization sharing
-      await awaitUntilCondition(condition, 1000, 10, true, 'Please check that you have a test worker running');
+      await awaitUntilCondition(condition, 10000, { message: 'Please check that you have a test worker running' });
       const queryResult = await queryAsUserWithSuccess(USER_EDITOR, {
         query: REPORT_STIX_DOMAIN_ENTITIES,
         variables: { id: reportInternalId },

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -128,7 +128,7 @@ describe('Telemetry manager test coverage', () => {
         await fetchTelemetryData(filigranTelemetryMeterManager);
         return filigranTelemetryMeterManager.sharedSavedFiltersCount === 1
           && filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount === 1;
-      }, 60000, { message: 'Shared saved filters telemetry counters were not updated in time' });
+      }, 3000, { message: 'Shared saved filters telemetry counters were not updated in time' });
 
       expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
       expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
@@ -180,7 +180,7 @@ describe('Telemetry manager test coverage', () => {
     // Those gauges are fed by fire-and-forget helpers, so poll until they land. Giving up
     // silently here would let the assertions below report a counter mismatch instead of the
     // actual cause.
-    await awaitUntilCondition(isRedisUpdatedCallback, 60000, { message: 'Redis telemetry gauges were not updated in time' });
+    await awaitUntilCondition(isRedisUpdatedCallback, 3000, { message: 'Redis telemetry gauges were not updated in time' });
 
     // WHEN data is fetched from elastic (platform wide gauges) and redis (user event gauge)
     await fetchTelemetryData(filigranTelemetryMeterManager);

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -128,7 +128,7 @@ describe('Telemetry manager test coverage', () => {
         await fetchTelemetryData(filigranTelemetryMeterManager);
         return filigranTelemetryMeterManager.sharedSavedFiltersCount === 1
           && filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount === 1;
-      }, 1000, 60, true, 'Shared saved filters telemetry counters were not updated in time');
+      }, 60000, { message: 'Shared saved filters telemetry counters were not updated in time' });
 
       expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
       expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
@@ -180,7 +180,7 @@ describe('Telemetry manager test coverage', () => {
     // Those gauges are fed by fire-and-forget helpers, so poll until they land. Giving up
     // silently here would let the assertions below report a counter mismatch instead of the
     // actual cause.
-    await awaitUntilCondition(isRedisUpdatedCallback, 1000, 60, true, 'Redis telemetry gauges were not updated in time');
+    await awaitUntilCondition(isRedisUpdatedCallback, 60000, { message: 'Redis telemetry gauges were not updated in time' });
 
     // WHEN data is fetched from elastic (platform wide gauges) and redis (user event gauge)
     await fetchTelemetryData(filigranTelemetryMeterManager);

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -261,13 +261,7 @@ describe('Telemetry manager test coverage', () => {
       const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
       return nlqValue === 1 && exportValue === 2;
     };
-    let countersUpdated = await allCountersUpdated();
-    let pollCurrent = 0;
-    while (!countersUpdated && pollCurrent < 3) {
-      await waitInSec(1);
-      countersUpdated = await allCountersUpdated();
-      pollCurrent += 1;
-    }
+    await awaitUntilCondition(allCountersUpdated, 3000, { message: 'Ask AI and export telemetry counters were not updated in time' });
     for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
       const feature = ASK_AI_FEATURES[featureIndex];
       expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -760,7 +760,7 @@ describe('CustomView resolvers', () => {
           const created = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED);
           const enabled = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
           return created === 5 && enabled === 1;
-        }, 1000, 5, true, 'Custom view telemetry gauges were not updated in time');
+        }, 5000, { message: 'Custom view telemetry gauges were not updated in time' });
 
         expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED)).toBe(5);
         expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED)).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -760,7 +760,7 @@ describe('CustomView resolvers', () => {
           const created = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED);
           const enabled = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
           return created === 5 && enabled === 1;
-        }, 5000, { message: 'Custom view telemetry gauges were not updated in time' });
+        }, 3000, { message: 'Custom view telemetry gauges were not updated in time' });
 
         expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED)).toBe(5);
         expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED)).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
+++ b/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
@@ -40,10 +40,9 @@ const RULE_MUTATION = gql`
   }
 `;
 
-// Those two waits had no bound at all and could only end on the vitest timeout. The budgets
-// are deliberately generous, to be narrowed once the reported timings say what they really cost.
-const RULE_ACTIVATION_BUDGET = 300000;
-const RULE_STABILISATION_BUDGET = 120000;
+// Those two waits had no bound at all and could only end on the vitest timeout.
+const RULE_ACTIVATION_BUDGET = 10000;
+const RULE_STABILISATION_BUDGET = 15000;
 
 export const changeRule = async (ruleId, active) => {
   const start = new Date().getTime();

--- a/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
+++ b/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
@@ -2,11 +2,11 @@ import { expect } from 'vitest';
 import gql from 'graphql-tag';
 import { topEntitiesOrRelationsList } from '../../src/database/middleware';
 import { SYSTEM_USER } from '../../src/utils/access';
-import { isNotEmptyField, READ_INDEX_HISTORY, READ_INDEX_INFERRED_ENTITIES, READ_INDEX_INFERRED_RELATIONSHIPS, wait } from '../../src/database/utils';
+import { isNotEmptyField, READ_INDEX_HISTORY, READ_INDEX_INFERRED_ENTITIES, READ_INDEX_INFERRED_RELATIONSHIPS } from '../../src/database/utils';
 import { ENTITY_TYPE_BACKGROUND_TASK } from '../../src/schema/internalObject';
 import { internalFindByIds, internalLoadById, topEntitiesList } from '../../src/database/middleware-loader';
 import { testContext } from './testQuery';
-import { queryAsAdmin } from './testQueryHelper';
+import { awaitUntilCondition, queryAsAdmin } from './testQueryHelper';
 import { fetchStreamInfo } from '../../src/database/stream/stream-handler';
 import { logApp } from '../../src/config/conf';
 import { TASK_TYPE_RULE } from '../../src/domain/backgroundTask-common';
@@ -40,13 +40,17 @@ const RULE_MUTATION = gql`
   }
 `;
 
+// Those two waits had no bound at all and could only end on the vitest timeout. The budgets
+// are deliberately generous, to be narrowed once the reported timings say what they really cost.
+const RULE_ACTIVATION_BUDGET = 300000;
+const RULE_STABILISATION_BUDGET = 120000;
+
 export const changeRule = async (ruleId, active) => {
   const start = new Date().getTime();
   // Change the status
   await queryAsAdmin({ query: RULE_MUTATION, variables: { id: ruleId, enable: active } });
   // Wait for rule to finish activation
-  let ruleActivated = false;
-  while (ruleActivated !== true) {
+  await awaitUntilCondition(async () => {
     // Handle tasks
     const tasks = await topEntitiesList(testContext, SYSTEM_USER, [ENTITY_TYPE_BACKGROUND_TASK]);
     const ruleActivationTask = tasks.filter((t) => t.type === TASK_TYPE_RULE && t.rule === ruleId && t.enable === active);
@@ -68,21 +72,20 @@ export const changeRule = async (ruleId, active) => {
     });
     const doneWorks = works.filter((t) => t.status !== 'complete').length === 0;
     // Final status
-    ruleActivated = doneProvision && doneWorks;
-    await wait(1000);
-  }
+    return doneProvision && doneWorks;
+  }, RULE_ACTIVATION_BUDGET, { intervalMs: 1000, message: `Rule ${ruleId} did not finish its activation` });
   // Wait all events to be consumed
   let stableCount = 1;
-  while (stableCount < 3) {
+  await awaitUntilCondition(async () => {
     const innerInfo = await fetchStreamInfo();
     const ruleManagerInfo = await getManagerInfo(testContext, SYSTEM_USER);
-    await wait(2000);
     const lastEventDate = new Date(parseInt(innerInfo.lastEventId.split('-').at(0), 10));
     const managerEventDate = new Date(parseInt(ruleManagerInfo.lastEventId.split('-').at(0), 10));
     if (managerEventDate >= lastEventDate) {
       stableCount += 1;
     }
-  }
+    return stableCount >= 3;
+  }, RULE_STABILISATION_BUDGET, { intervalMs: 2000, message: `Rule ${ruleId} stream did not stabilise` });
   const stop = new Date().getTime() - start;
   logApp.info(`[TEST] Rule ${ruleId} ${active ? 'activated' : 'disabled'} in ${stop} ms`);
 };

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -6,6 +6,7 @@ import { ApolloServer } from '@apollo/server';
 import createSchema from '../../src/graphql/schema';
 import { downloadFile } from '../../src/database/raw-file-storage';
 import { streamConverter } from '../../src/database/file-storage';
+import { wait } from '../../src/database/utils';
 import { logApp } from '../../src/config/conf';
 import { AUTH_REQUIRED, FORBIDDEN_ACCESS } from '../../src/config/errors';
 import { getSettings, settingsEditField } from '../../src/domain/settings';
@@ -279,32 +280,77 @@ export const unSetOrganization = async () => {
   expect(settingsResult.platform_organization).toBeUndefined();
 };
 
+const AWAIT_MIN_INTERVAL = 200;
+const AWAIT_MAX_INTERVAL = 2000;
+const AWAIT_TARGET_POLLS = 20;
+
 /**
+ * Polling interval derived from the budget, so callers only have to express how long they
+ * accept to wait. Aiming at AWAIT_TARGET_POLLS attempts keeps short budgets responsive and
+ * long ones cheap, and the bounds avoid both a busy loop and a wait that overshoots the
+ * budget on its first sleep.
+ */
+const intervalForBudget = (budgetMs: number) => {
+  const target = Math.round(budgetMs / AWAIT_TARGET_POLLS);
+  return Math.min(AWAIT_MAX_INTERVAL, Math.max(AWAIT_MIN_INTERVAL, target));
+};
+
+/** First stack frame outside this helper, so every measurement is attributable. */
+const resolveCallSite = () => {
+  const frames = new Error().stack?.split('\n').slice(1) ?? [];
+  const frame = frames.find((f) => !f.includes('testQueryHelper'));
+  return frame?.match(/([\w.-]+\.(?:ts|js):\d+:\d+)/)?.[1] ?? 'unknown';
+};
+
+interface AwaitUntilConditionOptions {
+  /** Message added to the error when the budget is exhausted. */
+  message?: string;
+  /** Forces the polling interval in ms instead of deriving it from the budget. */
+  intervalMs?: number;
+  /** Expected result of the condition. */
+  expectToBeTrue?: boolean;
+}
+
+/**
+ * Waits until a condition holds, within a time budget.
+ *
+ * Every call reports how much of its budget it actually consumed, so the budgets can be set
+ * from observed timings rather than from guesses.
+ *
  * @param conditionPromise A function checking if the condition is verified.
- * @param sleepTimeBetweenLoop Time to wait between each loop in ms.
- * @param loopCount Max loop to do.
- * @param expectToBeTrue The expecting result of the condition.
- * @param message Message to display when condition is not met
+ * @param budgetMs How long polling may go on, in ms. A poll is only started while the budget
+ *                holds, so the budget bounds when polls start, not the total duration: a poll
+ *                already in flight is never interrupted. Always stated by the caller: what a
+ *                wait is allowed to cost is a decision of the test, never a default.
+ * @param options Message, forced polling interval, expected result.
  */
 export const awaitUntilCondition = async (
   conditionPromise: () => Promise<boolean>,
-  sleepTimeBetweenLoop = 1000,
-  loopCount = 10,
-  expectToBeTrue = true,
-  message: string = '',
+  budgetMs: number,
+  options: AwaitUntilConditionOptions = {},
 ) => {
-  let isConditionOk = await conditionPromise();
-  let loopCurrent = 0;
+  const { message = '', expectToBeTrue = true } = options;
+  const intervalMs = options.intervalMs ?? intervalForBudget(budgetMs);
+  const callSite = resolveCallSite();
+  const startTime = Date.now();
 
-  while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {
-    await new Promise((resolve) => setTimeout(resolve, sleepTimeBetweenLoop));
+  let isConditionOk = await conditionPromise();
+  let polls = 1;
+
+  while (!isConditionOk === expectToBeTrue && Date.now() - startTime + intervalMs <= budgetMs) {
+    await wait(intervalMs);
     isConditionOk = await conditionPromise();
-    loopCurrent += 1;
+    polls += 1;
   }
+
+  const elapsed = Date.now() - startTime;
+  const share = Math.round((elapsed / budgetMs) * 100);
 
   if (!isConditionOk === expectToBeTrue) {
-    throw new Error(`Condition not met after ${loopCount} attempts - ${message}`);
+    throw new Error(`Condition not met after ${elapsed}ms (budget ${budgetMs}ms, ${polls} polls) at ${callSite} - ${message}`);
   }
+
+  logApp.info(`[TEST-AWAIT] ${callSite} met in ${elapsed}ms (${share}% of ${budgetMs}ms budget, ${polls} polls)`);
 };
 
 const serverFromUser = new ApolloServer<AuthContext>({


### PR DESCRIPTION
## Proposed changes

Two telemetry tests were polling fire-and-forget counters with budgets too short for a loaded runner — see #18133. Rather than raising those budgets again, this makes the waits measurable and then sets every budget from what it actually costs.

### 1. The helper takes a budget, and reports what it consumed

`awaitUntilCondition` took a sleep interval and a loop count, so every call site had to invent both and the resulting budget was implicit:

```ts
awaitUntilCondition(condition, budgetMs, { message?, intervalMs?, expectToBeTrue? })
```

The polling interval is derived from the budget, aiming at twenty attempts and bounded between 200ms and 2s. That heuristic reproduces the values callers had picked by hand: a 20s budget gives back the 1000ms of `audit-test`, a 40s one the 2000ms of `log-test`. `intervalMs` remains for the cases that need it, such as the two cache reset subscriptions polling every 10ms.

The budget is **required**: what a wait may cost is a decision of the test, never a default.

The loop is also bounded by elapsed time rather than by a number of sleeps, so a budget of 20s now means 20s whatever the condition itself costs to evaluate. Before, `1000, 20` meant twenty times one second **plus** twenty evaluations.

Every call reports its result:

```
[TEST-AWAIT] telemetryManager-test.ts:127:13 met in 154ms (0% of 60000ms budget, 1 polls)
```

The call site comes from the stack, so none of the twenty-two call sites had to be annotated.

### 2. The remaining hand-rolled loops are converted

Five of them: the Ask AI and export counters, the two cache reset subscriptions of `redis-test`, and the two of `rule-utils`. They are now bounded, they fail naming what was being waited for, and they report their timings like every other wait.

The two in `rule-utils` had **no bound at all** and could only end on the vitest timeout, twenty minutes later, without saying why. The two in `redis-test` used to exit silently and let an unrelated assertion fail.

### 3. Budgets set from a CI run

Fifty-five measurements collected over one run, budgets set at three times the observed maximum, three second floor, rounded.

| Call site | Before | Observed max | Now |
| --- | ---: | ---: | ---: |
| `rule-utils.js:79` stabilisation | unbounded | 4011ms *(n=20)* | 15000 |
| `rule-utils.js:53` activation | unbounded | 2036ms *(n=20)* | 10000 |
| `audit-test.ts:208` | 20000 | 3046ms | 10000 |
| `log-test.ts:51` | 40000 | 2015ms | 10000 |
| `organization-sharing-test.ts:128` | 10000 | 1696ms | 5000 |
| `telemetryManager-test.ts:127` | 60000 | 154ms | 3000 |
| `telemetryManager-test.ts:183` | 60000 | 1ms | 3000 |
| `telemetryManager-test.ts:264` | 3000 | 2ms | 3000 |
| `audit-test.ts:129`, `:178` | 20000 | 26ms, 58ms | 3000 |
| `redis-test.js:412`, `:437` | 5000 | 10ms, 0ms | 3000 |
| `customView-resolvers-test.ts:759` | 5000 | 0ms | 3000 |
| `connector-composer-test.ts:840`, `:1020` | 1500, 2000 | 138ms, 9ms | 3000 |

Some budgets go **up** rather than down: proportionality is the point, not shrinking.

The two telemetry waits raised to 60s by #18110 consumed 154ms and 1ms. Those seconds were compensating for the telemetry collector wiping the Redis gauges mid-run, which #18142 has since removed at the source.

### Two zones that could not be measured

Both carry a short comment saying so: the `else` branches of `connector-composer-test.ts`, dead while `FORCE_POLLING` is `true`, and the skipped `draft-organization-sharing-test.ts`, whose budget was `10000000` — a typo for `10000`.

## Related issues

- Closes #18133

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint and tsc on the changed files; integration suite validated by CI, which is also where the measurements come from)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
