### PR TITLE
docs(integrations): refresh built-in integration guides (#18153)

### DIFF
--- a/docs/docs/usage/form-intake.md
+++ b/docs/docs/usage/form-intake.md
@@ -1,303 +1,342 @@
-# Create knowledge via Form Intake
+# Create knowledge with Form intake
 
-
-The Form Intake allows administrators to design structured forms that analysts fill out to quickly create STIX entities, relationships, and observables ready for knowledge ingestion — without navigating complex creation dialogs.
+Form intake lets administrators design structured forms that analysts can submit to create STIX entities, cyber observables, and relationships. It provides a guided alternative to individual creation dialogs and can send submissions either directly to the knowledge base or to a draft for review.
 
 ## Key features
 
-- Visual form designer with field configuration and reordering of 16 supported field types (text, date, select, toggle, lookup, vocabulary, etc.)
-- Field width control (full, half, third)
-- 4 entity creation modes: Single, Multiple, Parsed, and Lookup
-- Add additional entities and relationships in a single form
-- Generate STIX bundle from submissions
-- Export/import form definitions across instances (JSON)
-- Draft workspace integration
+- Build forms from entity attributes and reorder the displayed fields.
+- Create one or several instances of the main entity.
+- Select existing entities or allow users to create them from lookup fields.
+- Parse comma-separated or line-separated values for bulk creation.
+- Add optional or required additional entities and relationships.
+- Set default, required, or read-only field values.
+- Create Indicators from observables or observables from Indicators.
+- Create submissions in a draft and preconfigure draft metadata and access.
+- Duplicate forms and export or import their JSON configuration.
 
-## Prerequisites & Permissions
-More details on our [Role-Based access control here](../administration/users.md)
+## Permissions
 
-|Action |Details |Required Capability| Control of capabilities in Draft mode (EE) |
-|:------|:-------|:---------------------|---------------|
-|Manage form intakes|Create, edit, delete, activate/deactivate, export, import|Manage ingestion|Capability not existing|
-|Submit form intakes|Fill and submit forms|Create / Update knowledge| Create / Update knowledge (creation forced to draft)|
-|View form intakes list| |Manage ingestion or Create / Update knowledge|Create / Update knowledge (creation forced to draft)|
+For more information about capabilities, see [Roles and capabilities](../administration/users.md).
 
+| Action | Required capability |
+| --- | --- |
+| Create, update, duplicate, activate, deactivate, import, export, or delete a form | **Manage ingestion** |
+| Submit directly to the knowledge base | **Create / Update knowledge** |
+| Submit to a draft | A compatible knowledge capability in draft mode; users restricted to draft creation cannot disable draft mode |
+| View available forms | **Create / Update knowledge**, **Import knowledge**, or an applicable draft capability |
 
-When draft creation is enforced, form submissions create entities in a draft workspace for review before publication to knowledge.
-Administrators can optionally allow users to skip draft mode per submission.
-The form intake Authorize Members choice is hidden when the user does not have 'Authorized Members update' rights in draft context. See [Override of capabilities in draft](https://docs.opencti.io/latest/administration/users/?h=capab#override-of-capabilities-in-draft) for details on controlling users capabilities in draft mode.
+When draft creation is enforced by the form or by the user's capabilities, the submission creates a draft for review before ingestion.
 
+The **Authorized Members** setting is available only to users who can manage authorized members in the applicable draft context. See [Control of capabilities in Draft mode](../administration/users.md#control-of-capabilities-in-draft-mode).
 
-# Defining a Form Intake
-To create a form intake, navigate to the Ingestion menu, Form intake menu and click Create.
+## Create a form
 
-You can set core detail fields: 
+1. Go to **Integrations > Available**.
+2. Select the **Built-in ingestion** category.
+3. Find **Form intake**, then select **Create**.
+4. Enter a name and description.
+5. Leave **Active** enabled to make the form available for submission.
+6. Configure the main entity, additional entities, relationships, and draft behavior.
+7. Select **Create**.
 
-- Name of your form intake
-- Description of the form intake 
-- Active (toggle on/off, default to on): when enabled, your form will be present in the form intake list.
+Created forms appear under **Integrations > Deployed**. Select a form there to open and submit it.
 
+## Configure the main entity
 
-## Draft and form intake
+The main entity determines:
 
-### Creation of a draft by default 
+- The primary entity created or selected by the form.
+- The entity list pages from which users can open the form.
+- Whether additional entities can be included in a container.
 
-When defining a new form intake, you can decide whether the Form Intake output will create a draft or not by toggling the option: **Create as draft by default**. If this option is enabled, you can then choose to **Allow users to uncheck draft mode**.
+The default main entity type is **Report**. You can select any supported STIX Domain Object, STIX Cyber Observable, or STIX Meta Object. OpenCTI automatically adds attributes that are mandatory for the selected entity type.
 
-This has been built to offer advanced users the option to directly submit their input to the main database instead of a draft.
+### Choose an entity entry mode
 
-### Creation of a draft by default if user only has the capability to create data in draft
+Configure the main entity with one of the following approaches:
 
-However, if your user is only able to create data via draft, due to the [user's specific draft capabilities (enterprise edition)](../administration/users.md) then the user will not be able to untick the box.
-By default, the form intake will be accessible to the user and the form intake output will result in a draft creation.
+| Configuration | Result |
+| --- | --- |
+| Single instance | The user completes one set of entity fields. |
+| **Allow multiple instances of main entity** with **Multiple fields** | The user can add and complete several field groups. |
+| **Allow multiple instances of main entity** with **Parsed values** | The user enters comma-separated values or one value per line. |
+| **Entity lookup (select existing entities)** | The user selects one or more existing entities instead of completing entity fields. |
 
-### Advanced draft settings
+When lookup is enabled, users can create an entity from the lookup if they have the required creation capability. Enable **Disable on-the-fly entity creation** to restrict the field to existing entities only. An entity created from a lookup is submitted with the form, so it is created in the same draft when draft mode is used.
 
-This section in the form intake is dedicated to control the parameters linked to the draft creation. 
-You can control fields default values & allow (or not) users to edit them:
+### Configure parsed values
 
-- Draft name: you can define a default value and allow users to edit it.
-- Draft description: you can define a default value for draft description and allow users to edit it.
-- Draft Assignee: you can define default assignees for your draft and allow users to edit them.
-- Draft Participant: you can define default participants and allow participants to edit them.
-- Draft author: Draft author is a bit specific, since it offers you 3 choices. You can either **reuse the main entity author**, **specify a specific author** or **do not apply default value**. Please be aware that when applying specific author, the user may not have access to this author due to RBAC (which should show as "restricted" on the main draft page).
-- Apply Authorize Members: you can activate the restriction. Doing so, then you can apply some specific authorized members on the **draft itself**. Some authorized members are a bit specific, the ones indicated as "Dynamic form draft".
+Parsed mode is available when multiple instances are enabled. Configure:
 
-##### Authorized members dynamic from draft
+- **Parse Field Type**: use a single-line text field or text area.
+- **Parse Mode**: separate values with commas or, for a text area, enter one value per line.
+- **Map parsed values to attribute**: select the string attribute that receives each parsed value.
+- **Automatically convert to STIX patterns**: for Indicators, convert submitted observable values to STIX patterns.
 
-Some specific authorized members have been introduced, to allow you to have a dynamic approach: 
+Additional fields in parsed mode apply to every entity created from the parsed values. For example, if values map to a Report name and the form also contains a description, every generated Report receives the same description.
 
-- draft author (org) allows you to select the entity being the Author of the Draft. If this entity happens to be an organization, then you can also select an intersection with a group. **This allows you to perform the following use case: I want users part of the group analyst pertaining to the organisation that submitted the draft to be able to edit the draft, while users from the organisation that submitted the draft but are not analysts are in view only.** 
-- creator: allows you to directly apply some rights to the draft creator.
-- assignee: allows you to directly apply some rights to the draft assignees.
-- participant: allows you to directly apply some rights to the draft participants.
+### Include entities in a container
 
-### Configuration issues
+For a container main entity, enable **Include entities in container** to include additional entities in the container.
 
-#### Default and mandatory values between form intake & draft in entity/customization
+If the form creates several containers, each container contains the additional entities. Containers are processed sequentially, so later containers can also contain containers created earlier in the submission.
 
-Any default value or mandatory value set at the form intake level will override any default value or mandatory values set in entity/customization for drafts. 
+### Create Indicators and observables automatically
 
-The rationale behind this approach is that a form intake should provide an expected output which is decided by the admin. As a result, the conditions defined in the form intake will apply. 
+For Indicator and observable forms, you can enable:
 
-### Provide "Can manage" to a user not having the "Manage Authorized Members capability"
+- **Automatically create observables from indicators**
+- **Automatically create indicators from observables**
 
-A user which is granted the "can manage" capability via authorized members but who does not have the capability "manage authorized members" provided via its role will not be able to manage the authorized members on a draft.
+Enable only the direction required by the form to avoid unnecessary circular creation.
 
+## Configure entity fields
 
+For every main or additional entity field, configure:
 
-## Main entity definition
-Defining a main entity sets two variables: 
+- **Map to attribute**: the entity attribute populated by the field.
+- **Field Type**: a compatible input for the selected attribute.
+- **Field Label**: the label shown to users.
+- **Description**: guidance displayed with the field.
+- **Required**: whether the user must provide a value.
+- **Read only** and **Default value**: provide a value that users cannot change.
+- **Field width**: full, half, or one-third of the form width.
 
-- The entity view where the form intake will be available, this is in addition to the import menu. E.g. if your main entity is a Report, you will see your form intake in the Report List view.
-- Which entity you want to create first, this is especially useful for a container entity.
+Mandatory entity attributes cannot normally be removed. In parsed mode, the parsed attribute supplies the deduplication value, and the form can apply other configured fields to all generated entities.
 
-By default, the main entity selected is a **Report**.
+Supported field types include:
 
-### Common fields
+| Field type | Usage |
+| --- | --- |
+| Text | Single-line string input |
+| Text Area | Multi-line string, Markdown, or text input |
+| Number | Numeric, integer, or floating-point input |
+| Date & Time | Date and time input |
+| Checkbox / Toggle | Boolean input |
+| Select / Multi-Select | One or several predefined values |
+| Open Vocabulary | Values from the OpenCTI vocabulary mapped to the attribute |
+| Created By | Author identity |
+| Object Marking | Marking definitions such as TLP or PAP |
+| Object Label | Labels applied to created entities |
+| External References | Existing external references |
+| Files | File attachments, with optional multiple-file support |
 
-For each main entity, you can configure multiple fields: 
+!!! warning
 
-- **Entity Lookup** (disabled by default): if enabled, users will be forced to choose from existing entities. Another field will appear when you enable this field: **Disable on-the-fly entity creation**
-- **Disable on-the-fly entity creation** (disabled by default): Enable this If you want your users to only select an existing entity. 
-- **Allow multiple instancess of main entity** (disabled by default): Enable this if you want to allow your users to be able to enter the same entity multiple times.  When enabled **multiple instancess mode** will appear. 
+    A required or mandatory attribute must have either a user-provided value or a configured default value. Otherwise, the form cannot create the entity.
 
-#### Multiple Mode for Main Entity
-When enabled multiple instancess of the same entity type can be created. 
-You can choose between 'Multiple fields' or 'Parsed values'.
+## Configure additional entities
 
-   - **Multiple fields** (default): users are presented with a button to create a new instance of the same type of entity.
-   - Parsed values: users can enter text to be parsed by selected delimiter.
+Use the **Additional Entities** tab to add other entities to the same submission. For each entity:
 
-In parsed value mode, additional options are offered to you: 
+1. Select its entity type.
+2. Set **Label for entities** to provide a user-friendly role, such as `Attacker`.
+3. Choose single, multiple, parsed, or lookup behavior.
+4. Configure its fields.
 
-- Parse field type: Text or Text Area. 
-- Parse mode: choose the delimiter between each value comma-separated (default) or one-per-line.
-- Map parsed values to attribute: choose the attribute the parsed text is mapped to.
+For a single entity, enable **Required** to require it. An optional additional entity is omitted when the user leaves all its fields empty. If any field is completed, its required attributes must also be provided.
 
-**Warning**: when creating multiple instances via parsed values, the other fields defined for that entity type will be applied consistently to all the instances you create. For example, when generating multiple reports from parsed values, the text is mapped to each report’s name attribute. If you also provide a description field, all generated reports will have the same description.
+For multiple entities, **Minimum amount** controls how many entries are required. Set it to `0` to make the entire entity group optional.
 
-### Supported Entity Types as main entity
-Any entity can be created as a main entity, whether it is a STIX Domain Object or a STIX Cyber Observable. 
+Lookup and parsed behavior works the same way as for the main entity, including on-the-fly creation and additional fields shared by parsed entities.
 
-By default, when selecting an entity type, the mandatory fields needed for [deduplication](deduplication.md) are automatically added. 
+## Configure relationships
 
-#### Main entity as a container
+The **Relationships** tab becomes available after you add an additional entity.
 
-If your main entity is a container, any additional entities created will be contained in your container.
-**warning** If several containers are created at once (via multiple mode enabled), any additional entities created will appear in each container. 
+For each relationship:
 
-#### Main entity as an IOC or an Observable
-If you want to allow your users to bulk create multiple IOCs or observables, you can setup a form intake that allows multiple entities to be created at once using the option **Automatically create indicators/observables from observables/indicators**.
+1. Select the source entity and target entity by their configured labels.
+2. Select a compatible relationship type.
+3. Enable **Required** to create the relationship automatically for matching source and target instances.
+4. Optionally add fields for the relationship.
 
+Relationship fields can populate description, confidence, status, start time, stop time, author, markings, and labels, depending on the selected field type.
 
-- **Automatically create indicators/observables from observables/indicators**: this directly creates the entities added by the user.
+Users do not manually add relationships while completing the form. Only relationships enabled as **Required** are created on submission.
 
+## Configure draft creation
 
-**Warning**: Containers are created sequentially, not all at once. This means the first container will include only the additional entities. Each subsequent container will also include the containers that were created before it.
+Enable **Create as draft by default** to send submissions to a draft. Enable **Allow users to uncheck draft mode** if users with sufficient capabilities may submit directly to the knowledge base.
 
+Users whose capabilities restrict them to draft creation cannot disable draft mode, even when the form allows an override.
 
-### Specify fields for each entity type 
+### Set draft defaults
 
-When you have added an entity type to be created in the form, you can then set the entity attributes to populate.
+Expand **Advanced Draft Settings** to configure:
 
-Options for each field: 
+| Draft field | Available configuration |
+| --- | --- |
+| Name | Default value, editable by user, required |
+| Description | Default value, editable by user, required |
+| Assignees | Default users, editable by user, required |
+| Participants | Default users, editable by user, required |
+| Author | No default, reuse the main entity author, or select a specific author; editable by user; required |
+| Authorized Members | Activate access restriction, set defaults, and allow editing |
 
-- Map to attribute: choose the attribute of the entity that you need your users to provide (for instance, description).
-- Field label: name your field with a custom label so that if your users are not acquainted with STIX 2.1 they will be able to understand what is expected for them.
-- Required: make the field required. Enable this if the users need to enter this field. 
-- Field width: size of the field on the screen (Full/half/third)
+Form-level defaults and requirements take precedence over draft entity customization. This ensures that a form produces the draft structure selected by its administrator.
 
-We support the following field types: 
+The draft author and authorized members remain subject to role-based access control (RBAC). A selected identity that the submitter cannot access can appear as restricted in the draft.
 
-|Field | Type |	Description|
-|:-----|:-----|:-----------|
-|Text |	Single-line |text input|
-|Text Area	|Multi-line text input|
-|Number	|Numeric input|
-|Date & Time|	Date and time picker|
-|Checkbox	|Boolean checkbox|
-|Toggle	|Boolean| on/off switch (respects defaultValue — e.g., Malware is_family)|
-|Select	|Single-value| dropdown with predefined options|
-|Multi-select|	Multi-value dropdown|
-|Open Vocabulary|	|Vocabulary-based field with predefined values from OpenCTI vocabularies (auto-detected based on entity type and attribute)|
-|Created By|	|Set the author/creator identity|
-|Object Marking	||Apply marking definitions (TLP, PAP)|
-|Object Label	||Apply labels to created entities|
-|External References|	|Add external references|
-|Files	| |Attach files|
+### Use dynamic authorized members
 
-**Warning:** If you have defined additional mandatory fields for an entity (e.g. description) and your description is not added, your entity will not be created. 
+Authorized members can include dynamic values resolved when the draft is created:
 
-## Additional entities definition
+- **Creators**: the user who submitted the form.
+- **Draft author (org)**: the draft author's organization, optionally intersected with a group.
+- **Assignees**: the draft assignees.
+- **Participants**: the draft participants.
 
-Once you have defined your main entity, you can define additional entities to allow your users to add additional entities within the same form submission. 
+Assign the required access right to each member. A user who receives **Can manage** on the draft but lacks the **Manage authorized members** capability still cannot change its authorized members.
 
-Additional entities can be created of the same type. 
+If a [draft workflow](draft-workflow.md) is published, the draft created by the form uses that workflow like any other draft.
 
-### Details of required / not required and display labels for additional entities: 
+## Submit a form
 
-In addition to the various modes allowed to add additional entities, you have two other options: 
+Users can open active forms from:
 
-- If you enable the option **"allow multiple instancess"**, then you can specify that this entity is optional by entering 0 in the minimum amount field. This means that you do not require an entity to be created.
-- If you disable the option **"allow multiple instancess"**, then another option is offered to you: **required**. This means that the entity must be provided to submit the form.
+- **Integrations > Deployed**, by selecting the form.
+- A supported entity list page that matches the form's main entity type.
+- The file import dialog, by selecting **Import using a Form**.
 
-The display **label for entity** allows you to set labels so that users who aren't experts in STIX 2.1 can  use the form. For example you can set a label to "attacker" to use in place of intrusion set.
+The form action is hidden when the user lacks the capability required to submit it.
 
-## Relationships 
+On submission, OpenCTI:
 
-You can define relationships to be created between entities created in the form. The **relationship type** will only present compatible entities.
+1. Validates required values and entity attributes.
+2. Validates observable syntax and restores defanged values such as `hxxp://` and `[.]`.
+3. Resolves existing entities and prepares entities created from lookup fields.
+4. Maps identity classes and creates the configured STIX objects.
+5. Creates configured relationships and container references.
+6. Creates any requested Indicators or observables.
+7. Sends the STIX bundle for ingestion, either directly or through the created draft.
 
-When you add a relation, you need to choose: 
+## Manage form definitions
 
-- the Source entity (identified in the form by its label)
-- the Target entity (identified in the form by its label)
-- the relationship type (select as soon as Source & Target are provided)
-- Required: toggling the required switch will allow you to automatically create each relation. 
+Open the action menu for a deployed Form intake to:
 
-**Warning**: adding some relations in the form definition will not allow users to create the relation manually in the form. You need to toggle the **required** field to create the relation automatically at form submission. This means that any entities matching as source & targets will have a relation created between them.
+- **Update** its definition or activation state.
+- **Duplicate** it as the starting point for another form.
+- **Export** its complete JSON configuration.
+- **Delete** the form definition.
 
+Exported configurations contain the form schema and settings, but not previously submitted data. Import a JSON configuration from the **Form intake** card under **Integrations > Available**. Verify version compatibility before importing a form exported from another OpenCTI instance.
 
+Deleting a form does not delete entities or relationships created by earlier submissions.
 
-## Places to submit a form intake: 
+## GraphQL API reference
 
-Forms can be submitted from three locations:
+### Get a form
 
-- Entity list pages — Click the form intake toggle button (available on: Reports, Groupings, Malware, Case Incidents, Case RFIs, Case RFTs, Incidents, Campaigns, Intrusion Sets, Threat Actors Group, Threat Actors Individual, Indicators).
-- Import dialog — Select "Import using a Form" in the import file dialog (displays full-width).
-- Ingestion/form intake: when you click directly on the form intake you created, the form is prompted to you.
-
-Note: The form intake button is hidden if the user does not have Create/update capabilities.
-
-## Submission process
-When a form is submitted, the following 7-step pipeline executes:
-
-- Validate required fields
-- 	Validate observable syntax	Backend checks format for observable entities (IPv4, IPv6, Domain, URL, Email, hashes). Invalid values throw INCORRECT_OBSERVABLE_FORMAT error.
-- 	De-sanitize/defang observables	Converts defanged IOCs: hxxp:// → http://, test[.]com → test.com
-- 	Map identity classes	Ensures correct STIX identity_class for Identity types: Individual → individual, Sector → class, System → system
-- 	Generate STIX bundle
-- 	Auto-create indicators/observables
-- 	Import bundle	Imports into OpenCTI directly, or into a draft workspace if draft mode is enabled
-
-## Export
-Export a form definition as a JSON file via the options (kebab) menu → Export.
-Includes the full schema, field configuration, entity types, and relationships.
-Use for backup or cross-instance sharing.
-Does not export previously submitted data.
-
-## Import
-Import a form definition from a JSON file via the Form Intake list page.
-The import dialog displays full-width for readability.
-Cross-instance compatible — share form templates between OpenCTI instances (version ≥ 6.8.1).
-Note: Verify version compatibility when importing across different OpenCTI versions.
-
-## Delete
-Delete via the options (kebab) menu → Delete. Deletion is permanent and cannot be undone.
-Previously submitted data (entities, relationships already created) is not affected — only the form definition is removed.
-
-
-## GraphQL API Reference
-
-### Get a single form by ID
-`query GetForm($id: String!) {
+```graphql
+query GetForm($id: ID!) {
   form(id: $id) {
     id
     name
     description
-    entity_type
-    schema
+    active
+    form_schema
     created_at
     updated_at
   }
-}`
+}
+```
 
-### List all forms with filtering and search
-`query ListForms($first: Int, $search: String, $orderBy: FormOrdering, $orderMode: OrderingMode) {
-  forms(first: $first, search: $search, orderBy: $orderBy, orderMode: $orderMode) {
+### List forms
+
+```graphql
+query ListForms(
+  $first: Int
+  $search: String
+  $orderBy: FormsOrdering
+  $orderMode: OrderingMode
+) {
+  forms(
+    first: $first
+    search: $search
+    orderBy: $orderBy
+    orderMode: $orderMode
+  ) {
     edges {
       node {
         id
         name
         description
-        entity_type
+        active
+        form_schema
       }
     }
   }
-}` 
+}
+```
 
-### Create a new form
-`mutation CreateForm($input: FormAddInput!) {
+### Create a form
+
+The `form_schema` value is a JSON-encoded string.
+
+```graphql
+mutation CreateForm($input: FormAddInput!) {
   formAdd(input: $input) {
     id
     name
+    active
   }
-}`
+}
+```
 
+### Update a form
 
-### Delete a form
-`mutation DeleteForm($id: ID!) {
-  formDelete(id: $id)
-}`
-
-### Submit a filled form
-`mutation SubmitForm($id: ID!, $input: FormSubmitInput!) {
-  formSubmit(id: $id, input: $input) {
+```graphql
+mutation UpdateForm($id: ID!, $input: [EditInput!]!) {
+  formFieldPatch(id: $id, input: $input) {
     id
+    name
+    active
+    form_schema
   }
-}`
+}
+```
 
-## Best Practices
+### Submit a form
 
-### Form Design
+The `values` property in `FormSubmissionInput` is a JSON-encoded string containing the completed form values.
 
-- Start simple: Begin with essential fields and iterate based on analyst feedback.
-- Use Parsed mode for bulk IOCs: Comma or line-separated input is the fastest approach for high-volume observable ingestion.
-- Set field widths strategically: Use third for short fields (dates, scores, markings), full for text areas.
-- Mark only truly essential fields as required - reduces friction for analysts while maintaining data quality.
+```graphql
+mutation SubmitForm(
+  $input: FormSubmissionInput!
+  $isDraft: Boolean!
+) {
+  formSubmit(input: $input, isDraft: $isDraft) {
+    success
+    bundleId
+    message
+    entityId
+  }
+}
+```
 
-### Data Ingestion
+### Import and export a form
 
-- Enable auto-create indicators from observables for actionable intelligence and detection pipeline integration.
-- Do not enable both auto-create directions simultaneously (indicator → observable AND observable → indicator) to avoid circular creation loops.
-- Use draft mode for high-volume ingestion to allow review before publication (Enterprise Edition).
+```graphql
+mutation ImportForm($file: Upload!) {
+  formImport(file: $file) {
+    id
+    name
+  }
+}
+
+query ExportForm($id: ID!) {
+  form(id: $id) {
+    toConfigurationExport
+  }
+}
+```
+
+## Best practices
+
+- Start with the minimum fields required for deduplication and analysis.
+- Use explicit labels and descriptions for users who do not work directly with STIX concepts.
+- Use parsed mode for bulk observable or Indicator creation.
+- Use lookup mode when the form should connect new information to existing knowledge.
+- Use read-only defaults for values that must remain consistent across submissions.
+- Use draft mode when submissions require review, access control, or workflow approval.

--- a/docs/docs/usage/import/csv-feed.md
+++ b/docs/docs/usage/import/csv-feed.md
@@ -1,113 +1,141 @@
 # CSV Feeds
 
-CSV feed ingester enables users to import CSV files exposed on URLs.
+CSV Feeds periodically retrieve a CSV file from a URL and convert its rows to STIX objects with a CSV mapper. Use them for sources that publish structured data as a regularly updated file.
 
-<a id="best-practices-section"></a>
-## Best practices
+## Prerequisites and permissions
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides Service accounts with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and JSON/CSV Feeds.
+Creating and managing CSV Feeds requires **Manage ingestion**. Prepare either an existing [CSV mapper](../../administration/csv-mappers.md) or the information needed to build an inline mapper.
 
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
+Automatic service-account creation requires a default ingestion group under **Settings > Accesses > Policies**.
 
-1. Create a dedicated Service account for each source: Generate a technical user (or Service account) specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the Service account to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
+## Create a CSV Feed
 
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated service account and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
-
-Under Settings > Policies, you can now define a default group for the ingestion user, allowing you to create a specific Service accounts when setting up the CSV Feed.
-
-![Select default group in settings](../assets/settings_default_group.png)
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **CSV Feed**.
+3. Select **Create**.
+4. Enter a name, CSV URL, and polling schedule.
+5. Select an existing mapper or configure an inline mapper.
+6. Configure authentication, SSL verification, markings, and the service account.
+7. Select **Verify** to test the URL and mapper.
+8. After a successful test, select **Create**, then start the feed from **Integrations > Deployed**.
 
 ## Configuration
 
-Here's a step-by-step guide to configure Csv Feeds:
+| Setting | Description |
+| --- | --- |
+| Name | Required name displayed for the integration. |
+| Description | Optional purpose or source information. |
+| Schedule period | Platform default of approximately 30 seconds, or 5, 15, or 30 minutes; 1, 6, or 12 hours; or 24 hours. The initial value is 1 hour. |
+| CSV URL | Required URL of the CSV file. |
+| Existing csv mappers | Select an existing mapper instead of defining one inline. |
+| Marking definition levels | Markings used when the mapper allows the ingestion user to choose them. |
+| Authentication type | None, Basic, bearer token, or client certificate. |
+| Verify SSL certificate | Validates the source certificate. |
 
-1. CSV URL: Provide the URL of the CSV file exposed from which items will be imported.
-2. Configure Your CSV Mapper
-    1. Create a CSV mapper on the fly by clicking "Inline CSV Mapper."
-    2. Select the CSV mapper you want to use for data import.
-3. Authentication Type (if required): Specify the authentication method to be used.
-4. Scheduling Interval: Choose how often the feed should run. By default, this is set to 1 hour.
+Authentication fields depend on the selected mode:
 
-!!! note "CSV mapper"
+| Mode | Required values |
+| --- | --- |
+| None | No credentials |
+| Basic | Username and password |
+| Bearer token | Token |
+| Client certificate | Base64-encoded certificate, private key, and certificate authority certificate |
 
-    CSV feed functionality is based on CSV mappers. It is necessary to create the appropriate CSV mapper to import the data contained in the file. See the page dedicated to the [CSV mapper](../../administration/csv-mappers.md).
+## Configure the service account
 
-Additional configuration options:
+CSV Feed creation defaults to a service account named `[F] <feed name>` with confidence level `50`. Disable **Automatically create a service account** to select an existing account.
 
-- Service account responsible for data creation: Define the Service account responsible for creating data received from this CSV feed. Best practice is to dedicate one Service account per source for organizational clarity by clicking on "Automatically create a service account". The name is not editable (unless you change the feed's name) but you must define a confidence level (between 0 and 100) to set this confidence to the Service account that will be automatically created. _Important_ : before clicking on "Automatically create a service account" you must define a default group for ingestion users, in the Settings part.
-- Description
+The account's default markings can be applied through the mapper. If the mapper instead lets the ingestion user choose markings, configure **Marking definition levels** in the feed.
 
-![csv-feeds-creation.png](../assets/csv-feeds-creation.png)
+## Configure the CSV mapper
 
-In CSV Mappers, if you created a representative for Marking definition, you could have chosen between 2 options:
+Enable **Existing csv mappers** to select a platform mapper. Disable it to use the **Inline csv mapper** tab.
 
-- Use default marking definitions of the user by default on creation
-- Let the user choose marking definitions
+An inline mapper can configure:
 
-![CSV feeds creation: CSV mapper test](../assets/csv-feeds-create-after-test.png)
-![CSV feeds creation: CSV mapper test Inline CSV Mapper](../assets/csv-feeds-create-inline-mappers.png)
+- Whether the CSV contains headers.
+- Comma, semicolon, or pipe as the separator.
+- A one-character line escape.
+- Entity representations and their attribute mappings.
+- Relationship representations between mapped entities.
 
-To finalize the creation, click on "Verify" to run a check on the submitted URL with the selected CSV mapper. A valid URL-CSV mapper combination results in the identification of up to 50 entities.
+See [CSV mappers](../../administration/csv-mappers.md) for mapping concepts and supported representations.
 
+![CSV Feed inline mapper](../assets/csv-feeds-create-inline-mappers.png)
 
-![CSV feeds creation: list](../assets/csv-feeds-creation-list.png)
+## Verify the feed
 
-To start your new ingester, click on "Start", in the burger menu.
+Verification retrieves and maps the first 10 CSV lines. The result displays:
 
-![CSV feeds creation: start](../assets/csv-feeds-creation-start.png)
-CSV feed ingestion is made possible thanks to the connector "ImportCSV". So you can track the progress in "Integrations > Deployed". On a regular basis, the ingestion is updated when new data is added to the CSV feed.
+- The number of mapped entities and relationships.
+- The generated STIX objects as JSON.
+- Mapping or source errors that must be corrected.
 
-![CSV feeds creation: connectors](../assets/csv-feeds-connectors.png)
+The feed can be created only when verification returns at least one entity. Updating, duplicating, or importing a feed also requires successful verification.
 
-![CSV feeds creation: tracking](../assets/csv-feeds-importCSV-connector-tracking.png)
+![CSV Feed creation](../assets/csv-feeds-creation.png)
 
-## Duplicate a CSV feed ingester
+![CSV Feed verification result](../assets/csv-feeds-create-after-test.png)
 
-If you need to modify your previous configuration which is already activated, we recommend to duplicate the CSV feed using the duplicate option in the burger button.
+## Manage and monitor a CSV Feed
 
-![CSV feeds duplicate: duplicate](../assets/csv-feeds-burger-button.png)
+The detail action menu provides:
 
-As you see, when you duplicate the CSV feed, the fields are pre-filled but you can change any of them. We advice you to keep the name with '-copy' to signify the origin of the duplicate feed.
+- **Start** and **Stop**
+- **Update**
+- **Duplicate**
+- **Export**
+- **Reset state**
+- **Delete**
 
-![CSV feeds duplication form: duplicate](../assets/csv-feeds-duplicate.png)
-As you see previously, you need to verify your CSV configuration before validating your form. Finally, you need to click on start to launch your new ingester.
+![CSV Feed detail action menu](../assets/csv-feeds-burger-button.png)
 
-![CSV feeds duplication form: duplicate](../assets/feeds-start-duplicate.png)
+Duplication creates a prefilled `<name> - copy` configuration, including its mapper. Verify the duplicate before creating it.
 
-## Export a CSV feed
+![CSV Feed duplication form](../assets/csv-feeds-duplicate.png)
 
-You can export your existing CSV feed from the platform, making it easy to share your configuration with others.
+![Starting a duplicated CSV Feed](../assets/feeds-start-duplicate.png)
 
-To export your ingester, click on "Export", in the burger menu.
-![CSV feed export](../assets/csv-feeds-export.png)
+Reset state restarts ingestion from the beginning of the source. Use it carefully because previously processed rows can be evaluated again.
 
-Note: When exporting a CSV feed linked to a CSV Mapper ID, the configuration will be inlined directly within the file. This means that when you import it again, it will appear under the "Inline CSV Mapper" tabs.
+The detail page provides **Overview** and **Works**. When ingestion-feed logs are enabled, **Logs** displays timestamp, severity, message, and expandable or copyable metadata.
 
-## Import a CSV feed ingester
+The CSV Feed's technical connector is represented inside the feed detail and is not listed as a separate deployed connector.
 
-If you have a JSON CSV feed file you can import it by clicking on the icon next to "Import from hub"
-![CSV feed import button](../assets/csv-feeds-import-icon.png)
+![CSV Feed in Deployed integrations](../assets/csv-feeds-creation-list.png)
 
-When you click, you can select the desired file. After that, a drawer will open with the form pre-filled with the relevant information.
-If necessary, configure the authentication type. By default, a user is already provided.
+![Starting a CSV Feed](../assets/csv-feeds-creation-start.png)
 
-![CSV feed import drawer](../assets/csv-feeds-import.png)
+![CSV Feed technical connector activity](../assets/csv-feeds-connectors.png)
 
-As you see previously, you need to verify your CSV configuration before validating your form. Finally, you need to click on start to launch your new ingester.
+![CSV Feed Works and ingestion tracking](../assets/csv-feeds-importCSV-connector-tracking.png)
 
+## Import and export
 
-You can select CSV Feeds from the XTM Hub by clicking the ```Import from Hub``` button
+Export downloads a JSON configuration. If the feed references a platform CSV mapper, its mapper configuration is embedded in the file so it can be recreated on another platform.
 
-#### One-click CSV Feed deployment
+![CSV Feed export action](../assets/csv-feeds-export.png)
 
-From the XTM Hub, you can effortlessly deploy your desired CSV Feed with just a single click.
-To get started, simply register your OpenCTI platform following the instructions in our [OpenCTI registration documentation](../../administration/hub.md).
-Next, navigate to your preferred CSV Feed and click the ```Deploy in OpenCTI``` button located in the top right corner.
-If you have multiple OpenCTI platforms registered, choose the platform where you wish to deploy the CSV Feed.
-You will then be redirected to the OpenCTI platform, where the process will proceed automatically.
-Within a few seconds, you'll be directed to your newly created CSV Feed.
+To import:
 
-_Make sure you have the capability to create a CSV Feed on OpenCTI_
+1. Open **Integrations > Available** and find **CSV Feed**.
+2. Select the file-import action and choose the JSON file.
+3. Review authentication, markings, schedule, and the embedded mapper.
+4. Choose or create the local service account.
+5. Verify, create, and start the feed.
 
-![1Click CSV Feed button](../assets/one-click-deploy.png)
+![CSV Feed configuration import action](../assets/csv-feeds-import-icon.png)
+
+![Imported CSV Feed configuration](../assets/csv-feeds-import.png)
+
+When XTM Hub is configured and accessible, the card also displays **Import from Hub**. Hub deployment downloads the configuration and opens a prefilled creation drawer; you must still verify, create, and start the feed.
+
+## Best practices
+
+- Use a dedicated service account and organization for each source.
+- Verify the mapper whenever the source changes its columns or delimiter.
+- Use an import schedule appropriate for the file's update frequency.
+- Review Works and Logs before resetting state.
+- Keep authentication secrets out of exported configurations.
+
+For the platform-wide CSV minimum interval, see [Advanced feed configuration](advanced-feed-configuration.md#csv-feed-settings).

--- a/docs/docs/usage/import/getting-started.md
+++ b/docs/docs/usage/import/getting-started.md
@@ -9,6 +9,7 @@ Users can streamline the data ingestion process using various automated import c
 - [RSS Feeds](rss-feed.md) facilitate the import of items in report form from specified RSS feeds, offering a straightforward way to stay updated on relevant intelligence.
 - [CSV Feeds](csv-feed.md) facilitate the ingestion of data exposed in the form of CSV files, offering a straightforward way to ingest any CSV feeds.
 - [JSON Feeds](json-feed.md) facilitate the ingestion of data exposed in JSON format, offering a straightforward way to ingest any JSON feeds.
+- [Form intake](../form-intake.md) provides guided forms for creating curated STIX entities, observables, and relationships.
 
 By leveraging these automated import functionalities, OpenCTI users can build a comprehensive, up-to-date threat intelligence database. The platform's adaptability and user-friendly configuration options ensure that intelligence workflows remain agile, scalable, and tailored to the unique needs of each organization.
 
@@ -25,9 +26,15 @@ Both tabs provide the same controls above the results:
 
 In the filter sidebar, each facet displays the number of matching items next to it, and a **Clear all** action appears as soon as at least one filter is active. Results are grouped into collapsible sections by type.
 
+Automatic service-account creation for supported built-in feeds requires a default ingestion group under **Settings > Accesses > Policies**.
+
+![Default ingestion group configuration](../assets/settings_default_group.png)
+
 ### Available tab (catalog)
 
-The **Available** tab is the catalog of everything you can deploy on your platform: connectors published in the [XTM Hub Integrations Library](https://hub.filigran.io/cybersecurity-solutions/open-cti-integrations) and the built-in ingestion methods shipped with the platform (Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, CSV Feeds and JSON Feeds). From a connector card you can start a deployment; from a built-in method card you can create a new feed.
+The **Available** tab is the catalog of everything you can deploy on your platform: connectors published in the [XTM Hub Integrations Library](https://hub.filigran.io/cybersecurity-solutions/open-cti-integrations) and the built-in ingestion methods shipped with the platform (OpenCTI Streams, TAXII Feeds, TAXII Push, RSS Feeds, CSV Feeds, JSON Feeds, and Form intake). From a connector card you can start a deployment; from a built-in method card you can create a new instance.
+
+Built-in cards also provide configuration import when the integration supports it. OpenCTI Streams, TAXII Feeds, RSS Feeds, and CSV Feeds can additionally display **Import from Hub** when the platform is connected to XTM Hub and the user has access.
 
 The filter sidebar of the catalog offers the following facets:
 
@@ -54,7 +61,7 @@ The **Deployed** tab lists the integrations currently running on your platform: 
 The filter sidebar of this tab offers the following facets:
 
 - **Kind**: filter between **Connectors** and **Built-in** feed instances.
-- **Type**: filter by connector type or built-in feed kind (Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, CSV Feeds, JSON Feeds).
+- **Type**: filter by connector type or built-in kind (OpenCTI Streams, TAXII Feeds, TAXII Push, RSS Feeds, CSV Feeds, JSON Feeds, and Form intake).
 - **Status**: filter by runtime status — **Active**, **Processing** or **Inactive**.
 
 The **Sort by** control on this tab offers **Name (A-Z)**, **Status**, **Last run** and **Queued messages** (integrations with the largest backlog first).
@@ -66,13 +73,14 @@ The level of configuration granularity regarding the imported data type varies w
 
 ## Stream / Push / Feed import behaviors
 
-An ingestion manager runs periodically in background, and for each running feeds:
-- fetches new data from the source. When data is paginated, fetches the next page
-- compose a stix bundle for data and send it in queue to be processed by workers
+An ingestion manager runs periodically in the background and, for each running feed:
 
-!!! Note on timeline of data ingestion from Taxii feed, CSV feed, JSON feed and RSS feed.
+- Fetches new data from the source. When data is paginated, it fetches the next page.
+- Creates a STIX bundle and sends it to the queue for processing by workers.
 
-    Depending on workers load, the data can take some time between the fetch from source and visibility in the platform.
+!!! note "Data ingestion timeline"
+
+    Depending on worker load, some time can pass between fetching data from a source and displaying it in the platform.
 
 Periodicity interval is configured with the manager with `ingestion_manager:interval`.
-Feed can be configured to schedule data fetch on a longer period.
+Each feed can use the platform default interval or a longer polling schedule.

--- a/docs/docs/usage/import/internal-streams.md
+++ b/docs/docs/usage/import/internal-streams.md
@@ -1,59 +1,92 @@
-# Internal streams
+# OpenCTI Streams
 
-Live Streams enable users to consume data from another OpenCTI platform, fostering collaborative intelligence sharing.
+OpenCTI Streams synchronize knowledge from a live stream exposed by another OpenCTI platform. Use them for continuous platform-to-platform intelligence sharing while preserving source traceability.
 
-<a id="best-practices-section"></a>
-## Best practices
+## Prerequisites
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides users with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and CSV/JSON Feeds.
+The remote platform must expose a live stream that the importing platform can access. Private streams require a token from a remote user with the **Access data sharing** capability. Public streams can be accessed without a token.
 
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
+Creating and managing a stream requires **Manage ingestion**. For shared guidance about service accounts and source organizations, see [Automated import](getting-started.md).
 
-1. Create a dedicated user for each source: Generate a user specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the user to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
+## Create an OpenCTI Stream
 
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated user and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **OpenCTI Stream**.
+3. Select **Create**.
+4. Enter a name and the remote OpenCTI URL, without a path.
+5. Enter a remote token when the stream is not public.
+6. Choose whether to verify the remote SSL certificate, then select **Validate**.
+7. Select an accessible remote stream. Its name, description, and filters are displayed for confirmation.
+8. Complete the synchronization settings.
+9. Select **Verify**, then **Create**.
+
+The complete configuration must be verified successfully before it can be created.
+
+![OpenCTI Stream configuration](../assets/live-stream-configuration.png)
 
 ## Configuration
 
-Live Streams enable users to consume data from another OpenCTI platform, fostering collaborative intelligence sharing. Here's a step-by-step guide to configure Live streams synchroniser:
+| Setting | Description |
+| --- | --- |
+| Name | Name displayed for the deployed integration. |
+| Remote OpenCTI URL | Base URL of the remote platform, such as `https://opencti.example`. |
+| Remote OpenCTI token | Optional for public streams; required for private streams. |
+| Remote OpenCTI stream ID | Stream selected after validating the remote connection. |
+| Service account responsible for data creation | Local account attributed as the creator of synchronized data. |
+| Starting synchronization | Oldest event to retrieve. New configurations default to the beginning of the current day; clear the value to synchronize from the beginning of the stream. |
+| Take deletions into account | Deletes local data when the remote stream emits a deletion, unless another source still references the data. Enabled by default. |
+| Verify SSL certificate | Validates the certificate of the remote platform. Disabled by default. |
+| Avoid dependencies resolution | Avoids resolving built-in relationships while still resolving required references such as the author. Disabled by default. |
+| Use perfect synchronization | Treats the remote stream as the only source of truth for synchronized data. Use only for controlled platform replication. Disabled by default. |
 
-1. Remote OpenCTI URL: Provide the URL of the remote OpenCTI platform (e.g., `https://[domain]`; don't include the path).
-2. Remote OpenCTI token: Provide the user token. An administrator from the remote platform must supply this token, and the associated user must have the "Access data sharing" privilege.
-3. After filling in the URL and user token, validate the configuration.
-4. Once validated, select a live stream to which you have access.
-
-![Live stream configuration](../assets/live-stream-configuration.png)
-
-Additional configuration options:
-
-- User responsible for data creation: Define the user responsible for creating data received from this stream. Best practice is to dedicate one user per source for organizational clarity. Please [see the section "Best practices" below](../getting-started.md) for more information.
-- Starting synchronization: Specify the date of the oldest data to retrieve. Leave the field empty to import everything.
-- Take deletions into account: Enable this option to delete data from your platform if it was deleted on the providing stream. (Note: Data won't be deleted if another source has imported it previously.)
-- Verify SSL certificate: Check the validity of the certificate of the domain hosting the remote platform.
-- Avoid dependencies resolution: Import only entities without their relationships. For instance, if the stream shares malware, all the malware's relationships will be retrieved by default. This option enables you to choose not to recover them.
-- Use perfect synchronization: This option is specifically for synchronizing two platforms. If an imported entity already exists on the platform, the one from the stream will overwrite it.
-
-![Live stream additional configuration](../assets/live-stream-additional-configuration.png)
+![OpenCTI Stream additional configuration](../assets/live-stream-additional-configuration.png)
 
 !!! note
-    By default, entities imported through this synchronizer keep no recognizable processing status, since the remote platform's status reference isn't valid locally. To keep processing statuses consistent across both platforms instead, enable [Entity status sync](../../administration/entities.md#workflow-section) on the entity types you want to synchronize.
 
-## Export an OpenCTI Stream
+    Remote processing-status identifiers are not valid on the local platform. To synchronize statuses by name, enable [Entity status sync](../../administration/entities.md#workflow-section) for the applicable entity types.
 
-You can export your existing OpenCTI Stream from the platform, making it easy to share your configuration with others.
+## Configure the service account
 
-To export your OpenCTI Stream, click on "Export", in the burger menu.
-![OpenCTI Stream export](../assets/opencti-stream-export.png)
+By default, OpenCTI creates a service account named `[S] <stream name>` with confidence level `50`. Disable **Automatically create a service account** to select an existing account instead.
 
-## Import an OpenCTI Stream
+Automatic account creation requires a default ingestion group under **Settings > Accesses > Policies**. The form displays a warning when no default group is configured.
 
-If you have a JSON OpenCTI Stream file you can import it by clicking on the icon next to "Import from hub"
-![OpenCTI Stream import button](../assets/opencti-stream-import-icon.png)
+## Manage and monitor a stream
 
-When you click, you can select the desired file. After that, a drawer will open with the form pre-filled with the relevant information.
-Add your desired platform's token. 
-By default, a user is already provided.
+Created streams appear under **Integrations > Deployed**. Open a stream to inspect its URL, stream identifier, creator, synchronization options, queue metrics, state, and activity.
 
-You can select an OpenCTI Stream from the XTM Hub by clicking the ```Import from Hub``` button
+The action menu provides:
 
+- **Start** and **Stop**
+- **Update**
+- **Export**
+- **Delete**
+
+Update and Delete are unavailable while the stream is running. OpenCTI Streams do not have a Logs tab; use the activity and consumer metrics to monitor processing.
+
+![OpenCTI Stream export action](../assets/opencti-stream-export.png)
+
+## Import and export
+
+Select **Export** from a deployed stream to download its JSON configuration.
+
+To import a configuration:
+
+1. Open **Integrations > Available**.
+2. Find **OpenCTI Stream**.
+3. Select the file-import action and choose the exported JSON file.
+4. Enter the remote token and choose a local service account.
+5. Validate and verify the connection, then create the stream.
+
+The imported file can prefill the name, URL, stream identifier, start date, and synchronization options. It does not contain the remote token or local service account.
+
+![OpenCTI Stream configuration import action](../assets/opencti-stream-import-icon.png)
+
+When XTM Hub is configured and accessible, the card also displays **Import from Hub**.
+
+## Best practices
+
+- Use a dedicated local service account and organization for each remote source.
+- Enable SSL verification for production endpoints with trusted certificates.
+- Use perfect synchronization only when the remote platform must fully control the synchronized objects.
+- Test deletion synchronization with non-production data before enabling it for an existing stream.

--- a/docs/docs/usage/import/json-feed.md
+++ b/docs/docs/usage/import/json-feed.md
@@ -1,127 +1,146 @@
 # JSON Feeds
 
-JSON feed ingester enables users to import any Web JSON API.
+JSON Feeds periodically call a JSON web API and convert its response to STIX objects with a JSON mapper. They support simple endpoints, stateful pagination, custom headers, and GET or POST requests.
 
-<a id="best-practices-section"></a>
+## Prerequisites and permissions
+
+Creating and managing JSON Feeds requires **Manage ingestion**. Create a compatible [JSON mapper](../../administration/json-mappers.md) before configuring the feed; JSON Feeds do not provide an inline mapper editor.
+
+## Create a JSON Feed
+
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **JSON Feed**.
+3. Select **Create**.
+4. Enter a name, schedule, URL, and HTTP verb.
+5. Configure the request body, headers, pagination, and authentication as required.
+6. Select the JSON mapper and creator.
+7. Select **Verify** to test the request and mapping.
+8. After a successful test, select **Create**, then start the feed from **Integrations > Deployed**.
+
+## Basic configuration
+
+| Setting | Description |
+| --- | --- |
+| Name | Required name displayed for the integration. |
+| Description | Optional purpose or source information. |
+| Schedule period | Platform default of approximately 30 seconds, or 5, 15, or 30 minutes; 1, 6, or 12 hours; or 24 hours. |
+| HTTP JSON URL | Required API URL. It can reference pagination variables. |
+| HTTP VERB | GET by default, or POST. |
+| HTTP BODY POST | Request body displayed for POST requests. It can reference pagination variables. |
+| User responsible for data creation | Local creator assigned to imported objects. Empty uses System. |
+| JSON mapper | Required mapper used to convert the response. |
+| Marking definition levels | Displayed when the mapper lets the ingestion user choose markings. |
+| Verify SSL certificate | Validates the source certificate. Enabled by default. |
+
+Unlike OpenCTI Stream, TAXII Feed, RSS Feed, and CSV Feed creation, JSON Feed does not automatically create a service account.
+
+## Configure authentication
+
+| Mode | Required values |
+| --- | --- |
+| None | No credentials |
+| Basic | Username and password |
+| Bearer token | Token |
+| Client certificate | Base64-encoded certificate, private key, and certificate authority certificate |
+
+Authentication defaults to None.
+
+## Configure pagination
+
+Use variables in the URL, POST body, or headers to carry state between requests. A variable named `offset`, for example, can be referenced as `${offset}`:
+
+```text
+https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=20&startIndex=${offset}
+```
+
+For a POST request:
+
+```json
+{
+  "page": "${offset}"
+}
+```
+
+Each query attribute defines how OpenCTI obtains and updates a variable:
+
+| Setting | Description |
+| --- | --- |
+| Resolve from | Read the value from response Data or Header. |
+| Exposed attribute to | Insert the next value into the request Body, Query parameter, or Header. |
+| Resolve operation | Use the resolved Data or its Count. |
+| State operation | Replace the previous value or add to it with Sum. |
+| Get from path | JSON path used to extract the response value, such as `$.vulnerabilities`. |
+| To attribute name | Variable name referenced by the next request. |
+| Default value | Initial value before the first request. |
+
+![JSON Feed pagination configuration](../assets/json-feed-paginated.png)
+
+### Sub-pagination
+
+Enable **Sub pagination** when the response provides another URI that must be followed before advancing the main state, as with some Trino APIs.
+
+Configure:
+
+- Sub-pagination HTTP verb: GET or POST.
+- Attribute path used to retrieve the next URI.
+
+Sub-pagination is disabled by default.
+
+![JSON Feed sub-pagination configuration](../assets/json-feed-sub.png)
+
+## Configure headers
+
+Add request headers for API-specific values or pagination state. Do not duplicate credentials in custom headers when an authentication mode already supplies them.
+
+![JSON Feed custom headers](../assets/json-feed-headers.png)
+
+## Verify the feed
+
+Verification requires a URL and JSON mapper. It retrieves up to the first 50 response items and displays:
+
+- Mapped entity and relationship counts.
+- The computed pagination state.
+- Generated STIX objects.
+- Request or mapping errors.
+
+The feed can be created only when verification returns at least one entity. Updates, duplicates, and imports must also pass verification.
+
+![JSON Feed verification result](../assets/json-feed-verify.png)
+
+## Manage and monitor a JSON Feed
+
+The detail action menu provides:
+
+- **Start** and **Stop**
+- **Update**
+- **Duplicate**
+- **Export**
+- **Reset state**
+- **Delete**
+
+Duplication opens a prefilled `<name> - copy` configuration. Reset state clears the stored pagination state, causing processing to resume from its configured defaults.
+
+The detail page provides the feed overview and technical connector Works when the user can access them. JSON Feeds do not have an ingestion Logs tab.
+
+## Import and export
+
+Export downloads a dated JSON configuration containing the feed and embedded mapper settings.
+
+To import:
+
+1. Open **Integrations > Available** and find **JSON Feed**.
+2. Select the file-import action and choose the JSON configuration.
+3. Review the imported mapper and request settings.
+4. Re-enter credentials and choose the local creator and markings.
+5. Verify, create, and start the feed.
+
+JSON Feed supports configuration-file import but not **Import from Hub**.
+
 ## Best practices
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides users with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and JSON/CSV Feeds.
-
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
-
-1. Create a dedicated user for each source: Generate a user specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the user to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
-
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated user and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
-
-## Configuration
-
-Configuring a JSON feed will be simple or complex depending on the needs of pagination.
-So we will show by example of its different and how to configure it in the two cases.
-
-### Simple API
-
-Here's a step-by-step guide to configure JSON ingesters:
-
-1. Schedule period: As the API is not paginated, its recommended to configure a longer polling period
-2. HTTP JSON URL: Provide the URL of the JSON API from which items will be imported.
-3. HTTP Verb: Provide the type of verb that will be GET by default.
-4. JSON Mappers: Choose the JSON mapper to be used to import the data.
-5. Authentication type (if necessary): Enter the authentication type.
-
-### Paginated API
-
-For paginated APIs, it's more difficult to configure the JSON feed. You have more elements.
-
-#### Verb and variables
-
-You need to start to configure the verb to use and the variables.
-
-**GET**
-
-When you use a GET API, a majority of cases will use query parameters to be able to setup variables for the pagination.
-For example lets take an api where the get command need to specify the page number to consume.
-There is a part of the URI that need to be dynamic.
-
-```https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=20&startIndex=$offset```
-
-You can see in this example that the page query parameter need to be associated with the pagination.
-
-So to be able to do this, you have to configure this parameter as a variable, here **${offset}**
-
-**POST**
-
-When you use a POST API, you need to specify the body of the post. Depending on the API it could be JSON or any other body content.
-
-Like the previous example in the get, you can specify variables in the body configuration.
-
-``` { "page": "$offset" }```
-
-or for example this kind of command for a Trino query that define a $created variable.
-
-```SELECT * FROM observables WHERE created_at > TIMESTAMP '$created' ORDER BY created_at ASC LIMIT 10```
-
-#### Query attributes
-
-The query attribute will be the definition of how to setup the required variable.
-
-Let's take the previous example with the GET uri.
-
-```https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=20&startIndex=$offset```
-
-For the uri of the GET example, we need to configure the **offset** variables.
-
-![Data import and workbenches panel](../assets/json-feed-paginated.png)
-Lets describe each configuration:
-- Resolve from: **Data**
-
-Where the variable will be parsed from. You can choose between Header and Data.
-
-- Exposed attribute to: **Query parameter**
-
-How the attribute will be exposed in the next http call. You can choose between Body / Query parameter and Header
-
-- Resolve operation: **Count**
-
-Apply an operation on the resolved data. You can choose between Data and Count.
-
-- State operation: **Sum**
-
-How to compute the state for the next execution. You can choose between Replace and Sum.
-
-- Get from path: **$.vulnerabilities**
-
-How to extract the data from the data result. 
-
-- To attribute name: **offset**
-
-The name of the attribute that will contain the value and so **to use in the query / body or headers**
-
-- Default value: **0**
-
-The default value for the target attribute.
-
-#### Headers
-
-If your API require some specific headers, you can simply add some.
-
-![JSON feed headers](../assets/json-feed-headers.png)
-
-#### Sub pagination
-
-This one is a very specific option that will be used in some really rare use case. For example Trino is a system that require sub pagination to get the data.
-
-![JSON sub pagination option](../assets/json-feed-sub.png)
-
-#### Mapper and verify
-
-With the correct mapper configured you can click on the verify button to get an idea of what you can get.
-
-![JSON feed verify](../assets/json-feed-verify.png)
-
-In the result you will be able to see the result of the query parameters computing (state) and the data mapped to STIX (objects). 
-
-The state is a json object that represent information that will be injected in the parameters / body or headers for the next execution.
-
-You need to be careful and really take the time to adapt your configuration to obtain the expected mapping.
-
+- Test pagination with a small response before enabling a short schedule.
+- Use explicit default values for every pagination variable.
+- Choose a dedicated creator rather than System when source traceability is important.
+- Keep SSL verification enabled for trusted production APIs.
+- Review the computed state during verification and before resetting a running feed.
+- Update the mapper when the upstream response structure changes.

--- a/docs/docs/usage/import/rss-feed.md
+++ b/docs/docs/usage/import/rss-feed.md
@@ -1,53 +1,80 @@
 # RSS Feeds
 
-RSS Feeds functionality enables users to seamlessly ingest items in report form from specified RSS feeds.
+RSS Feeds poll an RSS or Atom source and create an OpenCTI Report for each imported item. Use them to monitor publications and news sources without deploying a separate connector.
 
-<a id="best-practices-section"></a>
-## Best practices
+## Prerequisites and permissions
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides users with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and JSON/CSV Feeds.
+Obtain the RSS or Atom feed URL. Creating and managing RSS Feeds requires **Manage ingestion**.
 
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
+For source-account recommendations, see [Automated import](getting-started.md).
 
-1. Create a dedicated user for each source: Generate a technical user (or Service account) specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the user to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
+## Create an RSS Feed
 
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated user and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
-
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **RSS Feed**.
+3. Select **Create**.
+4. Enter a name and feed URL.
+5. Configure the schedule, service account, and import start date.
+6. Set defaults for the generated Reports.
+7. Select **Create**, then start the feed from **Integrations > Deployed**.
 
 ## Configuration
 
-Here's a step-by-step guide to configure RSS ingesters:
+| Setting | Description |
+| --- | --- |
+| Name | Required name displayed for the integration. |
+| Description | Optional purpose or source information. |
+| Schedule period | Platform default of approximately 30 seconds, or 5, 15, or 30 minutes; 1, 6, or 12 hours; or 24 hours. |
+| RSS Feed URL | Required RSS or Atom endpoint. |
+| Service account responsible for data creation | Creator assigned to imported Reports. |
+| Import from date | Oldest entries to retrieve. Leave empty to retrieve all available items. |
+| Default report types | Report types applied to generated Reports. |
+| Default author | Author identity applied to generated Reports. |
+| Default marking definitions | Markings applied to generated Reports. |
+| Verify SSL certificate | Validates the feed server certificate. |
 
-1. RSS Feed URL: Provide the URL of the RSS feed from which items will be imported.
+![RSS Feed configuration](../assets/rss-feed-configuration.png)
 
-Additional configuration options:
+## Configure the service account
 
-- User responsible for data creation: Define the user responsible for creating data received from this RSS feed. Best practice is to dedicate one user per source for organizational clarity. Please [go to the page ](../getting-started.md) for more information.
-- Import from date: Specify the date of the oldest data to retrieve. Leave the field empty to import everything.
-- Default report types: Indicate the report type to be applied to the imported report.
-- Default author: Indicate the default author to be applied to the imported report. Please [go to the page](../getting-started.md) for more information.
-- Default marking definitions: Indicate the default markings to be applied to the imported reports.
+By default, OpenCTI creates a service account named `[F] <feed name>` with confidence level `50`. Disable **Automatically create a service account** to select an existing account.
 
-![RSS feed configuration](../assets/rss-feed-configuration.png)
+Automatic creation requires a default ingestion group under **Settings > Accesses > Policies**.
 
-## Export a RSS feed
-You can export your existing RSS feed from the platform, making it easy to share your configuration with others.
+## Manage and monitor an RSS Feed
 
-To export your ingester, click on "Export", in the burger menu.
-![RSS feed export](../assets/rss-feeds-export.png)
+The deployed feed action menu provides:
 
-## Import a RSS feed ingester
+- **Start** and **Stop**
+- **Update**
+- **Export**
+- **Delete**
 
-If you have a JSON RSS feed file you can import it by clicking on the icon next to "Import from hub"
-![RSS feed import button](../assets/rss-feeds-import-icon.png)
+The detail page shows its configuration, schedule, status, activity, and technical connector Works when the user can access them. RSS Feeds do not provide Duplicate, Reset state, or ingestion Logs actions.
 
-When you click, you can select the desired file. After that, a drawer will open with the form pre-filled with the relevant information.
-By default, a user is already provided.
+![RSS Feed export action](../assets/rss-feeds-export.png)
 
-Finally, you need to click on create to create your new ingester.
+## Import and export
 
+Export downloads a dated JSON configuration containing the feed settings.
 
-You can select RSS Feeds from the XTM Hub by clicking the ```Import from Hub``` button. 
+To import a configuration:
 
-If your OpenCTI instance is registered on the XTM Hub, you can directly import RSS Feeds in 1 click from XTM Hub. After a confirmation popup, it will open the creation drawer with everything prefilled where you can adjust the config before creating the ingester.
+1. Open **Integrations > Available** and find **RSS Feed**.
+2. Select the file-import action and choose the JSON configuration.
+3. Review the prefilled schedule, URL, import date, Report defaults, and markings.
+4. Choose or create the local service account.
+5. Create and start the feed.
+
+![RSS Feed configuration import action](../assets/rss-feeds-import-icon.png)
+
+When XTM Hub is configured and accessible, the card also displays **Import from Hub**. A Hub configuration opens the same prefilled creation drawer for review; it does not start the feed automatically.
+
+## Best practices
+
+- Use a dedicated service account and source organization.
+- Apply default markings appropriate for all content from the feed.
+- Set an import date to avoid creating Reports for irrelevant historical posts.
+- Choose a polling schedule that respects the source and the platform-wide minimum interval.
+
+For the RSS minimum interval and HTTP user agent, see [Advanced feed configuration](advanced-feed-configuration.md#rss-feed-settings).

--- a/docs/docs/usage/import/taxii-feed.md
+++ b/docs/docs/usage/import/taxii-feed.md
@@ -1,51 +1,91 @@
 # TAXII Feeds
 
-TAXII Feeds in OpenCTI provide a robust mechanism for ingesting TAXII collections from TAXII servers or other OpenCTI instances.
+TAXII Feeds poll a TAXII 2.1 collection and ingest its STIX objects into OpenCTI. Use them to consume standards-based threat intelligence from an ISAC, vendor, or another OpenCTI platform.
 
-<a id="best-practices-section"></a>
-## Best practices
+## Prerequisites
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides users with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and JSON/CSV Feeds.
+Obtain the TAXII server root URL, collection identifier, and any required credentials. For an OpenCTI TAXII collection, the root URL is typically `https://<domain>/taxii2/root`.
 
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
+Creating and managing TAXII Feeds requires **Manage ingestion**.
 
-1. Create a dedicated user for each source: Generate a user specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the user to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
+## Create a TAXII Feed
 
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated user and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **TAXII Feed**.
+3. Select **Create**.
+4. Enter a name, server URL, TAXII version, and collection identifier.
+5. Configure authentication and the service account.
+6. Set the schedule and import start date.
+7. Select **Create**, then start the feed from **Integrations > Deployed**.
+
+!!! note "TAXII root URL"
+
+    Enter the TAXII API root, not a collection URL. For example, use `https://example.org/taxii2/root` rather than `https://example.org/taxii2/root/collections/<id>`.
 
 ## Configuration
 
-Here's a step-by-step guide to configure TAXII ingesters:
+| Setting | Description |
+| --- | --- |
+| Name | Required name displayed for the integration. |
+| Description | Optional purpose or source information. |
+| Schedule period | Platform default of approximately 30 seconds, or 5, 15, or 30 minutes; 1, 6, or 12 hours; or 24 hours. |
+| TAXII server URL | Required TAXII root API URL. |
+| TAXII version | Required protocol version. The current form supports TAXII 2.1. |
+| TAXII Collection | Required collection identifier. |
+| Authentication type | None, Basic, bearer token, or client certificate. |
+| Import from date | Oldest collection items to retrieve. Leave empty to retrieve all available items. |
+| Copy confidence level to OpenCTI scores for indicators | Maps STIX Indicator confidence to OpenCTI score. Disabled by default. |
+| Verify SSL certificate | Validates the TAXII server certificate. Enabled by default. |
 
-1. TAXII server URL: Provide the root API URL of the TAXII server. For collections from another OpenCTI instance, the URL is in the form `https://[domain]/taxii2/root`.
-2. TAXII collection: Enter the ID of the TAXII collection to be ingested. For collections from another OpenCTI instance, the ID follows the format `426e3acb-db50-4118-be7e-648fab67c16c`.
-3. Authentication type (if necessary): Enter the authentication type. For non-public collections from another OpenCTI instance, the authentication type is "Bearer token." Enter the token of a user with access to the collection (similar to the point 2 of the Live streams configuration above).
+![TAXII Feed configuration](../assets/taxii-feed-configuration.png)
 
-!!! note "TAXII root API URL"
+Authentication fields depend on the selected mode:
 
-    Many ISAC TAXII configuration instructions will provide the URL for the collection or discovery service. In these cases, remove the last path segment from the TAXII Server URL in order to use it in OpenCTI. eg. use https://[domain]/tipapi/tip21, and not https://[domain]/tipapi/tip21/collections.
+| Mode | Required values |
+| --- | --- |
+| None | No credentials |
+| Basic | Username and password |
+| Bearer token | Token |
+| Client certificate | Base64-encoded certificate, private key, and certificate authority certificate |
 
-Additional configuration options:
+## Configure the service account
 
-- User responsible for data creation: Define the user responsible for creating data received from this TAXII feed. Best practice is to dedicate one user per source for organizational clarity. Please [go to the page](../getting-started.md) for more information.
-- Import from date: Specify the date of the oldest data to retrieve. Leave the field empty to import everything.
+By default, OpenCTI creates a service account named `[F] <feed name>` with confidence level `50`. Disable **Automatically create a service account** to select an existing account.
 
-![TAXII feed configuration](../assets/taxii-feed-configuration.png)
+Automatic creation requires a default ingestion group under **Settings > Accesses > Policies**.
 
-## Export a Taxii feed
-You can export your existing taxii feed from the platform, making it easy to share your configuration with others.
+## Manage and monitor a TAXII Feed
 
-To export your taxii feed, click on "Export", in the burger menu.
-![Taxii feed export](../assets/taxii-feeds-export.png)
+The deployed feed action menu provides:
 
-## Import a Taxii feed
+- **Start** and **Stop**
+- **Update**
+- **Export**
+- **Reset state**
+- **Delete**
 
-If you have a JSON Taxii feed file you can import it by clicking on the icon next to "Import from hub"
-![Taxii feed import button](../assets/taxii-feeds-import-icon.png)
+Resetting state makes the feed restart collection ingestion from the beginning, subject to its import date.
 
-When you click, you can select the desired file. After that, a drawer will open with the form pre-filled with the relevant information.
-If necessary, configure the authentication type. By default, a user is already provided.
+The detail page provides **Overview** and **Works**. When ingestion-feed logs are enabled on the platform, a **Logs** tab displays timestamp, severity, message, and expandable JSON details.
 
-You can select Taxii Feeds from the XTM Hub by clicking the ```Import from Hub``` button
+![TAXII Feed export action](../assets/taxii-feeds-export.png)
 
+## Import and export
+
+Export downloads the feed configuration as JSON. Authentication secrets and the local service account are not exported.
+
+To import a configuration, use the file-import action on the **TAXII Feed** card under **Integrations > Available**. The file can prefill the name, description, URL, schedule, version, collection, authentication type, and import date. Re-enter credentials, choose or create the service account, verify SSL behavior, and create the feed.
+
+![TAXII Feed configuration import action](../assets/taxii-feeds-import-icon.png)
+
+When XTM Hub is configured and accessible, the card also displays **Import from Hub**.
+
+## Best practices
+
+- Use a dedicated service account and organization for each TAXII source.
+- Keep SSL verification enabled for trusted production endpoints.
+- Use a conservative schedule for large collections.
+- Set an import date for the first run when ingesting the complete collection would be unnecessary.
+- Review feed logs and Works before resetting ingestion state.
+
+For platform-wide TAXII polling limits, see [Advanced feed configuration](advanced-feed-configuration.md#taxii-feed-settings).

--- a/docs/docs/usage/import/taxii-push.md
+++ b/docs/docs/usage/import/taxii-push.md
@@ -1,34 +1,80 @@
 # TAXII Push
 
-TAXII Push ingester enables users to import STIX 2.1 objects in OpenCTI through an exposed TAXII collection.
+TAXII Push exposes a TAXII 2.1 collection endpoint that authorized clients can use to add STIX objects to OpenCTI. Use it when an external producer must push intelligence rather than wait for OpenCTI to poll a source.
 
-<a id="best-practices-section"></a>
-## Best practices
+The endpoint implements the TAXII 2.1 [Add Objects](https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107540) operation.
 
-In OpenCTI, the **Integrations** section — accessible from the main navigation bar on the left — provides users with built-in functions for automated data import. These functions are designed for specific purposes and can be configured to seamlessly ingest data into the platform. Feeds and connectors are managed from the **Integrations** page, which is split into a **Deployed** tab (the feeds and connectors running on your platform) and an **Available** tab (the catalog of connectors and built-in feeds you can deploy). To create a new feed, open the **Available** tab and use the creation button on the corresponding built-in card. For a detailed description of these two tabs and their filters, see [Getting started](getting-started.md#the-integrations-menu). Here, we'll explore the configuration process for the five built-in functions: Live Streams, TAXII Feeds, TAXII Push, RSS Feeds, and JSON/CSV Feeds.
+## Prerequisites and permissions
 
-Ensuring a secure and well-organized environment is paramount in OpenCTI. Here are two recommended best practices to enhance security, traceability, and overall organizational clarity:
+Creating and managing a TAXII Push instance requires **Manage ingestion**. Before creation, identify the users, groups, or organizations that can authenticate to the generated collection.
 
-1. Create a dedicated user for each source: Generate a user specifically for feed import, following the convention `[F] Source name` for clear identification. Assign the user to the "Connectors" group to streamline user management and permission related to data creation. Please [see here](../../deployment/connectors.md#connector-token-section) for more information on this good practice.
-2. Establish a dedicated Organization for the source: Create an organization named after the data source for clear identification. Assign the newly created organization to the "Default author" field in feed import configuration if available.
+## Create a TAXII Push instance
 
-By adhering to these best practices, you ensure independence in managing rights for each import source through dedicated user and organization structures. In addition, you enable clear traceability to the entity's creator, facilitating source evaluation, dashboard creation, data filtering and other administrative tasks.
-
-## Configuration
-
-TAXII Push ingester enables users to import STIX 2.1 objects in OpenCTI through an exposed TAXII collection, in compliance with the [“Add objects” part of the TAXII 2.1 specification](https://docs.oasis-open.org/cti/taxii/v2.1/os/taxii-v2.1-os.html#_Toc31107540).
-Here's a step-by-step guide to configure TAXII Push ingesters:
-
-1. Name: Enter a name for the TAXII Push ingester.
-2. Description (optional): Enter a description for the TAXII Push ingester.
-3. User responsible for data creation: Define the user responsible for creating data received from this TAXII Push ingester. Best practice is to dedicate one user per source for organizational clarity. Please [go to the page](getting-started.md) for more information.
-4. Accessible for: Enter the user, group or organization authorized to push data in the TAXII collection.
-5. Copy confidence level to OpenCTI scores for indicators: Enable this option to map the confidence level associate to STIX indicators to the OpenCTI scoring system.
+1. Go to **Integrations > Available**.
+2. Select **Built-in ingestion**, then find **TAXII Push**.
+3. Select **Create**.
+4. Enter a name and optional description.
+5. Optionally select the user responsible for created data. Leave it empty to use the System account.
+6. Under **Accessible for**, select at least one user, group, or organization authorized to push data.
+7. Choose whether to copy STIX Indicator confidence to OpenCTI scores.
+8. Select **Create**, then start the instance from **Integrations > Deployed**.
 
 ![TAXII Push configuration](../assets/taxii-push-configuration.png)
 
-After creating a new TAXII Push ingester, a TAXII endpoint is generated, which can be used to publish data in STIX 2.1 format.
-To start your new ingester, click on "Start", in the burger menu.
+## Configuration
 
-![TAXII Push creation: start](../assets/taxii-push-creation-start.png)
+| Setting | Description |
+| --- | --- |
+| Name | Required name displayed for the integration. |
+| Description | Optional purpose or producer information. |
+| User responsible for data creation | Local creator assigned to imported objects. Empty uses System. |
+| Accessible for | Required users, groups, or organizations allowed to push objects. |
+| Copy confidence level to OpenCTI scores for indicators | Maps STIX Indicator confidence to OpenCTI score. |
 
+TAXII Push controls authentication through **Accessible for**. It does not expose the authentication-mode selector used by polling feeds.
+
+## Use the generated endpoint
+
+After creation, OpenCTI generates a collection endpoint in this form:
+
+```text
+https://<opencti-base-url>/taxii2/root/collections/<ingester-id>/objects/
+```
+
+Start the TAXII Push instance before sending STIX 2.1 bundles to the endpoint.
+
+![Start TAXII Push](../assets/taxii-push-creation-start.png)
+
+## Manage and monitor TAXII Push
+
+The deployed instance action menu provides:
+
+- **Start** and **Stop**
+- **Update**
+- **Export**
+- **Delete**
+
+The detail page shows its status, description, creator, confidence-mapping option, dates, and technical connector Works when the user can access them. TAXII Push does not have an ingestion Logs tab.
+
+## Import and export
+
+Export downloads a JSON configuration named with the date and TAXII Push name.
+
+To import a configuration:
+
+1. Open **Integrations > Available** and find **TAXII Push**.
+2. Select the file-import action.
+3. Choose the JSON configuration.
+4. Select the local creator and authorized members.
+5. Create and start the instance.
+
+The file prefills the name, description, and confidence-mapping option. The creator and **Accessible for** values remain platform-specific and are not imported.
+
+TAXII Push supports file import but not **Import from Hub**.
+
+## Best practices
+
+- Grant access only to dedicated producer accounts or narrowly scoped groups.
+- Use a dedicated creator identity to make pushed data easy to audit and filter.
+- Distribute the collection endpoint only to authorized producers.
+- Stop the instance immediately if a producer credential is compromised.


### PR DESCRIPTION
### Proposed changes

The built-in integration documentation had drifted from the current marketplace, configuration forms, and deployed-integration workflows.

* Refresh the OpenCTI Stream, TAXII Feed, TAXII Push, RSS Feed, CSV Feed, JSON Feed, and Form intake guides with current fields, permissions, lifecycle actions, monitoring, and import/export behavior.
* Align shared navigation with **Integrations > Available** and **Integrations > Deployed**, and restore existing screenshots beside the workflows they should illustrate so they can be recaptured without changing filenames.

### Related issues

* closes #18153

### How to test this PR

1. Build the documentation with `cd docs && mkdocs build --strict`.
2. Review each built-in integration page under **Usage > Import and synchronization** and **Create via form**.
3. Confirm each screenshot is placed beside the current UI workflow it is intended to illustrate.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Documentation-only change; automated test cases are not applicable. Existing screenshot filenames are intentionally preserved so the images can be updated independently against the current application UI.