### PR TITLE
feat(frontend): start investigations from selected entities (#4314)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -135,6 +135,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
   | 'disableBulkEnroll'
   | 'deleteDisable'
   | 'container'
+  | 'knowledgeEntityId'
 > & {
   taskScope?: string;
   globalSearch?: string;
@@ -155,6 +156,7 @@ const DataTableInternalToolbar = ({
   disableBulkEnroll,
   deleteDisable,
   container,
+  knowledgeEntityId,
 }: DataTableInternalToolbarProps) => {
   const theme = useTheme<Theme>();
 
@@ -198,6 +200,7 @@ const DataTableInternalToolbar = ({
         disableBulkEnroll={disableBulkEnroll}
         deleteDisable={deleteDisable}
         container={container}
+        knowledgeEntityId={knowledgeEntityId}
       />
     </div>
   );
@@ -267,6 +270,7 @@ const DataTable = (props: OCTIDataTableProps) => {
     disableBulkEnroll,
     deleteDisable,
     container,
+    knowledgeEntityId,
   } = props;
 
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
@@ -317,6 +321,7 @@ const DataTable = (props: OCTIDataTableProps) => {
         dataTableToolBarComponent={(
           <DataTableInternalToolbar
             container={container}
+            knowledgeEntityId={knowledgeEntityId}
             entityTypes={entityTypes}
             handleCopy={handleCopy}
             taskScope={taskScope}

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -100,6 +100,7 @@ export interface DataTableProps {
   additionalFilterKeys?: string[];
   entityTypes?: string[];
   container?: any;
+  knowledgeEntityId?: string;
   settingsMessagesBannerHeight?: number;
   storageHelpers?: UseLocalStorageHelpers;
   redirectionMode?: string | undefined;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationships.tsx
@@ -376,6 +376,7 @@ const StixCoreRelationships: FunctionComponent<StixCoreRelationshipsProps> = (
             lineFragment={stixCoreRelationshipsFragment}
             preloadedPaginationProps={preloadedPaginationProps}
             exportContext={{ entity_type: 'stix-core-relationship' }}
+            knowledgeEntityId={entityId}
             currentView={currentView}
             additionalHeaderToggleButtons={[...viewButtons]}
           />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
@@ -300,6 +300,7 @@ const EntityStixCoreRelationshipsContextualViewComponent: FunctionComponent<Enti
             search={searchTerm}
             handleClearSelectedElements={handleClearSelectedElements}
             variant="medium"
+            knowledgeEntityId={entityId}
             warning={true}
             warningMessage={t_i18n(
               'Be careful, you are about to delete the selected entities',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesView.tsx
@@ -260,6 +260,7 @@ const EntityStixCoreRelationshipsEntitiesView: FunctionComponent<
         search={searchTerm}
         handleClearSelectedElements={handleClearSelectedElements}
         variant="medium"
+        knowledgeEntityId={entityId}
         warning={true}
         warningMessage={t_i18n(
           'Be careful, you are about to delete the selected entities (not the relationships)',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsRelationshipsView.tsx
@@ -341,6 +341,7 @@ const EntityStixCoreRelationshipsRelationshipsView: FunctionComponent<EntityStix
         handleClearSelectedElements={handleClearSelectedElements}
         variant="medium"
         type="stix-core-relationship"
+        knowledgeEntityId={entityId}
       />
 
       {allowCreation && (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
@@ -301,6 +301,7 @@ const EntityStixCoreRelationshipsIndicatorsContextualViewComponent: FunctionComp
         search={searchTerm}
         handleClearSelectedElements={handleClearSelectedElements}
         variant="medium"
+        knowledgeEntityId={entityId}
         warning={true}
         warningMessage={t_i18n(
           'Be careful, you are about to delete the selected entities',

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
@@ -256,6 +256,7 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={entityStixCoreRelationshipsIndicatorsEntitiesViewLineFragment}
           exportContext={{ entity_id: entityId, entity_type: 'Indicator' }}
+          knowledgeEntityId={entityId}
           currentView={currentView}
           additionalHeaderToggleButtons={[...viewButtons]}
         />

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -78,6 +78,7 @@ import {
   BYPASS,
   EXPLORE_EXUPDATE_EXDELETE,
   EXPLORE_EXUPDATE_PUBLISH,
+  INVESTIGATION_INUPDATE,
   INVESTIGATION_INUPDATE_INDELETE,
   KNOWLEDGE_KNUPDATE,
   KNOWLEDGE_KNUPDATE_KNDELETE,
@@ -99,6 +100,8 @@ import StixDomainObjectCreation from '../common/stix_domain_objects/StixDomainOb
 import { killChainPhasesSearchQuery } from '../settings/KillChainPhases';
 import { labelsSearchQuery } from '../settings/LabelsQuery';
 import UserEmailSend from '../settings/users/UserEmailSend';
+import InvestigationCreationFromSelection from '../workspaces/investigations/InvestigationCreationFromSelection';
+import { buildInvestigationEntityIds, isInvestigationSelectionEnabled } from '../workspaces/investigations/investigationSelectionUtils';
 import PromoteDrawer from './drawers/PromoteDrawer';
 
 import EnrollPlaybookDrawer from '@components/data/drawers/EnrollPlaybookDrawer';
@@ -2253,6 +2256,7 @@ class DataTableToolBar extends Component {
       warning,
       warningMessage,
       taskScope,
+      knowledgeEntityId,
     } = this.props;
     const {
       actions,
@@ -2346,6 +2350,18 @@ class DataTableToolBar extends Component {
           // endregion
           // region promote filters
           const stixCyberObservableTypes = schema.scos.map((sco) => sco.id).concat('Stix-Cyber-Observable');
+          const stixCoreRelationshipTypes = schema.scrs.map((relationship) => relationship.id);
+          const stixDomainObjectTypes = schema.sdos.map((sdo) => sdo.id).concat('Stix-Domain-Object');
+          const investigationEntityIds = buildInvestigationEntityIds(selectedElements || {}, knowledgeEntityId);
+          const investigationSelectionEnabled = isInvestigationSelectionEnabled({
+            numberOfSelectedElements,
+            selectAll,
+            selectedTypes: selectedElementsList.map((element) => element.entity_type),
+            stixCyberObservableTypes,
+            stixCoreRelationshipTypes,
+            stixDomainObjectTypes,
+            isInDraft: Boolean(isInDraft || removeFromDraftEnabled),
+          });
           const promotionTypes = stixCyberObservableTypes.concat(['Indicator']);
 
           const isOnlyStixCyberObservablesTypes = entityTypeFilterValues.length > 0
@@ -2581,6 +2597,15 @@ class DataTableToolBar extends Component {
                             </IconButton>
                           </span>
                         </Tooltip>
+                      </Security>
+                    )}
+                    {!removeAuthMembersEnabled && !isUserDatatable && (
+                      <Security needs={[INVESTIGATION_INUPDATE]}>
+                        <InvestigationCreationFromSelection
+                          disabled={!investigationSelectionEnabled || this.state.processing}
+                          entityIds={investigationEntityIds}
+                          title={t('Start an investigation')}
+                        />
                       </Security>
                     )}
                     {container && (
@@ -3513,6 +3538,7 @@ DataTableToolBar.propTypes = {
   removeFromDraft: PropTypes.bool,
   markAsReadEnabled: PropTypes.bool,
   taskScope: PropTypes.string,
+  knowledgeEntityId: PropTypes.string,
 };
 
 export default R.compose(inject18n, withTheme, withStyles(styles))(DataTableToolBar);

--- a/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ToolBar.jsx
@@ -62,6 +62,7 @@ const ToolBar = (props) => {
     handleCopy,
     search,
     taskScope,
+    knowledgeEntityId,
   } = props;
   const classes = useStyles();
   const theme = useTheme();
@@ -121,6 +122,7 @@ const ToolBar = (props) => {
             trashOperationsEnabled={trashOperationsEnabled}
             handleCopy={handleCopy}
             taskScope={taskScope}
+            knowledgeEntityId={knowledgeEntityId}
           />
         </Drawer>
       )}
@@ -149,6 +151,7 @@ ToolBar.propTypes = {
   mergeDisable: PropTypes.bool,
   trashOperationsEnabled: PropTypes.bool,
   taskScope: PropTypes.string,
+  knowledgeEntityId: PropTypes.string,
 };
 
 export default ToolBar;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationCreationFromSelection.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationCreationFromSelection.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material/styles';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ThemeDark from '../../../../components/ThemeDark';
+import InvestigationCreationFromSelection from './InvestigationCreationFromSelection';
+
+const { createInvestigation, mutationState } = vi.hoisted(() => ({
+  createInvestigation: vi.fn(),
+  mutationState: { creating: false },
+}));
+
+vi.mock('./useCreateInvestigationFromSelection', () => ({
+  default: () => ({ createInvestigation, creating: mutationState.creating }),
+}));
+
+const testTheme = createTheme(ThemeDark() as ThemeOptions);
+
+const renderComponent = (disabled: boolean, entityIds: string[]) => render(
+  <ThemeProvider theme={testTheme}>
+    <InvestigationCreationFromSelection
+      disabled={disabled}
+      entityIds={entityIds}
+    />
+  </ThemeProvider>,
+);
+
+describe('InvestigationCreationFromSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutationState.creating = false;
+  });
+
+  it('starts an investigation with the supplied entity ids', () => {
+    renderComponent(false, ['entity--1', 'relationship--2']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start an investigation' }));
+
+    expect(createInvestigation).toHaveBeenCalledWith(['entity--1', 'relationship--2']);
+  });
+
+  it('does not start an investigation when disabled', () => {
+    renderComponent(true, ['entity--1']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start an investigation' }));
+
+    expect(createInvestigation).not.toHaveBeenCalled();
+  });
+
+  it('does not start another investigation while one is being created', () => {
+    mutationState.creating = true;
+    renderComponent(false, ['entity--1']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start an investigation' }));
+
+    expect(createInvestigation).not.toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationCreationFromSelection.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationCreationFromSelection.tsx
@@ -1,0 +1,35 @@
+import IconButton from '@common/button/IconButton';
+import { TravelExploreOutlined } from '@mui/icons-material';
+import Tooltip from '@mui/material/Tooltip';
+import useCreateInvestigationFromSelection from './useCreateInvestigationFromSelection';
+
+interface InvestigationCreationFromSelectionProps {
+  disabled: boolean;
+  entityIds: string[];
+  title?: string;
+}
+
+const InvestigationCreationFromSelection = ({
+  disabled,
+  entityIds,
+  title = 'Start an investigation',
+}: InvestigationCreationFromSelectionProps) => {
+  const { createInvestigation, creating } = useCreateInvestigationFromSelection();
+
+  return (
+    <Tooltip title={title}>
+      <span>
+        <IconButton
+          aria-label={title}
+          disabled={disabled || creating}
+          onClick={() => createInvestigation(entityIds)}
+          size="small"
+        >
+          <TravelExploreOutlined fontSize="small" />
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default InvestigationCreationFromSelection;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { buildInvestigationEntityIds, isInvestigationSelectionEnabled } from './investigationSelectionUtils';
+
+describe('investigationSelectionUtils', () => {
+  describe('buildInvestigationEntityIds', () => {
+    it('includes the selected rows and the current knowledge entity once', () => {
+      const selectedElements = {
+        'entity--1': { id: 'entity--1' },
+        'entity--2': { id: 'entity--2' },
+      };
+
+      expect(buildInvestigationEntityIds(selectedElements, 'entity--1')).toEqual([
+        'entity--1',
+        'entity--2',
+      ]);
+    });
+
+    it('appends a distinct current knowledge entity', () => {
+      const selectedElements = {
+        'entity--1': { id: 'entity--1' },
+      };
+
+      expect(buildInvestigationEntityIds(selectedElements, 'entity--context')).toEqual([
+        'entity--1',
+        'entity--context',
+      ]);
+    });
+  });
+
+  describe('isInvestigationSelectionEnabled', () => {
+    const allowedTypes = {
+      stixCyberObservableTypes: ['IPv4-Addr'],
+      stixDomainObjectTypes: ['Malware'],
+      stixCoreRelationshipTypes: ['uses'],
+    };
+
+    it.each([
+      ['domain objects', ['Malware']],
+      ['cyber observables', ['IPv4-Addr']],
+      ['relationships', ['uses']],
+      ['sightings', ['stix-sighting-relationship']],
+      ['mixed supported objects', ['Malware', 'IPv4-Addr', 'uses']],
+    ])('allows explicit selections of %s', (_label, selectedTypes) => {
+      expect(isInvestigationSelectionEnabled({
+        ...allowedTypes,
+        numberOfSelectedElements: selectedTypes.length,
+        selectAll: false,
+        selectedTypes,
+      })).toBe(true);
+    });
+
+    it('rejects query-wide select all', () => {
+      expect(isInvestigationSelectionEnabled({
+        ...allowedTypes,
+        numberOfSelectedElements: 10,
+        selectAll: true,
+        selectedTypes: ['Malware'],
+      })).toBe(false);
+    });
+
+    it('rejects unsupported entity types', () => {
+      expect(isInvestigationSelectionEnabled({
+        ...allowedTypes,
+        numberOfSelectedElements: 1,
+        selectAll: false,
+        selectedTypes: ['Label'],
+      })).toBe(false);
+    });
+
+    it('rejects an empty selection', () => {
+      expect(isInvestigationSelectionEnabled({
+        ...allowedTypes,
+        numberOfSelectedElements: 0,
+        selectAll: false,
+        selectedTypes: [],
+      })).toBe(false);
+    });
+
+    it('rejects selections in a draft', () => {
+      expect(isInvestigationSelectionEnabled({
+        ...allowedTypes,
+        numberOfSelectedElements: 1,
+        selectAll: false,
+        selectedTypes: ['Malware'],
+        isInDraft: true,
+      })).toBe(false);
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.test.ts
@@ -36,8 +36,11 @@ describe('investigationSelectionUtils', () => {
 
     it.each([
       ['domain objects', ['Malware']],
+      ['generic domain objects', ['Stix-Domain-Object']],
       ['cyber observables', ['IPv4-Addr']],
+      ['generic cyber observables', ['Stix-Cyber-Observable']],
       ['relationships', ['uses']],
+      ['generic relationships', ['stix-core-relationship']],
       ['sightings', ['stix-sighting-relationship']],
       ['mixed supported objects', ['Malware', 'IPv4-Addr', 'uses']],
     ])('allows explicit selections of %s', (_label, selectedTypes) => {

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/investigationSelectionUtils.ts
@@ -1,0 +1,46 @@
+interface SelectedInvestigationEntity {
+  id: string;
+}
+
+interface InvestigationSelectionEligibility {
+  numberOfSelectedElements: number;
+  selectAll: boolean;
+  selectedTypes: string[];
+  stixCyberObservableTypes: string[];
+  stixCoreRelationshipTypes: string[];
+  stixDomainObjectTypes: string[];
+  isInDraft?: boolean;
+}
+
+export const buildInvestigationEntityIds = (
+  selectedElements: Record<string, SelectedInvestigationEntity>,
+  knowledgeEntityId?: string,
+) => Array.from(new Set([
+  ...Object.values(selectedElements).map(({ id }) => id),
+  ...(knowledgeEntityId ? [knowledgeEntityId] : []),
+]));
+
+export const isInvestigationSelectionEnabled = ({
+  numberOfSelectedElements,
+  selectAll,
+  selectedTypes,
+  stixCyberObservableTypes,
+  stixCoreRelationshipTypes,
+  stixDomainObjectTypes,
+  isInDraft = false,
+}: InvestigationSelectionEligibility) => {
+  if (isInDraft || selectAll || numberOfSelectedElements === 0) {
+    return false;
+  }
+  const supportedTypes = new Set([
+    'Stix-Cyber-Observable',
+    'Stix-Domain-Object',
+    'stix-core-relationship',
+    'stix-sighting-relationship',
+    ...stixCyberObservableTypes,
+    ...stixCoreRelationshipTypes,
+    ...stixDomainObjectTypes,
+  ]);
+  return selectedTypes.length > 0
+    && selectedTypes.every((type) => supportedTypes.has(type));
+};

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/useCreateInvestigationFromSelection.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/useCreateInvestigationFromSelection.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import useCreateInvestigationFromSelection from './useCreateInvestigationFromSelection';
+
+const { commitMutation, navigate, mutationState } = vi.hoisted(() => ({
+  commitMutation: vi.fn(),
+  navigate: vi.fn(),
+  mutationState: { inFlight: false },
+}));
+
+vi.mock('../../../../utils/hooks/useApiMutation', () => ({
+  default: () => [commitMutation, mutationState.inFlight],
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+describe('useCreateInvestigationFromSelection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-07T12:34:56.000Z'));
+    vi.clearAllMocks();
+    mutationState.inFlight = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates a timestamped investigation containing the supplied entities', () => {
+    const { result } = renderHook(() => useCreateInvestigationFromSelection());
+
+    act(() => result.current.createInvestigation(['entity--1', 'relationship--2']));
+
+    expect(commitMutation).toHaveBeenCalledWith(expect.objectContaining({
+      variables: {
+        input: {
+          type: 'investigation',
+          name: 'Investigation 2026-09-07T12:34:56.000Z',
+          investigated_entities_ids: ['entity--1', 'relationship--2'],
+          refresh_interval: null,
+        },
+      },
+    }));
+  });
+
+  it('opens the newly created investigation', () => {
+    const { result } = renderHook(() => useCreateInvestigationFromSelection());
+
+    act(() => result.current.createInvestigation(['entity--1']));
+    const mutationConfig = commitMutation.mock.calls[0][0];
+    act(() => mutationConfig.onCompleted({ workspaceAdd: { id: 'workspace--1' } }));
+
+    expect(navigate).toHaveBeenCalledWith('/dashboard/workspaces/investigations/workspace--1');
+  });
+
+  it('exposes the mutation in-flight state', () => {
+    mutationState.inFlight = true;
+
+    const { result } = renderHook(() => useCreateInvestigationFromSelection());
+
+    expect(result.current.creating).toBe(true);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/useCreateInvestigationFromSelection.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/useCreateInvestigationFromSelection.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { graphql } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
+import { handleError } from '../../../../relay/environment';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import { useCreateInvestigationFromSelectionMutation } from './__generated__/useCreateInvestigationFromSelectionMutation.graphql';
+
+const createInvestigationMutation = graphql`
+  mutation useCreateInvestigationFromSelectionMutation($input: WorkspaceAddInput!) {
+    workspaceAdd(input: $input) {
+      id
+    }
+  }
+`;
+
+const useCreateInvestigationFromSelection = () => {
+  const navigate = useNavigate();
+  const [commitMutation, creating] = useApiMutation<useCreateInvestigationFromSelectionMutation>(
+    createInvestigationMutation,
+  );
+
+  const createInvestigation = useCallback((entityIds: string[]) => {
+    commitMutation({
+      variables: {
+        input: {
+          type: 'investigation',
+          name: `Investigation ${new Date().toISOString()}`,
+          investigated_entities_ids: entityIds,
+          refresh_interval: null,
+        },
+      },
+      onCompleted: (data) => {
+        const investigationId = data.workspaceAdd?.id;
+        if (investigationId) {
+          navigate(`/dashboard/workspaces/investigations/${investigationId}`);
+        }
+      },
+      onError: handleError,
+    });
+  }, [commitMutation, navigate]);
+
+  return { createInvestigation, creating };
+};
+
+export default useCreateInvestigationFromSelection;


### PR DESCRIPTION
### Proposed changes

* Add a massive-operation toolbar action that creates an Investigation from explicitly selected SDOs, SCOs, SROs, and sightings.
* Include the current entity when the selection comes from a Knowledge panel, deduplicating it from the selected rows.
* Reuse `workspaceAdd`, navigate to the new Investigation, and guard creation by capability, draft state, select-all state, and mutation progress.

### Related issues

* Closes #4314

### How to test this PR

1. Select supported objects or relationships in search results or a list and click **Start an investigation**.
2. Confirm the new Investigation opens and contains the selected entities.
3. Repeat from an entity Knowledge panel and confirm the current entity is also included once.
4. Confirm the action is unavailable for query-wide select all, unsupported types, and drafts.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (not required for this focused toolbar action)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Verification completed locally with Node.js 22 and `TZ=UTC`: 154 test files / 1,361 tests passed, TypeScript and ESLint passed, and Relay plus the production build completed successfully.