### PR TITLE
fix(backend): preserve standard id when building a restricted entity (#18026)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2143,6 +2143,26 @@ class OpenCTIStix2:
                 ],
             }
 
+    @staticmethod
+    def _is_restricted_identity(identity: Dict) -> bool:
+        """Detect a createdBy identity obfuscated by the platform because the
+        user has no access to it (see buildRestrictedEntity on the backend).
+
+        Both name and identity_class must match: identity_class is a
+        platform-controlled field and is never legitimately set to the
+        literal string "Restricted", so requiring both avoids false
+        positives on a real entity that happens to be named "Restricted".
+
+        :param identity: createdBy entity as returned by the API
+        :type identity: Dict
+        :return: True if the identity is a restricted placeholder
+        :rtype: bool
+        """
+        return (
+            identity.get("name") == "Restricted"
+            and identity.get("identity_class") == "Restricted"
+        )
+
     def prepare_export(
         self,
         entity: Dict,
@@ -2172,6 +2192,7 @@ class OpenCTIStix2:
             not no_custom_attributes
             and "createdBy" in entity
             and entity["createdBy"] is not None
+            and not self._is_restricted_identity(entity["createdBy"])
         ):
             created_by = self.generate_export(entity=entity["createdBy"])
             if entity["type"] in STIX_CYBER_OBSERVABLE_MAPPING:

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2145,19 +2145,7 @@ class OpenCTIStix2:
 
     @staticmethod
     def _is_restricted_identity(identity: Dict) -> bool:
-        """Detect a createdBy identity obfuscated by the platform because the
-        user has no access to it (see buildRestrictedEntity on the backend).
-
-        Both name and identity_class must match: identity_class is a
-        platform-controlled field and is never legitimately set to the
-        literal string "Restricted", so requiring both avoids false
-        positives on a real entity that happens to be named "Restricted".
-
-        :param identity: createdBy entity as returned by the API
-        :type identity: Dict
-        :return: True if the identity is a restricted placeholder
-        :rtype: bool
-        """
+        """Detect the platform's restricted-access placeholder identity."""
         return (
             identity.get("name") == "Restricted"
             and identity.get("identity_class") == "Restricted"

--- a/client-python/tests/01-unit/utils/test_opencti_stix2.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2.py
@@ -2,12 +2,26 @@ import datetime
 
 import pytest
 
+from pycti import OpenCTIApiClient
 from pycti.utils.opencti_stix2 import OpenCTIStix2
 
 
 @pytest.fixture
 def opencti_stix2(api_client):
     return OpenCTIStix2(api_client)
+
+
+@pytest.fixture
+def opencti_stix2_no_server():
+    """Same as opencti_stix2, but skips the live-server health check so these
+    tests can run without a running OpenCTI instance."""
+    client = OpenCTIApiClient(
+        "http://localhost:4000",
+        "test-token",
+        ssl_verify=False,
+        perform_health_check=False,
+    )
+    return OpenCTIStix2(client)
 
 
 def test_unknown_type(opencti_stix2: OpenCTIStix2, caplog):
@@ -532,6 +546,114 @@ def test_prepare_export_keeps_non_embedded_markdown_image_uri(
     assert len(result) == 1
     assert result[0]["description"] == "desc ![img](/storage/get/import/global/a.png)"
     assert len(fetch_calls) == 0
+
+
+def test_prepare_export_drops_restricted_created_by_ref(
+    opencti_stix2_no_server: OpenCTIStix2, monkeypatch
+):
+    """When createdBy is a restricted placeholder (name and identity_class both
+    forced to "Restricted" by the backend), the export must not set
+    created_by_ref and must not include the placeholder identity in the
+    bundle (see OpenCTI-Platform/opencti#18026)."""
+    monkeypatch.setattr(
+        opencti_stix2_no_server.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **kwargs: [],
+    )
+
+    entity = {
+        "id": "report--44444444-4444-4444-8444-444444444444",
+        "type": "report",
+        "entity_type": "Report",
+        "x_opencti_id": "internal-report-id-restricted",
+        "createdBy": {
+            "id": "internal-identity-id-restricted",
+            "standard_id": "identity--55555555-5555-4555-8555-555555555555",
+            "entity_type": "Organization",
+            "parent_types": ["Stix-Domain-Object", "Identity"],
+            "name": "Restricted",
+            "identity_class": "Restricted",
+        },
+        "createdById": "internal-identity-id-restricted",
+    }
+
+    result = opencti_stix2_no_server.prepare_export(entity=entity, mode="simple")
+
+    assert len(result) == 1
+    assert "created_by_ref" not in result[0]
+    assert not any(obj.get("type") == "identity" for obj in result)
+
+
+def test_prepare_export_keeps_created_by_ref_for_real_identity(
+    opencti_stix2_no_server: OpenCTIStix2, monkeypatch
+):
+    """Regression guard: a real (accessible) createdBy must still be exported
+    and referenced normally."""
+    monkeypatch.setattr(
+        opencti_stix2_no_server.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **kwargs: [],
+    )
+
+    entity = {
+        "id": "report--66666666-6666-4666-8666-666666666666",
+        "type": "report",
+        "entity_type": "Report",
+        "x_opencti_id": "internal-report-id-real",
+        "createdBy": {
+            "id": "internal-identity-id-real",
+            "standard_id": "identity--77777777-7777-4777-8777-777777777777",
+            "entity_type": "Organization",
+            "parent_types": ["Stix-Domain-Object", "Identity"],
+            "name": "Acme Corp",
+            "identity_class": "organization",
+        },
+        "createdById": "internal-identity-id-real",
+    }
+
+    result = opencti_stix2_no_server.prepare_export(entity=entity, mode="simple")
+
+    assert len(result) == 2
+    identity = next(obj for obj in result if obj["type"] == "identity")
+    report = next(obj for obj in result if obj["type"] == "report")
+    assert report["created_by_ref"] == identity["id"]
+    assert identity["name"] == "Acme Corp"
+
+
+def test_prepare_export_keeps_created_by_ref_for_identity_literally_named_restricted(
+    opencti_stix2_no_server: OpenCTIStix2, monkeypatch
+):
+    """A real identity that happens to be named "Restricted" but has a real
+    identity_class must not be mistaken for the platform's restricted
+    placeholder."""
+    monkeypatch.setattr(
+        opencti_stix2_no_server.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **kwargs: [],
+    )
+
+    entity = {
+        "id": "report--88888888-8888-4888-8888-888888888888",
+        "type": "report",
+        "entity_type": "Report",
+        "x_opencti_id": "internal-report-id-named-restricted",
+        "createdBy": {
+            "id": "internal-identity-id-named-restricted",
+            "standard_id": "identity--99999999-9999-4999-8999-999999999999",
+            "entity_type": "Organization",
+            "parent_types": ["Stix-Domain-Object", "Identity"],
+            "name": "Restricted",
+            "identity_class": "organization",
+        },
+        "createdById": "internal-identity-id-named-restricted",
+    }
+
+    result = opencti_stix2_no_server.prepare_export(entity=entity, mode="simple")
+
+    assert len(result) == 2
+    identity = next(obj for obj in result if obj["type"] == "identity")
+    report = next(obj for obj in result if obj["type"] == "report")
+    assert report["created_by_ref"] == identity["id"]
 
 
 def test_generate_export_fetches_external_reference_files_by_id(

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -754,6 +754,7 @@ export const buildRestrictedEntity = (resolvedEntity: BasicStoreEntity): BasicSt
   return {
     ...restrictedEntity,
     id: resolvedEntity.internal_id,
+    standard_id: resolvedEntity.standard_id, // keep the real standard_id: it must stay a valid STIX id
     name: 'Restricted',
     entity_type: resolvedEntity.entity_type,
     parent_types: resolvedEntity.parent_types,

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-distribution-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-distribution-unit-test.ts
@@ -111,6 +111,33 @@ describe('convertAggregateDistributions via distributionEntities (field=creator_
     expect(result[0].value).toBe(7);
     expect(result[0].entity).toBeNull();
   });
+
+  it('returns a restricted entity with a valid standard_id when access is denied', async () => {
+    vi.spyOn(accessModule, 'isUserCanAccessStoreElement').mockResolvedValue(false);
+
+    vi.mocked(engine.elAggregationCount).mockResolvedValue([
+      { label: ENTITY_ID_1, value: 4 },
+    ] as any);
+
+    const entity = {
+      ...makeEntity(ENTITY_ID_1, 'Secret Org'),
+      standard_id: 'identity--d4551de9-4b9c-570e-a51c-d3c321eb9a8d',
+    };
+    vi.mocked(engine.elFindByIds).mockResolvedValue({
+      [ENTITY_ID_1]: entity,
+    } as any);
+
+    const result = await distributionEntities(mockContext, accessModule.SYSTEM_USER, ['Threat-Actor'], {
+      field: 'creator_id',
+      limit: 10,
+      order: 'desc',
+    } as any);
+
+    expect(result[0].entity?.name).toBe('Restricted');
+    // standard_id must remain the real one: it's not sensitive content and must
+    // stay a valid STIX id for downstream consumers (e.g. STIX bundle export).
+    expect((result[0].entity as any)?.standard_id).toBe(entity.standard_id);
+  });
 });
 
 // ── distributionEntities name branch: lines 902-906 ──────────────────────────

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-restricted-entity-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-restricted-entity-unit-test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Infrastructure stubs ─────────────────────────────────────────────────────
+// buildRestrictedEntity is a pure function, but middleware.ts pulls in a lot of
+// infrastructure at import time. Reuse the same stubs as the sibling
+// middleware-distribution-unit-test.ts to keep the import graph lightweight.
+
+vi.mock('../../../src/database/engine');
+vi.mock('../../../src/database/redis', () => ({ notify: vi.fn(), redisAddDeletions: vi.fn() }));
+vi.mock('../../../src/database/cache', () => ({
+  getEntitiesMapFromCache: vi.fn(),
+  getEntityFromCache: vi.fn(),
+}));
+vi.mock('../../../src/database/stream/stream-handler', () => ({
+  storeCreateEntityEvent: vi.fn(),
+  storeCreateRelationEvent: vi.fn(),
+  storeDeleteEvent: vi.fn(),
+  storeMergeEvent: vi.fn(),
+  storeUpdateEvent: vi.fn(),
+}));
+vi.mock('../../../src/database/file-search', () => ({
+  elUpdateRemovedFiles: vi.fn(),
+}));
+vi.mock('../../../src/listener/UserActionListener', () => ({
+  publishUserAction: vi.fn(),
+}));
+vi.mock('../../../src/config/conf', async () => {
+  const actual = await vi.importActual('../../../src/config/conf');
+  return {
+    ...(actual as object),
+    logApp: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    extendedErrors: false,
+    BUS_TOPICS: {},
+  };
+});
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { buildRestrictedEntity } from '../../../src/database/middleware';
+
+// ── Reproduction of GitHub issue #18026 ──────────────────────────────────────
+// https://github.com/OpenCTI-Platform/opencti/issues/18026
+//
+// When a Sector's created_by_ref (author Organization) is TLP-restricted for the
+// requesting user, pycti's get_stix_bundle_or_object_from_entity_id produces an
+// invalid STIX 2.1 bundle: the redacted author identity has id: "Restricted"
+// instead of a valid `identity--<uuid>` STIX id.
+//
+// The GraphQL "createdBy" resolver (batchInternalRels in
+// src/domain/stixCoreObject.js) returns buildRestrictedEntity(resolve) whenever
+// the user cannot access the author entity. pycti later maps this entity's
+// GraphQL "standard_id" field directly into the exported STIX object's "id"
+// (and into created_by_ref on the child entity), so standard_id must remain a
+// valid STIX identifier on the restricted entity.
+
+describe('buildRestrictedEntity (issue #18026)', () => {
+  const restrictedOrganization = {
+    id: '79d14387-751e-4608-9807-2e8ed9c8711b',
+    internal_id: '79d14387-751e-4608-9807-2e8ed9c8711b',
+    standard_id: 'identity--d4551de9-4b9c-570e-a51c-d3c321eb9a8d',
+    entity_type: 'Organization',
+    parent_types: ['Basic-Object', 'Stix-Object', 'Stix-Core-Object', 'Stix-Domain-Object', 'Identity'],
+    name: 'Restricted Corp',
+    description: 'A TLP-restricted organization',
+    x_opencti_organization_type: 'vendor',
+    representative: { main: 'Restricted Corp', secondary: '' },
+  };
+
+  it('keeps a valid STIX standard_id on the restricted entity', () => {
+    const restricted = buildRestrictedEntity(restrictedOrganization as any);
+
+    // This is the assertion that fails on the buggy implementation: standard_id
+    // gets genericized to the literal string 'Restricted', which is not a valid
+    // STIX 2.1 identifier and later ends up as created_by_ref / id in the bundle.
+    expect(restricted.standard_id).toBe(restrictedOrganization.standard_id);
+    expect(restricted.standard_id).toMatch(/^identity--[0-9a-f-]{36}$/);
+  });
+
+  it('still obfuscates sensitive attribute values', () => {
+    const restricted = buildRestrictedEntity(restrictedOrganization as any);
+
+    expect(restricted.name).toBe('Restricted');
+    expect((restricted as any).description).toBe('Restricted');
+    expect(restricted.representative).toEqual({ main: 'Restricted', secondary: 'Restricted' });
+  });
+
+  it('preserves identifying/queryable fields', () => {
+    const restricted = buildRestrictedEntity(restrictedOrganization as any);
+
+    expect(restricted.id).toBe(restrictedOrganization.internal_id);
+    expect(restricted.entity_type).toBe(restrictedOrganization.entity_type);
+    expect(restricted.parent_types).toEqual(restrictedOrganization.parent_types);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/stixCoreObject-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/stixCoreObject-test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as middleware from '../../../src/database/middleware';
+import * as middlewareLoader from '../../../src/database/middleware-loader';
 import * as fileStorage from '../../../src/database/file-storage';
 import * as access from '../../../src/utils/access';
 import * as draftContext from '../../../src/utils/draftContext';
 import * as identifier from '../../../src/schema/identifier';
 import * as masterLock from '../../../src/lock/master-lock';
 import * as entitySettingUtils from '../../../src/modules/entitySetting/entitySetting-utils';
-import { stixCoreObjectImportPush } from '../../../src/domain/stixCoreObject';
+import { batchInternalRels, stixCoreObjectImportPush } from '../../../src/domain/stixCoreObject';
 
 describe('stix core object domain import push', () => {
   beforeEach(() => {
@@ -62,5 +63,86 @@ describe('stix core object domain import push', () => {
     const uploadOptions = uploadSpy.mock.calls[0]?.[4] as { meta?: { fintel_template_id?: string } } | undefined;
     expect(uploadSpy.mock.calls[0][2]).toEqual('import/Report/report--1');
     expect(uploadOptions?.meta?.fintel_template_id).toBeUndefined();
+  });
+});
+
+describe('batchInternalRels', () => {
+  const mockContext = {} as never;
+  const mockUser = { id: 'user--1' } as never;
+
+  const author = {
+    id: 'org--internal-id',
+    internal_id: 'org--internal-id',
+    standard_id: 'identity--d4551de9-4b9c-570e-a51c-d3c321eb9a8d',
+    entity_type: 'Organization',
+    parent_types: ['Basic-Object', 'Stix-Object', 'Stix-Core-Object', 'Stix-Domain-Object', 'Identity'],
+    name: 'Secret Org',
+  };
+
+  const createdByDefinition = {
+    databaseName: 'rel_created-by.internal_id',
+    multiple: false,
+    toTypes: ['Organization'],
+  } as any;
+
+  const objectsDefinition = {
+    databaseName: 'rel_object.internal_id',
+    multiple: true,
+    toTypes: ['Organization'],
+  } as any;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the real author when the user has access', async () => {
+    vi.spyOn(middlewareLoader, 'internalFindByIds').mockResolvedValue({ [author.internal_id]: author } as never);
+    vi.spyOn(access, 'isUserCanAccessStoreElement').mockResolvedValue(true);
+
+    const element = { [createdByDefinition.databaseName]: author.internal_id };
+    const [result] = await batchInternalRels(mockContext, mockUser, [{ element, definition: createdByDefinition }]);
+
+    expect(result).toEqual(author);
+  });
+
+  it('returns a restricted author with a valid standard_id when access is denied', async () => {
+    vi.spyOn(middlewareLoader, 'internalFindByIds').mockResolvedValue({ [author.internal_id]: author } as never);
+    vi.spyOn(access, 'isUserCanAccessStoreElement').mockResolvedValue(false);
+
+    const element = { [createdByDefinition.databaseName]: author.internal_id };
+    const [result] = await batchInternalRels(mockContext, mockUser, [{ element, definition: createdByDefinition }]);
+
+    expect(result.name).toBe('Restricted');
+    // The regression from issue #18026: standard_id must stay the real STIX id,
+    // not the literal 'Restricted' string.
+    expect(result.standard_id).toBe(author.standard_id);
+  });
+
+  it('restricts individual entries within a multiple ref while keeping valid standard_ids', async () => {
+    const secondAuthor = {
+      ...author,
+      id: 'org--internal-id-2',
+      internal_id: 'org--internal-id-2',
+      standard_id: 'identity--2c3b6ef1-3e0d-5a3b-9a3a-7a7f5b0f6b2a',
+      name: 'Visible Org',
+    };
+    vi.spyOn(middlewareLoader, 'internalFindByIds').mockResolvedValue({
+      [author.internal_id]: author,
+      [secondAuthor.internal_id]: secondAuthor,
+    } as never);
+    vi.spyOn(access, 'isUserCanAccessStoreElement').mockImplementation(async (_ctx, _user, resolved: any) => {
+      return resolved.internal_id === secondAuthor.internal_id;
+    });
+
+    const element = { [objectsDefinition.databaseName]: [author.internal_id, secondAuthor.internal_id] };
+    const [result] = await batchInternalRels(mockContext, mockUser, [{ element, definition: objectsDefinition }]);
+
+    expect(result).toHaveLength(2);
+    const restricted = result.find((e: any) => e.id === author.internal_id) as any;
+    const visible = result.find((e: any) => e.internal_id === secondAuthor.internal_id);
+
+    expect(restricted.name).toBe('Restricted');
+    expect(restricted.standard_id).toBe(author.standard_id);
+    expect(visible).toEqual(secondAuthor);
   });
 });


### PR DESCRIPTION
### Proposed changes

* `buildRestrictedEntity` in `opencti-platform/opencti-graphql/src/database/middleware.ts` overwrote every string attribute of a restricted entity with the literal `"Restricted"`, including `standard_id`. This produced an invalid STIX identifier when the restricted entity was later exported (e.g. as `created_by_ref` in a STIX bundle).
* Fix: `standard_id` is now preserved on the restricted entity, alongside the already-preserved `id`, `entity_type`, and `parent_types`. All other attributes (`name`, `description`, `representative`, etc.) still resolve to `"Restricted"`.

### Related issues
* closes #18026

### How to test this PR

`cd opencti-platform/opencti-graphql && npx vitest --config vitest.config.ci-unit.ts run tests/01-unit/database/middleware-restricted-entity-unit-test.ts tests/01-unit/database/middleware-distribution-unit-test.ts tests/01-unit/domain/stixCoreObject-test.ts`

This runs:
* `middleware-restricted-entity-unit-test.ts` — direct unit test of `buildRestrictedEntity`, asserting `standard_id` stays a valid `identity--<uuid>`.
* `middleware-distribution-unit-test.ts` — added case for `convertAggregateDistributions`'s access-denied branch.
* `stixCoreObject-test.ts` — added cases for `batchInternalRels` (the GraphQL `createdBy` resolver), covering single-ref and mixed multi-ref access-denied scenarios.

All three fail against the pre-fix code (reproducing the issue) and pass after the fix.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Full unit suite (`vitest.config.ci-unit.ts`) run before/after: no regressions (2387/2389 tests pass, 2 skipped; 35 file-level failures pre-exist on the base branch, unrelated — caused by a missing `sanitize-html` package).
