### PR TITLE
fix(ux): Possibility to remove organizations sharing in tooltips (#18119)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
@@ -1,0 +1,28 @@
+import {AccountBalanceOutlined} from "@mui/icons-material";
+import Tag from "@common/tag/Tag";
+
+interface ItemOrganizationsProps {
+  organizationName: string;
+  organizationId: string;
+  removeOrganization: (id: string) => void;
+  disabled?: boolean;
+}
+
+const ItemOrganizations = ({
+  organizationName,
+  organizationId,
+  removeOrganization,
+  disabled,
+}: ItemOrganizationsProps) => {
+  return (
+    <Tag
+      label={organizationName}
+      onDelete={() => removeOrganization(organizationId)}
+      disabled={disabled}
+      icon={<AccountBalanceOutlined fontSize="small" />}
+      maxWidth={200}
+    />
+  );
+};
+
+export default ItemOrganizations;

--- a/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
@@ -1,5 +1,5 @@
-import {AccountBalanceOutlined} from "@mui/icons-material";
-import Tag from "@common/tag/Tag";
+import { AccountBalanceOutlined } from '@mui/icons-material';
+import Tag from '@common/tag/Tag';
 
 interface ItemOrganizationsProps {
   organizationName: string;

--- a/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemOrganizations.tsx
@@ -20,7 +20,7 @@ const ItemOrganizations = ({
       onDelete={() => removeOrganization(organizationId)}
       disabled={disabled}
       icon={<AccountBalanceOutlined fontSize="small" />}
-      maxWidth={200}
+      maxWidth={150}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -15,7 +15,7 @@ export interface TagProps {
   deleteTabIndex?: number;
   maxWidth?: number | string;
   icon?: React.ReactElement;
-  tooltipTitle?: string;
+  tooltipTitle?: React.ReactNode;
   disableTooltip?: boolean;
   labelTextTransform?: 'capitalize' | 'uppercase' | 'lowercase' | 'none';
   className?: string;

--- a/opencti-platform/opencti-front/src/components/common/tag/TagsOverflow.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/TagsOverflow.tsx
@@ -13,6 +13,7 @@ interface TagsOverflowProps<T> {
   children?: React.ReactNode;
   direction?: 'ltr' | 'rtl';
   onTagCounterClick?: () => void;
+  renderOverflowTooltip?: (hiddenItems: T[]) => React.ReactNode;
 }
 
 export function TagsOverflow<T>({
@@ -21,6 +22,7 @@ export function TagsOverflow<T>({
   getLabel,
   renderTag,
   onTagCounterClick,
+  renderOverflowTooltip,
   maxWidth = '100%',
   gapPx = 8,
   children,
@@ -42,9 +44,14 @@ export function TagsOverflow<T>({
   const displayItems = isRTL ? [...visibleItems].reverse() : visibleItems;
 
   const hiddenItems = (items as T[]).slice(visibleCount);
-  const tooltipTitle = getLabel
-    ? hiddenItems.map((item) => getLabel(item)).join(', ')
-    : undefined;
+  const renderDefaultOverflowTooltip = (items: T[]) => {
+    return getLabel
+      ? items.map((item) => getLabel(item)).join(', ')
+      : undefined;
+  };
+  const tooltipTitle = renderOverflowTooltip
+    ? renderOverflowTooltip(hiddenItems)
+    : renderDefaultOverflowTooltip(hiddenItems);
 
   return (
     <>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -7,7 +7,7 @@ import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { StixCoreObjectSharingListDeleteMutation } from './__generated__/StixCoreObjectSharingListDeleteMutation.graphql';
 import { StixCoreObjectSharingListFragment$key } from './__generated__/StixCoreObjectSharingListFragment.graphql';
 import TagsOverflow from '@common/tag/TagsOverflow';
-import ItemOrganizations from "src/components/ItemOrganizations";
+import ItemOrganizations from 'src/components/ItemOrganizations';
 
 const objectOrganizationFragment = graphql`
   fragment StixCoreObjectSharingListFragment on StixCoreObject {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -87,7 +87,17 @@ const StixCoreObjectSharingList = ({ data, disabled, inContainer, children }: St
         />
       )}
       renderOverflowTooltip={(hiddenOrganizations) => (
-        <Stack direction="column" gap={0.5} sx={{ p: 0.5 }}>
+        <Stack
+          direction="column"
+          gap={0.5}
+          sx={{
+            p: 0.5,
+            '& > span': {
+              width: '100%',
+              justifyContent: 'space-between',
+            },
+          }}
+        >
           {hiddenOrganizations.map((organization) => (
             <ItemOrganizations
               key={organization.id}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -1,13 +1,13 @@
 import { ReactNode, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Link } from 'react-router';
+import { Stack } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { StixCoreObjectSharingListDeleteMutation } from './__generated__/StixCoreObjectSharingListDeleteMutation.graphql';
 import { StixCoreObjectSharingListFragment$key } from './__generated__/StixCoreObjectSharingListFragment.graphql';
-import Tag from '@common/tag/Tag';
-import { AccountBalanceOutlined } from '@mui/icons-material';
 import TagsOverflow from '@common/tag/TagsOverflow';
+import ItemOrganizations from "src/components/ItemOrganizations";
 
 const objectOrganizationFragment = graphql`
   fragment StixCoreObjectSharingListFragment on StixCoreObject {
@@ -79,14 +79,25 @@ const StixCoreObjectSharingList = ({ data, disabled, inContainer, children }: St
       getKey={(organization) => organization.id}
       getLabel={(organization) => organization.name}
       renderTag={(organization) => (
-        <Tag
-          label={organization.name}
-          deleteLabel={`${t_i18n('Remove')} ${organization.name}`}
-          onDelete={() => removeOrganization(organization.id)}
+        <ItemOrganizations
+          organizationName={organization.name}
+          organizationId={organization.id}
+          removeOrganization={removeOrganization}
           disabled={disabled || disabledOrgs.includes(organization.id)}
-          icon={<AccountBalanceOutlined fontSize="small" />}
-          maxWidth={150}
         />
+      )}
+      renderOverflowTooltip={(hiddenOrganizations) => (
+        <Stack direction="column" gap={0.5} sx={{ p: 0.5 }}>
+          {hiddenOrganizations.map((organization) => (
+            <ItemOrganizations
+              key={organization.id}
+              organizationName={organization.name}
+              organizationId={organization.id}
+              removeOrganization={removeOrganization}
+              disabled={disabled || disabledOrgs.includes(organization.id)}
+            />
+          ))}
+        </Stack>
       )}
       direction="rtl"
     >


### PR DESCRIPTION
### Proposed changes
For an entity shared with organizations, if there are several organizations, the ones hidden in the '+ number_of_orga' should be removable via the tooltip : 

<img width="843" height="427" alt="image" src="https://github.com/user-attachments/assets/a1b7df41-6515-41c6-b935-17fa0321321d" />


### Related issues
closes #18119