### PR TITLE
chore(frontend): import from react-router instead of react-router-dom (#18156)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -112,7 +112,7 @@
     "react-pdf": "10.5.0",
     "react-relay": "21.0.1",
     "react-relay-network-modern": "6.2.2",
-    "react-router-dom": "7.18.3",
+    "react-router": "7.18.3",
     "react-syntax-highlighter": "16.1.1",
     "react-transition-group": "4.4.5",
     "react-virtualized": "9.22.6",

--- a/opencti-platform/opencti-front/src/app.test.tsx
+++ b/opencti-platform/opencti-front/src/app.test.tsx
@@ -4,7 +4,7 @@ import { RelayEnvironmentProvider } from 'react-relay';
 import type { OperationDescriptor } from 'react-relay';
 import { createMockEnvironment, MockPayloadGenerator as MockGen } from 'relay-test-utils';
 import { ThemeOptions, ThemeProvider, createTheme } from '@mui/material/styles';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { describe, afterEach, it, expect } from 'vitest';
 import AppIntlProvider from './components/AppIntlProvider';
 import Profile, { profileQuery } from './private/components/profile/Profile';

--- a/opencti-platform/opencti-front/src/app.tsx
+++ b/opencti-platform/opencti-front/src/app.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import React, { lazy, Suspense } from 'react';
 import { CookiesProvider } from 'react-cookie';
 import { APP_BASE_PATH } from './relay/environment';

--- a/opencti-platform/opencti-front/src/appRouterTransitions.test.tsx
+++ b/opencti-platform/opencti-front/src/appRouterTransitions.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Suspense, lazy } from 'react';
 import { act, render, screen } from '@testing-library/react';
-import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Link, Route, Routes } from 'react-router';
 
 const NeverReady = lazy(() => new Promise<never>(() => {}));
 

--- a/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
+++ b/opencti-platform/opencti-front/src/components/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/styles';
 import DangerZoneChip from '@components/common/danger_zone/DangerZoneChip';

--- a/opencti-platform/opencti-front/src/components/FilterValuesContent.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterValuesContent.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Stack, Tooltip } from '@mui/material';
 import { InformationOutline } from 'mdi-material-ui';
 import { filterValue, SELF_ID_VALUE } from '../utils/filters/filtersUtils';

--- a/opencti-platform/opencti-front/src/components/ItemAuthor.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemAuthor.tsx
@@ -1,5 +1,5 @@
 import Tag from '@common/tag/Tag';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { resolveLink } from '../utils/Entity';
 import { EMPTY_VALUE } from '../utils/String';
 

--- a/opencti-platform/opencti-front/src/components/ItemCreators.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCreators.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Security from '../utils/Security';
 import { SETTINGS_SETACCESSES } from '../utils/hooks/useGranted';
 import { Stack } from '@mui/material';

--- a/opencti-platform/opencti-front/src/components/RedirectManager.jsx
+++ b/opencti-platform/opencti-front/src/components/RedirectManager.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { MESSAGING$ } from '../relay/environment';
 
 export const RedirectManager = (props) => {

--- a/opencti-platform/opencti-front/src/components/SearchInput.jsx
+++ b/opencti-platform/opencti-front/src/components/SearchInput.jsx
@@ -3,7 +3,7 @@ import TextField from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import { ManageSearchOutlined, Search, TuneOutlined, KeyboardArrowDownOutlined } from '@mui/icons-material';
 import { LogoXtmOneIcon } from 'filigran-icon';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import makeStyles from '@mui/styles/makeStyles';
 import Tooltip from '@mui/material/Tooltip';
 import { useTheme } from '@mui/styles';

--- a/opencti-platform/opencti-front/src/components/SlugRedirectHandler.test.tsx
+++ b/opencti-platform/opencti-front/src/components/SlugRedirectHandler.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { screen } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import testRender from '../utils/tests/test-render';
 import SlugRedirectHandler from './SlugRedirectHandler';
 

--- a/opencti-platform/opencti-front/src/components/SlugRedirectHandler.tsx
+++ b/opencti-platform/opencti-front/src/components/SlugRedirectHandler.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 import useSplatLessBasePath from '../utils/hooks/useSplatLessBasePath';
 
 const EXTRACT_UUID_FROM_SEGMENT = (segment: string) => {

--- a/opencti-platform/opencti-front/src/components/common/card/Card.tsx
+++ b/opencti-platform/opencti-front/src/components/common/card/Card.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@mui/styles';
 import { Stack, SxProps, Card as CardMui, CardActionArea, StackProps } from '@mui/material';
 import CardTitle from './CardTitle';
 import { Theme } from '../../Theme';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { hasCustomColor } from '../../../utils/theme';
 
 export interface CardProps extends PropsWithChildren {

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetDistributionList.tsx
@@ -4,7 +4,7 @@ import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { useTheme } from '@mui/styles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { getMainRepresentative } from '../../utils/defaultRepresentatives';
 import ItemIcon from '../ItemIcon';
 import type { Theme } from '../Theme';

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetHorizontalBars.tsx
@@ -1,7 +1,7 @@
 import Chart, { OpenCTIChartProps } from '@components/common/charts/Chart';
 import React, { useMemo } from 'react';
 import { useTheme } from '@mui/styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { ApexOptions } from 'apexcharts';
 import { horizontalBarsChartOptions } from '../../utils/Charts';
 import { simpleNumberFormat } from '../../utils/Number';

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetListAudits.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetListAudits.tsx
@@ -1,6 +1,6 @@
 import List from '@mui/material/List';
 import { ListItemButton } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import React from 'react';

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
@@ -2,7 +2,7 @@ import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties, useMemo } from 'react';
 import { Skeleton, Checkbox, IconButton, Box } from '@mui/material';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { DataTableCellProps, DataTableLineProps } from '../dataTableTypes';
 import { DataTableVariant } from '../dataTableTypes';
 import type { Theme } from '../../Theme';

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableSearchEmptyState.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableSearchEmptyState.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import Box from '@mui/material/Box';
 import { DoNotDisturbOnOutlined, OpenInNew } from '@mui/icons-material';

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -32,7 +32,7 @@ import { useFormatter } from '../i18n';
 import Tag from '../common/tag/Tag';
 import { resolveLink } from '../../utils/Entity';
 import { typesWithNoAnalysesTab } from '../../utils/hooks/useAttributes';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import TagsOverflow from '../common/tag/TagsOverflow';
 import { VocabularyDefinition } from '../../utils/hooks/useVocabularyCategory';
 import { EMPTY_VALUE } from '../../utils/String';

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import { WarningOutlined } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../i18n';
 import { FiltersRestrictions, isFilterEditable, isFilterGroupNotEmpty, isRegardingOfFilterWarning, useFilterDefinition } from '../../utils/filters/filtersUtils';
 import { isDateIntervalTranslatable, translateDateInterval, truncate } from '../../utils/String';

--- a/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
@@ -4,7 +4,7 @@ import { ClearOutlined, DateRangeOutlined } from '@mui/icons-material';
 import IconButton from '@mui/material/IconButton';
 import { useTheme } from '@mui/material/styles';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../i18n';
 import { isValidDate, RELATIVE_DATE_REGEX } from '../../utils/String';
 import { Filter, handleFilterHelpers } from '../../utils/filters/filtersHelpers-types';

--- a/opencti-platform/opencti-front/src/components/graph/GraphContext.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContext.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useContext, createContext, useState, useEffect, useMemo, Dispatch, SetStateAction, MutableRefObject, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import * as graph2d from 'react-force-graph-2d';
 import * as graph3d from 'react-force-graph-3d';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../utils/ListParameters';

--- a/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
@@ -8,7 +8,7 @@ import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/styles';
 import IconButton from '@common/button/IconButton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { OpenInNewOutlined } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import EntityDetails from './EntityDetails';

--- a/opencti-platform/opencti-front/src/components/graph/components/EntityDetails.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/EntityDetails.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useState } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import Tooltip from '@mui/material/Tooltip';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import List from '@mui/material/List';

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
@@ -2,7 +2,7 @@ import { OpenWithOutlined, Undo } from '@mui/icons-material';
 import React, { useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import { graphql } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import InvestigationExpandForm, { InvestigationExpandFormProps } from '@components/workspaces/investigations/InvestigationExpandForm';
 import { useInvestigationState } from '@components/workspaces/investigations/utils/useInvestigationState';
 import InvestigationRollBackExpandDialog from '@components/workspaces/investigations/dialog/InvestigationRollBackExpandDialog';

--- a/opencti-platform/opencti-front/src/components/graph/components/RelationshipDetails.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/RelationshipDetails.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import Tooltip from '@mui/material/Tooltip';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 import List from '@mui/material/List';

--- a/opencti-platform/opencti-front/src/private/Index.tsx
+++ b/opencti-platform/opencti-front/src/private/Index.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useEffect } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
 import { useTheme } from '@mui/styles';

--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -1,7 +1,7 @@
 import { StyledEngineProvider } from '@mui/material/styles';
 import React, { FunctionComponent, useMemo } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery, useSubscription } from 'react-relay';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { AnalyticsProvider } from 'use-analytics';
 import Analytics from 'analytics';
 import { availableLanguage, ConnectedIntlProvider } from '../components/AppIntlProvider';

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -4,7 +4,7 @@ import * as PropTypes from 'prop-types';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ErrorNotFound from '../../components/ErrorNotFound';
 import { useFormatter } from '../../components/i18n';
 import { commitMutation } from '../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/RedirectByPath.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/RedirectByPath.test.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { describe, expect, it } from 'vitest';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router';
 import { screen } from '@testing-library/react';
 import testRender from '../../utils/tests/test-render';
 import RedirectByPath, { XTM_HUB_AUTO_REGISTER_QUERY_PARAM } from './RedirectByPath';

--- a/opencti-platform/opencti-front/src/private/components/RedirectByPath.tsx
+++ b/opencti-platform/opencti-front/src/private/components/RedirectByPath.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation, useParams } from 'react-router-dom';
+import { Navigate, useLocation, useParams } from 'react-router';
 import { NoMatch } from '@components/Error';
 
 export const XTM_HUB_AUTO_REGISTER_QUERY_PARAM = 'xtmHubAutoRegister';

--- a/opencti-platform/opencti-front/src/private/components/RootSearch.tsx
+++ b/opencti-platform/opencti-front/src/private/components/RootSearch.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import React from 'react';
 import { NoMatch } from '@components/Error';
 import Search from './Search';

--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import {
   SearchStixCoreObjectsLinesPaginationQuery,

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import { isEmpty } from 'ramda';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import SearchBulkUnknownEntities from './SearchBulkUnknownEntities';
 import { useFormatter } from '../../components/i18n';
 import Breadcrumbs from '../../components/Breadcrumbs';

--- a/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { compose } from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import { graphql } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/analyses/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Root.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 
 import { boundaryWrapper } from '../Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceDeletion.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { deleteNodeFromId } from '../../../../utils/store';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferencePopover.tsx
@@ -4,7 +4,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@common/button/IconButton';
 import { MoreVertOutlined } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import ToggleButton from '@mui/material/ToggleButton';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceStixCoreObjects.jsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/Root.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql, useSubscription } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferencesLines.tsx
@@ -22,7 +22,7 @@ import { FormikConfig } from 'formik/dist/types';
 import { includes } from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { createPaginationContainer, graphql, RelayPaginationProp } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
@@ -16,7 +16,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import React, { Component } from 'react';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ConnectionHandler } from 'relay-runtime';
 import { interval } from 'rxjs';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixSightingRelationshipExternalReferencesLines.jsx
@@ -17,7 +17,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import React, { Component } from 'react';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ConnectionHandler } from 'relay-runtime';
 import { interval } from 'rxjs';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -8,7 +8,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDeletion.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/StixDomainObjectAttackPatterns';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, useSubscription } from 'react-relay';
 import type { FragmentRef, GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootReportSubscription } from '@components/analyses/reports/__generated__/RootReportSubscription.graphql';

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { RelayError } from '../../../../relay/relayTypes';

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import EntityStixCoreRelationships from '@components/common/stix_core_relationships/EntityStixCoreRelationships';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import { RootMalwareAnalysisQuery$data } from './__generated__/RootMalwareAnalysisQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -1,5 +1,5 @@
 import { graphql, useSubscription } from 'react-relay';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { useMemo } from 'react';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteDeletion.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { StixCoreObjectOrStixCoreRelationshipNoteCard_node$data } from './__generated__/StixCoreObjectOrStixCoreRelationshipNoteCard_node.graphql';
 import { deleteNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Route, useParams } from 'react-router-dom';
+import { Route, useParams } from 'react-router';
 import { graphql, useSubscription } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { OpenInNewOutlined } from '@mui/icons-material';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid2';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionPopover.tsx
@@ -11,7 +11,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import { Formik } from 'formik';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { QueryRenderer } from '../../../../relay/environment';
 import { CollaborativeSecurity } from '../../../../utils/Security';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/Root.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsList.tsx
@@ -8,7 +8,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { FunctionComponent } from 'react';
 import { graphql, usePreloadedQuery } from 'react-relay';
 import type { PreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -8,7 +8,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDeletion.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertTitle, Checkbox, DialogActions, FormControlLabel, FormGroup
 import { useTheme } from '@mui/styles';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.tsx
@@ -1,6 +1,6 @@
 import { SyntheticEvent, useEffect, useReducer, useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router';
 import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/StixDomainObjectAttackPatterns';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledgeTimeLine.jsx
@@ -5,7 +5,7 @@ import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { graphql, useSubscription } from 'react-relay';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import StixDomainObjectMain from '@components/common/stix_domain_objects/StixDomainObjectMain';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import { Route, useLocation, useParams } from 'react-router-dom';
+import { Route, useLocation, useParams } from 'react-router';
 import Security from 'src/utils/Security';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import FileManager from '@components/common/files/FileManager';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
@@ -12,7 +12,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import StixCoreRelationshipPopover from '@components/common/stix_core_relationships/StixCoreRelationshipPopover';
 import { Box, ListItemButton, Stack } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import SecurityCoverageScores from '@components/analyses/security_coverages/SecurityCoverageScores';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
@@ -39,7 +39,7 @@ import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import SecurityCoverageEntityLine from './SecurityCoverageEntityLine';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { SecurityCoverageCreationMutation } from '@components/analyses/security_coverages/__generated__/SecurityCoverageCreationMutation.graphql';
 
 // Deprecated - https://mui.com/system/styles/basics/

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDeletion.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useDeletion from '../../../../utils/hooks/useDeletion';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
@@ -6,7 +6,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageKnowledge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { SecurityCoverageKnowledge_securityCoverage$key } from './__generated__/SecurityCoverageKnowledge_securityCoverage.graphql';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageSecurityPlatforms.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageSecurityPlatforms.tsx
@@ -5,7 +5,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Box, ListItemButton } from '@mui/material';
 import type { Theme } from '../../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/styles';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Box, ListItemButton } from '@mui/material';
 import type { Theme } from '../../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '@components/Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
 import useAuth from '../../../../utils/hooks/useAuth';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/cases/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '@components/Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -8,7 +8,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { handleErrorInForm } from 'src/relay/environment';
 import * as Yup from 'yup';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { RelayError } from '../../../../relay/relayTypes';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/StixDomainObjectAttackPatterns';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledgeTimeLine.jsx
@@ -5,7 +5,7 @@ import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import type { FragmentRef, GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixDomainObjectMain from '@components/common/stix_domain_objects/StixDomainObjectMain';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -8,7 +8,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { handleErrorInForm } from 'src/relay/environment';
 import * as Yup from 'yup';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/StixDomainObjectAttackPatterns';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledgeTimeLine.jsx
@@ -5,7 +5,7 @@ import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import type { FragmentRef, GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -8,7 +8,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { handleErrorInForm } from 'src/relay/environment';
 import * as Yup from 'yup';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { propOr } from 'ramda';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import StixDomainObjectAttackPatterns from '../../common/stix_domain_objects/StixDomainObjectAttackPatterns';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeTimeLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledgeTimeLine.jsx
@@ -5,7 +5,7 @@ import Timeline from '@mui/lab/Timeline';
 import TimelineItem from '@mui/lab/TimelineItem';
 import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineSeparator from '@mui/lab/TimelineSeparator';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import TimelineDot from '@mui/lab/TimelineDot';
 import TimelineConnector from '@mui/lab/TimelineConnector';
 import TimelineContent from '@mui/lab/TimelineContent';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import type { FragmentRef, GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, useLocation, useParams } from 'react-router-dom';
+import { Route, useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTasksLine.tsx
@@ -10,7 +10,7 @@ import MoreVert from '@mui/icons-material/MoreVert';
 import Drawer from '@components/common/drawer/Drawer';
 import CaseTaskOverview from '@components/cases/tasks/CaseTaskOverview';
 import { NorthEastOutlined } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ListItemButton } from '@mui/material';
 import ItemIcon from '../../../../components/ItemIcon';
 import type { Theme } from '../../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { deleteNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
@@ -6,7 +6,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
 import makeStyles from '@mui/styles/makeStyles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { PopoverProps } from '@mui/material/Popover';
 import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useIntl } from 'react-intl';
 import { ChatPanel, ChatMode } from '@filigran/chatbot';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useTheme } from '@mui/styles';
 import { LogoXtmOneIcon } from 'filigran-icon';
 import type { Theme } from '../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
@@ -18,7 +18,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import type { ApexOptions } from 'apexcharts';
 import ApexCharts from 'apexcharts';
 import { useTheme } from '@mui/styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { AuditsHorizontalBarsDistributionQuery } from '@components/common/audits/__generated__/AuditsHorizontalBarsDistributionQuery.graphql';
 import Chart from '../charts/Chart';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -9,7 +9,7 @@ import { useTheme } from '@mui/styles';
 import { ChartTimeline, VectorLink, VectorPolygon } from 'mdi-material-ui';
 import React, { useState } from 'react';
 import { createFragmentContainer, graphql, useLazyLoadQuery } from 'react-relay';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import ExportButtons from '../../../../components/ExportButtons';
 import { useFormatter } from '../../../../components/i18n';
 import PopoverMenu from '../../../../components/PopoverMenu';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerMappingContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerMappingContent.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery, useQueryLoader, UseQueryLoaderLoadQueryOptions } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import StixCoreObjectMappableContent from '@components/common/stix_core_objects/StixCoreObjectMappableContent';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ContainerStixCoreObjectsSuggestedMapping, { containerStixCoreObjectsSuggestedMappingQuery } from '@components/common/containers/ContainerStixCoreObjectsSuggestedMapping';
 import {
   ContainerStixCoreObjectsSuggestedMappingQuery,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsMappingLine.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsSuggestedMappingLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCoreObjectsSuggestedMappingLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixObjectOrStixRelationshipLine.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainerLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixRelationshipLastContainers.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql } from 'react-relay';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainers.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, Suspense } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { NorthEastOutlined, LoupeOutlined } from '@mui/icons-material';
 import { VectorLink } from 'mdi-material-ui';
 import IconButton from '@common/button/IconButton';

--- a/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainersDetailsTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainersDetailsTable.tsx
@@ -5,7 +5,7 @@ import {
   RelatedContainersDetailsTableLinesPaginationQuery,
 } from '@components/common/containers/related_containers/__generated__/RelatedContainersDetailsTableLinesPaginationQuery.graphql';
 import { RelatedContainersDetailsTableLines_data$data } from '@components/common/containers/related_containers/__generated__/RelatedContainersDetailsTableLines_data.graphql';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../../components/i18n';
 import DataTable from '../../../../../components/dataGrid/DataTable';
 import { usePaginationLocalStorage } from '../../../../../utils/hooks/useLocalStorage';

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEGuard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEGuard.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 
 interface EEGuardProps {

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileUploader.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { CloudUploadOutlined } from '@mui/icons-material';
 import IconButton from '@common/button/IconButton';

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileWork.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileWork.jsx
@@ -14,7 +14,7 @@ import { ArchitectureOutlined, CheckCircleOutlined, DeleteOutlined, WarningOutli
 import IconButton from '@common/button/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Slide from '@mui/material/Slide';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { commitMutation } from '../../../../relay/environment';
 import inject18n, { useFormatter } from '../../../../components/i18n';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';

--- a/opencti-platform/opencti-front/src/private/components/common/files/ImportWorksDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/ImportWorksDrawer.tsx
@@ -14,7 +14,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import { useTheme } from '@mui/styles';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { DataTableProps, DataTableVariant } from '../../../../components/dataGrid/dataTableTypes';
 import { defaultRender } from '../../../../components/dataGrid/dataTableUtils';
 import DataTableWithoutFragment from '../../../../components/dataGrid/DataTableWithoutFragment';

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -24,7 +24,7 @@ import { useTheme } from '@mui/styles';
 import { FormikConfig, FormikErrors, useFormik } from 'formik';
 import { useMemo, useState } from 'react';
 import { graphql, UseMutationConfig } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Theme } from '../../../../../components/Theme';
 import { THEME_DARK_DIALOG_BACKGROUND } from '../../../../../components/ThemeDark';
 import { THEME_LIGHT_DIALOG_BACKGROUND } from '../../../../../components/ThemeLight';

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -23,7 +23,7 @@ import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import { useEffect, useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { v4 as uuid } from 'uuid';
 import * as Yup from 'yup';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileLine.jsx
@@ -9,7 +9,7 @@ import Tooltip from '@mui/material/Tooltip';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import CircularProgress from '@mui/material/CircularProgress';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Slide from '@mui/material/Slide';
 import Chip from '@mui/material/Chip';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CreatorField.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, ReactNode, SyntheticEvent, useState } from 'react';
 import { graphql } from 'react-relay';
 import Box from '@mui/material/Box';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { OpenInNewOutlined } from '@mui/icons-material';
 import IconButton from '@common/button/IconButton';
 import { fetchQuery } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/common/history/HistoryLineContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/history/HistoryLineContent.tsx
@@ -14,7 +14,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import Tooltip from '@mui/material/Tooltip';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';

--- a/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/Filters.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, FunctionComponent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import ListFiltersWithoutLocalStorage from '@components/common/lists/ListFiltersWithoutLocalStorage';
 import { uniq } from 'ramda';
 import { constructHandleAddFilter, constructHandleRemoveFilter, emptyFilterGroup, FilterSearchContext, FiltersVariant } from '../../../../utils/filters/filtersUtils';

--- a/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/menus/NavToolbarMenu.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import Drawer from '@mui/material/Drawer';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectAskAI.tsx
@@ -15,7 +15,7 @@ import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
-import { createSearchParams, useNavigate } from 'react-router-dom';
+import { createSearchParams, useNavigate } from 'react-router';
 import Alert from '@mui/material/Alert';
 import { StixCoreObjectMappableContentFieldPatchMutation } from '@components/common/stix_core_objects/__generated__/StixCoreObjectMappableContentFieldPatchMutation.graphql';
 import {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContainer.tsx
@@ -18,7 +18,7 @@ import Tooltip from '@mui/material/Tooltip';
 import { AutocompleteInputChangeReason } from '@mui/material/useAutocomplete/useAutocomplete';
 import { ChangeEvent, SyntheticEvent, useEffect, useState } from 'react';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import useApiMutation from 'src/utils/hooks/useApiMutation';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
@@ -8,7 +8,7 @@ import { FileLineDeleteMutation as deleteMutation } from '@components/common/fil
 import { FileLineDeleteMutation } from '@components/common/files/__generated__/FileLineDeleteMutation.graphql';
 import MenuItem from '@mui/material/MenuItem';
 import Menu from '@mui/material/Menu';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import useDeletion from 'src/utils/hooks/useDeletion';
 import DeleteDialog from 'src/components/DeleteDialog';
 import StixCoreObjectFileExport, { BUILT_IN_HTML_TO_PDF } from '@components/common/stix_core_objects/StixCoreObjectFileExport';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentHeader.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import ToggleButton from '@mui/material/ToggleButton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { DifferenceOutlined, DriveFileRenameOutlineOutlined, NewspaperOutlined } from '@mui/icons-material';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentRoot.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import StixCoreObjectContentHeader from '@components/common/stix_core_objects/StixCoreObjectContentHeader';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router';
 import StixCoreObjectContent from '@components/common/stix_core_objects/StixCoreObjectContent';
 import { StixCoreObjectContent_stixCoreObject$key } from '@components/common/stix_core_objects/__generated__/StixCoreObjectContent_stixCoreObject.graphql';
 import ContainerMappingContent, { containerContentQuery } from '@components/common/containers/ContainerMappingContent';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { createSearchParams, useNavigate } from 'react-router-dom';
+import { createSearchParams, useNavigate } from 'react-router';
 import { FormikHelpers } from 'formik/dist/types';
 import { FileManagerExportMutation } from '@components/common/files/__generated__/FileManagerExportMutation.graphql';
 import { StixCoreObjectFileExportQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectFileExportQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFormSelector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFormSelector.tsx
@@ -4,7 +4,7 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { AssignmentOutlined } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { StixCoreObjectFormsFormsQuery$data } from '@components/common/stix_core_objects/__generated__/StixCoreObjectFormsFormsQuery.graphql';
 import Drawer from '../drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import Drawer from '@mui/material/Drawer';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectQuickSubscription.tsx
@@ -26,7 +26,7 @@ import { FormikConfig } from 'formik/dist/types';
 import { pick, uniq } from 'ramda';
 import React, { FunctionComponent, useState } from 'react';
 import { useRefetchableFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as Yup from 'yup';
 import AutocompleteField from '../../../../components/AutocompleteField';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSecurityCoverage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSecurityCoverage.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import Button from '@common/button/Button';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tooltip from '@mui/material/Tooltip';
 import makeStyles from '@mui/styles/makeStyles';
 import { Theme } from '@mui/material/styles/createTheme';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharing.tsx
@@ -14,7 +14,7 @@ import type { FormikHelpers } from 'formik/dist/types';
 import { BankPlus } from 'mdi-material-ui';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import { commitMutation, MESSAGING$, QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { StixCoreObjectSharingListDeleteMutation } from './__generated__/StixCoreObjectSharingListDeleteMutation.graphql';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
@@ -1,6 +1,6 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useTheme } from '@mui/material/styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Chart from '../charts/Chart';
 import { useFormatter } from '../../../../components/i18n';
 import { horizontalBarsChartOptions } from '../../../../utils/Charts';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineAll.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import ListItem from '@mui/material/ListItem';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineFrom.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import ListItem from '@mui/material/ListItem';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipLineTo.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import ListItem from '@mui/material/ListItem';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/EntityStixCoreRelationshipsHorizontalBars.jsx
@@ -1,6 +1,6 @@
 import { graphql } from 'react-relay';
 import CircularProgress from '@mui/material/CircularProgress';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTheme } from '@mui/styles';
 import Card from '@common/card/Card';
 import Chart from '../charts/Chart';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/SimpleStixObjectOrStixRelationshipStixCoreRelationshipLine.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import { AutoFix } from 'mdi-material-ui';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import ItemEntityType from '../../../../components/ItemEntityType';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipInference.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from 'react';
 import { Typography } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { isEmptyField } from '../../../../utils/utils';
 import MarkdownDisplay from '../../../../components/markdownDisplay/MarkdownDisplay';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
@@ -13,7 +13,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Component } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Card from '../../../../components/common/card/Card';
 import CardTitle from '../../../../components/common/card/CardTitle';
 import Label from '../../../../components/common/label/Label';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipStixCoreRelationshipsLines.jsx
@@ -6,7 +6,7 @@ import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { compose } from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tooltip from '@mui/material/Tooltip';
 import * as R from 'ramda';
 import { AutoFix } from 'mdi-material-ui';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualView.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql, PreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListLines from '../../../../../components/list_lines/ListLines';
 import { PaginationLocalStorage } from '../../../../../utils/hooks/useLocalStorage';
 import useAuth from '../../../../../utils/hooks/useAuth';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsContextualViewLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/EntityStixCoreRelationshipsEntitiesViewLine.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualView.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Chip from '@mui/material/Chip';
 import makeStyles from '@mui/styles/makeStyles';
 import {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsContextualViewLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as R from 'ramda';
 import { uniq } from 'ramda';
 import IconButton from '@common/button/IconButton';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectDetectDuplicate.jsx
@@ -9,7 +9,7 @@ import withStyles from '@mui/styles/withStyles';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
 import { Component } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import inject18n from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Box, ListItemButton } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import IconButton from '@common/button/IconButton';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -18,7 +18,7 @@ import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import React, { useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import * as Yup from 'yup';
 import PopoverMenu from '../../../../components/PopoverMenu';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
-import { Route } from 'react-router-dom';
+import { Route } from 'react-router';
 import testRender from '../../../../utils/tests/test-render';
 import StixDomainObjectMain from './StixDomainObjectMain';
 import { StixDomainObjectTabsBoxTab } from './StixDomainObjectTabsBox';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import StixDomainObjectTabsBox, { type StixDomainObjectTabsBoxTab } from './StixDomainObjectTabsBox';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import CustomViewRedirector from '@components/custom_views/CustomViewRedirector';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectNestedEntitiesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectNestedEntitiesLines.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton, Stack } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren, ReactNode } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTimeline.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTimeline.jsx
@@ -12,7 +12,7 @@ import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import Tooltip from '@mui/material/Tooltip';
 import TimelineDot from '@mui/lab/TimelineDot';
 import { graphql, createRefetchContainer } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Slide from '@mui/material/Slide';
 import ItemIcon from '../../../../components/ItemIcon';
 import inject18n, { isDateStringNone } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as R from 'ramda';
 import withStyles from '@mui/styles/withStyles';
 import IconButton from '@common/button/IconButton';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsLines.jsx
@@ -12,7 +12,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import { ExpandMore } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ListItemButton } from '@mui/material';
 import { truncate } from '../../../../utils/String';
 import { resolveLink } from '../../../../utils/Entity';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/diamond/types/nodes/NodeContainer.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, ReactNode } from 'react';
 import Button from '@common/button/Button';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Handle, Position } from 'reactflow';
 import { useFormatter } from 'src/components/i18n';
 import Card from '../../../../../../../components/common/card/Card';

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
@@ -31,8 +31,8 @@ vi.mock('../../drafts/useSwitchDraft', () => ({
   default: () => ({ exitDraft: vi.fn() }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return { ...actual, useNavigate: () => vi.fn() };
 });
 

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
@@ -32,8 +32,8 @@ vi.mock('../../drafts/useSwitchDraft', () => ({
   default: () => ({ exitDraft: vi.fn() }),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return { ...actual, useNavigate: () => vi.fn() };
 });
 

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.test.ts
@@ -45,8 +45,8 @@ vi.mock('react-relay', async (importOriginal) => {
   };
 });
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return { ...actual, useNavigate: () => mockNavigate };
 });
 

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useMutation } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useSwitchDraft from '../../drafts/useSwitchDraft';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSFIELDS } from '../../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import testRender from '../../../utils/tests/test-render';
 import CustomViewRedirector from './CustomViewRedirector';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { useCustomViewsData } from './useCustomViewsData';
 import type { CustomViewProps } from './CustomView';
 

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useMemo } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 import CustomView from './CustomView';
 import { useCustomViews } from './useCustomViews';
 import type { CustomView as CustomViewType } from './CustomViews-types';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTab.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tab, { TabProps } from '@mui/material/Tab';
 import type { CustomViewDisplayMode } from './useCustomViewTabs';
 import { useCustomViews } from './useCustomViews';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabDropDownMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabDropDownMenu.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import MenuItem from '@mui/material/MenuItem';
 import { DropDownMenu, useDropDownMenuState } from '../../../components/TabWithDropDownMenu';
 import { useCustomViews } from './useCustomViews';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import MenuItem from '@mui/material/MenuItem';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { useDropDownMenuState } from '../../../components/TabWithDropDownMenu';
 import { getCurrentTab } from '../../../utils/tabUtils';
 import { useCustomViews } from './useCustomViews';

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -60,7 +60,7 @@ import * as R from 'ramda';
 import { ascend, map, path, pathOr, pipe, sortWith, union } from 'ramda';
 import React, { Component } from 'react';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ItemIcon from '../../../components/ItemIcon';
 import ItemMarkings from '../../../components/ItemMarkings';
 import TasksFilterValueContainer from '../../../components/TasksFilterValueContainer';

--- a/opencti-platform/opencti-front/src/private/components/data/Feed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Feed.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import Box from '@mui/material/Box';
 import { FeedLinesPaginationQuery$data } from '@components/data/feeds/__generated__/FeedLinesPaginationQuery.graphql';
 import { QueryRenderer } from '../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/data/ImportMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ImportMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Tab from '@mui/material/Tab';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import Tabs from '@mui/material/Tabs';
 import { useFormatter } from '../../../components/i18n';
 

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
@@ -2,7 +2,7 @@ import React, { Suspense, useEffect, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { Field, useFormikContext } from 'formik';
 import Box from '@mui/material/Box';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Alert from '@mui/material/Alert';
 import CreatorField from '@components/common/form/CreatorField';
 import ConfidenceField from '@components/common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionRssImport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionRssImport.tsx
@@ -3,7 +3,7 @@ import VisuallyHiddenInput from '@components/common/VisuallyHiddenInput';
 import { graphql } from 'react-relay';
 import { FileUploadOutlined } from '@mui/icons-material';
 import ToggleButton from '@mui/material/ToggleButton/ToggleButton';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
 import { fetchQuery, MESSAGING$ } from '../../../relay/environment';
 import useXtmHubDownloadDocument from '../../../utils/hooks/useXtmHubDownloadDocument';

--- a/opencti-platform/opencti-front/src/private/components/data/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Root.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import useGranted, {
   AUTOMATION_AUTMANAGE,

--- a/opencti-platform/opencti-front/src/private/components/data/SyncImport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/SyncImport.tsx
@@ -3,7 +3,7 @@ import VisuallyHiddenInput from '@components/common/VisuallyHiddenInput';
 import { graphql } from 'react-relay';
 import { FileUploadOutlined } from '@mui/icons-material';
 import ToggleButton from '@mui/material/ToggleButton/ToggleButton';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
 import { fetchQuery, MESSAGING$ } from '../../../relay/environment';
 import SyncCreation from '@components/data/sync/SyncCreation';

--- a/opencti-platform/opencti-front/src/private/components/data/Taxii.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Taxii.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { TaxiiLinesPaginationQuery$data } from '@components/data/taxii/__generated__/TaxiiLinesPaginationQuery.graphql';
 import Box from '@mui/material/Box';
 import { QueryRenderer } from '../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -15,7 +15,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/styles';
 import { InformationOutline } from 'mdi-material-ui';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { interval } from 'rxjs';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';
 import FilterIconButton from '../../../../components/FilterIconButton';

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorDeploymentBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorDeploymentBanner.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import { Typography } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -14,7 +14,7 @@ import { PopoverProps } from '@mui/material/Popover';
 import ToggleButton from '@mui/material/ToggleButton';
 import { useTheme } from '@mui/styles';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -23,7 +23,7 @@ import Tooltip from '@mui/material/Tooltip';
 import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryLoader } from 'react-relay';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { interval } from 'rxjs';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Root.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { QueryRenderer } from '../../../../relay/environment';
 import Connector, { connectorQuery } from './Connector';
 import Loader from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
@@ -5,7 +5,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Checkbox from '@mui/material/Checkbox';
 import Skeleton from '@mui/material/Skeleton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { KeyboardArrowRight } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.test.tsx
@@ -32,8 +32,8 @@ vi.mock('../../../common/form/ObjectParticipantField', () => ({
 }));
 
 // Mock useParams
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useParams: () => ({ formId: 'form-id' }),

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
@@ -13,7 +13,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { Field, FieldArray, Form, Formik, FormikHelpers } from 'formik';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { fetchQuery, graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import * as Yup from 'yup';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 import Loader, { LoaderVariant } from '../../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/data/health/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/health/Root.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import PageContainer from '../../../../components/PageContainer';
 import HealthMenu from './HealthMenu';
 import Operations from './Operations';

--- a/opencti-platform/opencti-front/src/private/components/data/import/ManageImportConnectorMessage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ManageImportConnectorMessage.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/data/import/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/Root.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import Drafts from '../../drafts/Drafts';
 import WorkbenchFile from '../../common/files/workbench/WorkbenchFile';
 import ImportFilesContent from './ImportFilesContent';

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvImport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvImport.tsx
@@ -7,7 +7,7 @@ import { IngestionCsvImportQuery$data } from '@components/data/ingestionCsv/__ge
 import { IngestionCsvEditionFragment_ingestionCsv$data } from '@components/data/ingestionCsv/__generated__/IngestionCsvEditionFragment_ingestionCsv.graphql';
 import { FileUploadOutlined } from '@mui/icons-material';
 import ToggleButton from '@mui/material/ToggleButton/ToggleButton';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
 import { fetchQuery, MESSAGING$ } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionJson/IngestionJsonLine.tsx
@@ -10,7 +10,7 @@ import IngestionJsonPopover from '@components/data/ingestionJson/IngestionJsonPo
 import TableViewIcon from '@mui/icons-material/TableView';
 import { IngestionJsonLine_node$key } from '@components/data/ingestionJson/__generated__/IngestionJsonLine_node.graphql';
 import { IngestionJsonLinesPaginationQuery$variables } from '@components/data/ingestionJson/__generated__/IngestionJsonLinesPaginationQuery.graphql';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { useFormatter } from '../../../../components/i18n';
 import { DataColumns } from '../../../../components/list_lines';

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiImport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionTaxii/IngestionTaxiiImport.tsx
@@ -3,7 +3,7 @@ import VisuallyHiddenInput from '@components/common/VisuallyHiddenInput';
 import { graphql } from 'react-relay';
 import { FileUploadOutlined } from '@mui/icons-material';
 import ToggleButton from '@mui/material/ToggleButton/ToggleButton';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
 import { fetchQuery, MESSAGING$ } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookCreation.tsx
@@ -18,7 +18,7 @@ import { Field, Form, Formik } from 'formik';
 import Button from '@common/button/Button';
 import * as Yup from 'yup';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import ToggleButton from '@mui/material/ToggleButton';
 import { FileUploadOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookPopover.tsx
@@ -20,7 +20,7 @@ import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@common/button/IconButton';
 import MoreVert from '@mui/icons-material/MoreVert';
 import ToggleButton from '@mui/material/ToggleButton';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import fileDownload from 'js-file-download';
 import { PlaybooksLinesPaginationQuery$variables } from '@components/data/__generated__/PlaybooksLinesPaginationQuery.graphql';
 import PlaybookPopoverToggleDialog from './PlaybookPopoverToggleDialog';

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/Root.tsx
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import React, { Suspense, useEffect } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 import { graphql, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import type { PreloadedQuery } from 'react-relay';
 import { RootPlaybookQuery } from './__generated__/RootPlaybookQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/data/restriction/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/restriction/Root.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import PageContainer from '../../../../components/PageContainer';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import RestrictedDrafts from './RestrictedDrafts';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftApprove.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftApprove.tsx
@@ -10,7 +10,7 @@ import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
 import Transition from '../../../components/Transition';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
 import { MESSAGING$ } from '../../../relay/environment';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import useSwitchDraft from './useSwitchDraft';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
 import { DraftApproveFragment$key } from '@components/drafts/__generated__/DraftApproveFragment.graphql';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, ReactNode, useState } from 'react';
 import { DraftEntitiesLinesPaginationQuery, DraftEntitiesLinesPaginationQuery$variables } from '@components/drafts/__generated__/DraftEntitiesLinesPaginationQuery.graphql';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import { DraftEntitiesLines_data$data } from '@components/drafts/__generated__/DraftEntitiesLines_data.graphql';
 import StixDomainObjectCreation from '@components/common/stix_domain_objects/StixDomainObjectCreation';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftExit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftExit.tsx
@@ -1,5 +1,5 @@
 import { graphql } from 'relay-runtime';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Button from '../../../components/common/button/Button';
 import useSwitchDraft from './useSwitchDraft';
 import { useFormatter } from '../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import { DraftRelationshipsLines_data$data } from '@components/drafts/__generated__/DraftRelationshipsLines_data.graphql';
 import {

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/ContainerObjectsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/ContainerObjectsTab.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import LaunchIcon from '@mui/icons-material/Launch';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { useComputeLink } from '../../../../utils/hooks/useAppData';
 import useEntityTranslation from '../../../../utils/hooks/useEntityTranslation';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import LaunchIcon from '@mui/icons-material/Launch';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Loader from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/EntityContainerRefsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/EntityContainerRefsTab.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import LaunchIcon from '@mui/icons-material/Launch';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';
 import { EntityContainerRefsTabQuery } from './__generated__/EntityContainerRefsTabQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/EntityRelationsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/EntityRelationsTab.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import LaunchIcon from '@mui/icons-material/Launch';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { useComputeLink } from '../../../../utils/hooks/useAppData';
 import { EntityRelationsTabQuery } from './__generated__/EntityRelationsTabQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import { DraftSightingsLinesPaginationQuery, DraftSightingsLinesPaginationQuery$variables } from '@components/drafts/__generated__/DraftSightingsLinesPaginationQuery.graphql';
 import { DraftSightingsLines_data$data } from '@components/drafts/__generated__/DraftSightingsLines_data.graphql';

--- a/opencti-platform/opencti-front/src/private/components/drafts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Root.tsx
@@ -1,5 +1,5 @@
 import React, { lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
 

--- a/opencti-platform/opencti-front/src/private/components/entities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/entities/Sectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/Sectors.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as PropTypes from 'prop-types';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { QueryRenderer } from '../../../relay/environment';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../utils/ListParameters';
 import { useFormatter } from '../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';
 import useAuth from '../../../../utils/hooks/useAuth';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootEventQuery } from '@components/entities/events/__generated__/RootEventQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { propOr } from 'ramda';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -1,6 +1,6 @@
 import { propOr } from 'ramda';
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootOrganizationQuery } from '@components/entities/organizations/__generated__/RootOrganizationQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootSectorQuery } from '@components/entities/sectors/__generated__/RootSectorQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorLine.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import withStyles from '@mui/styles/withStyles';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorParentSectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorParentSectors.jsx
@@ -5,7 +5,7 @@ import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Domain } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { truncate } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorSubSectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorSubSectors.jsx
@@ -8,7 +8,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { ListItemButton, Tooltip } from '@mui/material';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import AddSubSector from './AddSubSector';
 import { addSubSectorsMutationRelationDelete } from './AddSubSectorsLines';
 import { commitMutation } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformDeletion.tsx
@@ -1,5 +1,5 @@
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import React from 'react';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformKnowledge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import StixDomainObjectKnowledge from '@components/common/stix_domain_objects/StixDomainObjectKnowledge';
 import { SecurityPlatformKnowledge_securityPlatform$key } from '@components/entities/securityPlatforms/__generated__/SecurityPlatformKnowledge_securityPlatform.graphql';

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams, useNavigate } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { propOr } from 'ramda';

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/events/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/Root.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationshipsIndicators from '@components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicators';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/ObservedDataDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, useParams } from 'react-router-dom';
+import { Route, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootObservedDataSubscription } from './__generated__/RootObservedDataSubscription.graphql';

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationshipLine.tsx
@@ -7,7 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { HelpOutlined, MoreVertOutlined } from '@mui/icons-material';
 import Chip from '@mui/material/Chip';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Skeleton from '@mui/material/Skeleton';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationship.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import Breadcrumbs from 'src/components/Breadcrumbs';
 import { useFormatter } from 'src/components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
@@ -14,7 +14,7 @@ import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Component } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import CardTitle from '../../../../components/common/card/CardTitle';
 import Label from '../../../../components/common/label/Label';
 import inject18n from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useMemo } from 'react';
-import { Link, Navigate, useParams } from 'react-router-dom';
+import { Link, Navigate, useParams } from 'react-router';
 import { Box, Stack, Tab, Tabs, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useQueryLoader } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/integrations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/Root.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import Loader from '../../../components/Loader';
 

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Box, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
 import { ViewListOutlined, ViewModuleOutlined, WidgetsOutlined } from '@mui/icons-material';
 import Grid from '@mui/material/Grid2';

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CardActions, Stack, Typography } from '@mui/material';
 import { GroupsOutlined } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { alpha, useTheme } from '@mui/material/styles';
 import { IngestionConnector } from '@components/integrations/catalog/types';
 import EnterpriseEditionButton from '@components/common/entreprise_edition/EnterpriseEditionButton';

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnector.tsx
@@ -10,7 +10,7 @@ import { ConnectorManagerStatusProvider, useConnectorManagerStatus } from '@comp
 import { Stack } from '@mui/material';
 import React, { Suspense, useEffect } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogConnectorCreation.tsx
@@ -10,7 +10,7 @@ import { graphql, useMutation } from 'react-relay';
 import { materialRenderers } from '@jsonforms/material-renderers';
 import { JsonForms } from '@jsonforms/react';
 import { Schema, Validator } from '@cfworker/json-schema';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { JsonSchema } from '@jsonforms/core';
 import Alert from '@mui/material/Alert';
 import Stack from '@mui/material/Stack';

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/hooks/useConnectorDeployDialog.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/hooks/useConnectorDeployDialog.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { IngestionConnector } from '@components/integrations/catalog/types';
 import { resolveLink } from '../../../../../utils/Entity';
 

--- a/opencti-platform/opencti-front/src/private/components/integrations/components/MarketplaceUi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/components/MarketplaceUi.tsx
@@ -3,7 +3,7 @@ import { Box, Chip, IconButton, Stack, Tooltip, Typography } from '@mui/material
 import { CheckCircleOutlined, ExpandMoreOutlined, Search } from '@mui/icons-material';
 import type { SvgIconComponent } from '@mui/icons-material';
 import { alpha, useTheme } from '@mui/material/styles';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Button from '@common/button/Button';
 import { useFormatter } from '../../../../components/i18n';
 import GradientCard from '../../../../components/GradientCard';

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { Box, MenuItem, Stack, TextField, ToggleButton, ToggleButtonGroup, Tooltip } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import { alpha, useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsStatsStrip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsStatsStrip.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, Suspense, useEffect, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { Box, Stack, Tooltip, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { DnsOutlined, DownloadOutlined, EngineeringOutlined, RocketLaunchOutlined, SpeedOutlined, StorageOutlined, SwapVertOutlined, UploadOutlined } from '@mui/icons-material';
 import type { SvgIconComponent } from '@mui/icons-material';
 import { interval } from 'rxjs';

--- a/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useEffect, useState } from 'react';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router';
 import { graphql, useQueryLoader, usePreloadedQuery } from 'react-relay';
 import type { GraphQLTaggedNode, PreloadedQuery } from 'react-relay';
 import type { OperationType } from 'relay-runtime';

--- a/opencti-platform/opencti-front/src/private/components/locations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';
 import { boundaryWrapper } from '../Error';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, type PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionDeletion.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootPositionQuery } from '@components/locations/positions/__generated__/RootPositionQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixDomainObjectKnowledge from '../../common/stix_domain_objects/StixDomainObjectKnowledge';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -69,7 +69,7 @@ import {
 } from 'mdi-material-ui';
 import React, { useRef, useState } from 'react';
 import { graphql, usePreloadedQuery } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { THEME_LIGHT_DEFAULT_BACKGROUND, THEME_LIGHT_DEFAULT_PAPER } from '../../../components/ThemeLight';
 import { useFormatter } from '../../../components/i18n';
 import { MESSAGING$ } from '../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
@@ -3,7 +3,7 @@ import { ArrowDropDown, OpenInNew } from '@mui/icons-material';
 import { Box, Divider, List, ListItemButton, ListItemIcon, Popover, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../components/i18n';
 import logoOpenAEVDark from '../../../static/images/logo_open_aev_dark.svg';
 import logoOpenAEVLight from '../../../static/images/logo_open_aev_light.svg';

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
@@ -2,7 +2,7 @@ import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
 import { alpha, Collapse, List, ListItemButton, ListItemIcon, ListItemText, MenuItem, MenuList, Popover, SxProps, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import React, { useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { Theme } from '../../../components/Theme';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
 

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -11,7 +11,7 @@ import { useTheme } from '@mui/styles';
 import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 import { usePage } from 'use-analytics';
 import { useFormatter } from '../../../components/i18n';
 import ItemBoolean from '../../../components/ItemBoolean';

--- a/opencti-platform/opencti-front/src/private/components/observations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 import { boundaryWrapper } from '@components/Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import StixSightingRelationship from '@components/events/stix_sighting_relationships/StixSightingRelationship';
 import StixCyberObservableKnowledge from '../stix_cyber_observables/StixCyberObservableKnowledge';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/DecayExclusionDialogContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/DecayExclusionDialogContent.tsx
@@ -4,7 +4,7 @@ import { IndicatorDetails_indicator$data } from '@components/observations/indica
 import { Stack, Typography } from '@mui/material';
 import DialogActions from '@mui/material/DialogActions';
 import { FunctionComponent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Alert from '../../../../components/Alert';
 import { useFormatter } from '../../../../components/i18n';
 import { resolveLink } from '../../../../utils/Entity';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { compose } from 'ramda';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { createFragmentContainer, graphql } from 'react-relay';
 import withStyles from '@mui/styles/withStyles';
 import ListItem from '@mui/material/ListItem';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import IndicatorEntities from './IndicatorEntities';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import StixSightingRelationship from '@components/events/stix_sighting_relationships/StixSightingRelationship';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootIndicatorQuery } from '@components/observations/indicators/__generated__/RootIndicatorQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import StixCoreObjectKnowledgeBar from '@components/common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootStixCyberObservableQuery } from '@components/observations/stix_cyber_observables/__generated__/RootStixCyberObservableQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
 import { assoc, difference, filter, fromPairs, head, includes, map, pick, pipe } from 'ramda';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import * as Yup from 'yup';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntitiesLines.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { interval } from 'rxjs';
 import { createPaginationContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableIndicators.jsx
@@ -13,7 +13,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/styles';
 import { useRef, useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Label from '../../../../components/common/label/Label';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql, createFragmentContainer } from 'react-relay';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import StixSightingRelationship from '@components/events/stix_sighting_relationships/StixSightingRelationship';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import StixCyberObservableKnowledgeEntities from './StixCyberObservableEntities';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableMalwareAnalyses.tsx
@@ -4,7 +4,7 @@ import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import makeStyles from '@mui/styles/makeStyles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Chip from '@mui/material/Chip';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/pir/Pir.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/Pir.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { Suspense } from 'react';
 import { graphql, usePreloadedQuery } from 'react-relay';
 import type { PreloadedQuery } from 'react-relay';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 import { PirQuery } from './__generated__/PirQuery.graphql';
 import PirHeader from './PirHeader';
 import PirTabs from './PirTabs';

--- a/opencti-platform/opencti-front/src/private/components/pir/PirPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/PirPopover.tsx
@@ -17,7 +17,7 @@ import React, { UIEvent, useState } from 'react';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { Menu, MenuItem, PopoverProps, ToggleButton } from '@mui/material';
 import { graphql, useFragment } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { PirPopoverFragment$key } from './__generated__/PirPopoverFragment.graphql';
 import { useFormatter } from '../../../components/i18n';
 import stopEvent from '../../../utils/domEvent';

--- a/opencti-platform/opencti-front/src/private/components/pir/PirTabs.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/PirTabs.tsx
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React from 'react';
 import { Box, Tab, Tabs } from '@mui/material';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { useFormatter } from '../../../components/i18n';
 import { PirTabsFragment$key } from './__generated__/PirTabsFragment.graphql';

--- a/opencti-platform/opencti-front/src/private/components/pir/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/Root.tsx
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import React, { Suspense } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { boundaryWrapper } from '@components/Error';
 import EnterpriseEdition from '@components/common/entreprise_edition/EnterpriseEdition';
 import Pirs from './Pirs';

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/PirOverviewHistory.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Tooltip from '@mui/material/Tooltip';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/pir_threat_map/PirThreatMapTooltip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/pir_threat_map/PirThreatMapTooltip.tsx
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React, { CSSProperties, MouseEventHandler } from 'react';
 import { useTheme } from '@mui/material/styles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Box } from '@mui/material';
 import type { Theme } from '../../../../../components/Theme';
 import { PirThreatMapMarker } from './pirThreatMapUtils';

--- a/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Alerts.tsx
@@ -13,7 +13,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
 import { FunctionComponent, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
 import { defaultRender } from '../../../components/dataGrid/dataTableUtils';

--- a/opencti-platform/opencti-front/src/private/components/profile/ForcePasswordChange.jsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/ForcePasswordChange.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Stack, useTheme } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import PasswordPolicies from '../common/form/PasswordPolicies';
 import { useFormatter } from '../../../components/i18n';
 import { MESSAGING$ } from '../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/profile/NewsFeed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/NewsFeed.tsx
@@ -5,7 +5,7 @@ import { Alert, IconButton, Stack, Tooltip } from '@mui/material';
 import { OpenInNewOutlined } from '@mui/icons-material';
 import React, { FunctionComponent, Suspense, useCallback, useEffect, useMemo } from 'react';
 import { graphql, PreloadedQuery, useMutation, useSubscription } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Tag from '../../../components/common/tag/Tag';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -3,7 +3,7 @@ import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { graphql, useLazyLoadQuery, useSubscription } from 'react-relay';
-import { Navigate, Outlet, useMatch, useNavigate } from 'react-router-dom';
+import { Navigate, Outlet, useMatch, useNavigate } from 'react-router';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';

--- a/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.jsx
@@ -13,7 +13,7 @@ import qrcode from 'qrcode';
 import { compose, pick } from 'ramda';
 import { useEffect, useState } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import * as Yup from 'yup';
 import { availableLanguage } from '../../../components/AppIntlProvider';
 import Label from '../../../components/common/label/Label';

--- a/opencti-platform/opencti-front/src/private/components/profile/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Root.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import Notifications from './Notifications';
 import Profile from './Profile';

--- a/opencti-platform/opencti-front/src/private/components/profile/__tests__/ForcePasswordChange.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/__tests__/ForcePasswordChange.test.tsx
@@ -8,8 +8,8 @@ import { handleErrorInForm, MESSAGING$ } from '../../../../relay/environment';
 const navigateMock = vi.fn();
 const commitFnMock = vi.fn();
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return {
     ...actual,
     useNavigate: () => navigateMock,

--- a/opencti-platform/opencti-front/src/private/components/search/SearchContainerQuery.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchContainerQuery.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, ReactNode, Suspense, useEffect } from 'react'
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router';
 import EEChip from '@components/common/entreprise_edition/EEChip';
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import Badge from '@mui/material/Badge';

--- a/opencti-platform/opencti-front/src/private/components/search/SearchIndexedFiles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/search/SearchIndexedFiles.tsx
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React from 'react';
 import { SearchIndexedFilesFile_node$data } from './__generated__/SearchIndexedFilesFile_node.graphql';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import EnterpriseEdition from '@components/common/entreprise_edition/EnterpriseEdition';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';

--- a/opencti-platform/opencti-front/src/private/components/settings/Groups.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Groups.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql } from 'react-relay';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../utils/ListParameters';
 import type { Theme } from '../../../components/Theme';
 import { useFormatter } from '../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/settings/Roles.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Roles.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../components/i18n';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../utils/ListParameters';

--- a/opencti-platform/opencti-front/src/private/components/settings/Root.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Root.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import testRender from '../../../utils/tests/test-render';
 import { SETTINGS_SETMANAGEXTMHUB, SETTINGS_SUPPORT } from '../../../utils/hooks/useGranted';
 import Root from './Root';

--- a/opencti-platform/opencti-front/src/private/components/settings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useEffect } from 'react';
-import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router';
 import {
   SETTINGS_SETCUSTOMIZATION,
   SETTINGS_SETLABELS,

--- a/opencti-platform/opencti-front/src/private/components/settings/SessionsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/SessionsList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql } from 'react-relay';
 import { ShortTextOutlined } from '@mui/icons-material';
 import VocabularyPopover from '@components/settings/attributes/VocabularyPopover';

--- a/opencti-platform/opencti-front/src/private/components/settings/accesses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/accesses/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import useGranted, {
   isOnlyOrganizationAdmin,
   SETTINGS_SETACCESSES,

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import Loader from '../../../../components/Loader';
 import ActivityMenu from '../ActivityMenu';
 import { SETTINGS_SECURITYACTIVITY } from '../../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditDrawer.tsx
@@ -2,7 +2,7 @@ import Drawer from '@components/common/drawer/Drawer';
 import { Stack } from '@mui/material';
 import { FunctionComponent, Suspense } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Alert from '../../../../../components/Alert';
 import Loader from '../../../../../components/Loader';
 import Label from '../../../../../components/common/label/Label';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateLine.tsx
@@ -4,7 +4,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ListItemButton } from '@mui/material';
 import type { Theme } from '../../../../components/Theme';
 import { CaseTemplateLine_node$key } from './__generated__/CaseTemplateLine_node.graphql';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
@@ -3,7 +3,7 @@ import MenuItem from '@mui/material/MenuItem';
 import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, PreloadedQuery } from 'react-relay';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import HeaderMainEntityLayout from '../../../../components/common/header/HeaderMainEntityLayout';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksPopover.tsx
@@ -11,7 +11,7 @@ import { PopoverProps } from '@mui/material/Popover';
 import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/settings/customization/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/customization/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import Loader from '../../../../components/Loader';
 import CustomizationMenu from '../CustomizationMenu';
 import useGranted, { SETTINGS_SETCUSTOMIZATION } from '../../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
@@ -5,7 +5,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
 import { InformationOutline } from 'mdi-material-ui';
 import DecayChart, { DecayHistory } from '@components/settings/decay/DecayChart';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { DecayRuleQuery } from '@components/settings/decay/__generated__/DecayRuleQuery.graphql';
 import { useTheme } from '@mui/styles';
 import DecayRuleEdition from './DecayRuleEdition';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import DeleteDialog from '../../../../components/DeleteDialog';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleTabs.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleTabs.tsx
@@ -7,7 +7,7 @@ import useConnectedDocumentModifier from 'src/utils/hooks/useConnectedDocumentMo
 import DecayRules from '@components/settings/decay/DecayRules';
 import Breadcrumbs from 'src/components/Breadcrumbs';
 import DecayExclusionRules from './DecayExclusionRules';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 const DecayRuleTabs = () => {
   const { t_i18n } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplate.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplate.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { EmailTemplateQuery } from '@components/settings/email_template/__generated__/EmailTemplateQuery.graphql';
 import { EmailTemplateProvider } from '@components/settings/email_template/EmailTemplateContext';
 import EmailTemplateHeader from '@components/settings/email_template/EmailTemplateHeader';

--- a/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateFormDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateFormDrawer.tsx
@@ -1,7 +1,7 @@
 import Drawer from '@components/common/drawer/Drawer';
 import React from 'react';
 import { FormikConfig } from 'formik/dist/types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import EmailTemplateForm, { EmailTemplateFormInputKeys, EmailTemplateFormInputs } from '@components/settings/email_template/EmailTemplateForm';
 import useEmailTemplateAdd from '@components/settings/email_template/useEmailTemplateAdd';
 import useEmailTemplateEdit from '@components/settings/email_template/useEmailTemplateEdit';

--- a/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { useTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles/createTheme';

--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
@@ -7,7 +7,7 @@ import { graphql } from 'react-relay';
 import { ExclusionListsLine_node$data } from '@components/settings/exclusion_lists/__generated__/ExclusionListsLine_node.graphql';
 import { ExclusionListsLinesPaginationQuery$variables } from '@components/settings/exclusion_lists/__generated__/ExclusionListsLinesPaginationQuery.graphql';
 import ExclusionListEdition, { exclusionListMutationFieldPatch } from '@components/settings/exclusion_lists/ExclusionListEdition';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesign.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesign.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { FintelDesignQuery } from '@components/settings/fintel_design/__generated__/FintelDesignQuery.graphql';
 import Grid from '@mui/material/Grid2';
 import Button from '@common/button/Button';

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignFormDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignFormDrawer.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
 import { Field, Form, Formik, FormikConfig, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { useTheme } from '@mui/material';
 import Drawer, { DrawerControlledDialType } from '@components/common/drawer/Drawer';

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Group.tsx
@@ -10,7 +10,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { InformationOutline } from 'mdi-material-ui';
 import * as R from 'ramda';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import GroupConfidenceLevel from '@components/settings/groups/GroupConfidenceLevel';
 import { uniq } from 'ramda';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupDeletionDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupDeletionDialog.tsx
@@ -3,7 +3,7 @@ import Dialog from '@common/dialog/Dialog';
 import { DialogActions, DialogContentText } from '@mui/material';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupLine.tsx
@@ -6,7 +6,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Box from '@mui/material/Box';
 import { CheckCircleOutlined, DoNotDisturbOnOutlined, KeyboardArrowRightOutlined, ReportGmailerrorred } from '@mui/icons-material';
 import Skeleton from '@mui/material/Skeleton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import makeStyles from '@mui/styles/makeStyles';
 import { GroupLine_node$data } from '@components/settings/groups/__generated__/GroupLine_node.graphql';
 import Tooltip from '@mui/material/Tooltip';

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/Root.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo, useState } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { Box, Stack } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/Root.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganization.tsx
@@ -7,7 +7,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Tooltip from '@mui/material/Tooltip';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import EnterpriseEdition from '@components/common/entreprise_edition/EnterpriseEdition';
 import { ListItemButton, Stack } from '@mui/material';
 import FieldOrEmpty from '../../../../components/FieldOrEmpty';

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationLine.tsx
@@ -4,7 +4,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import Skeleton from '@mui/material/Skeleton';
 import ListItemText from '@mui/material/ListItemText';
 import { KeyboardArrowRightOutlined, MoreVertOutlined } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import makeStyles from '@mui/styles/makeStyles';
 import { graphql, useFragment } from 'react-relay';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/platform_alerts/GroupWithNullConfidenceLevelAlertContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/platform_alerts/GroupWithNullConfidenceLevelAlertContent.tsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
 import React, { Fragment } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import { RootSettings$data } from '../../../__generated__/RootSettings.graphql';
 

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/Role.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/Role.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import makeStyles from '@mui/styles/makeStyles';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleDeletionDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleDeletionDialog.tsx
@@ -3,7 +3,7 @@ import Dialog from '@common/dialog/Dialog';
 import { DialogActions, DialogContentText } from '@mui/material';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleLine.jsx
@@ -8,7 +8,7 @@ import ListItemText from '@mui/material/ListItemText';
 import { KeyboardArrowRightOutlined } from '@mui/icons-material';
 import { compose } from 'ramda';
 import Skeleton from '@mui/material/Skeleton';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ListItemButton } from '@mui/material';
 import Box from '@mui/material/Box';
 import inject18n from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/Root.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
-import { Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router';
 import { graphql, PreloadedQuery, useLazyLoadQuery, usePreloadedQuery } from 'react-relay';
 import { Box, Stack } from '@mui/material';
 import MenuItem from '@mui/material/MenuItem';

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_analytics/SettingsAnalytics.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { InformationOutline } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
 import EEChip from '@components/common/entreprise_edition/EEChip';

--- a/opencti-platform/opencti-front/src/private/components/settings/smtp_configuration/SmtpRefreshTokenBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/smtp_configuration/SmtpRefreshTokenBanner.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect } from 'react';
 import { graphql, PreloadedQuery, useQueryLoader, usePreloadedQuery } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import TopBanner from '../../../../components/TopBanner';
 import { useFormatter } from '../../../../components/i18n';
 import { getSmtpRefreshTokenBannerState } from '../../../../utils/bannerUtils';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/Root.tsx
@@ -1,6 +1,6 @@
 import EEGuard from '@components/common/entreprise_edition/EEGuard';
 import { Suspense } from 'react';
-import { Navigate, Route, Routes, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useParams } from 'react-router';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Loader from '../../../../components/Loader';
 import FintelTemplate from './fintel_templates/FintelTemplate';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
@@ -2,7 +2,7 @@ import type { SubTypeQuery } from './__generated__/SubTypeQuery.graphql';
 import { Box, Stack } from '@mui/material';
 import React, { Suspense } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router';
 import { ErrorBoundary } from '@components/Error';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import ErrorNotFound from '../../../../components/ErrorNotFound';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeMenu.tsx
@@ -1,5 +1,5 @@
 import { Tab, Tabs } from '@mui/material';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import type { SubTypeTabs } from './SubTypeOutletContext';
 import { getCurrentTab } from '../../../../utils/tabUtils';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeOutletContext.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeOutletContext.ts
@@ -1,4 +1,4 @@
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext } from 'react-router';
 import { SubTypeQuery } from './__generated__/SubTypeQuery.graphql';
 
 export const SUBTYPE_TAB_WORKFLOW = 'workflow';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
@@ -6,7 +6,7 @@ import { KeyboardArrowRightOutlined, CheckCircleOutlined, DoNotDisturbOnOutlined
 import ListItem from '@mui/material/ListItem';
 import Skeleton from '@mui/material/Skeleton';
 import { ListItemButton } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Checkbox from '@mui/material/Checkbox';
 import makeStyles from '@mui/styles/makeStyles';
 import ItemIcon from '../../../../components/ItemIcon';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, UIEvent, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEdition.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo, useState } from 'react';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import Box from '@mui/material/Box';
 import { Stack } from '@mui/material';
 import ErrorNotFound from '../../../../../components/ErrorNotFound';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewFormDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewFormDrawer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { type FormikConfig } from 'formik';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Drawer from '@components/common/drawer/Drawer';
 import { useFormatter } from '../../../../../components/i18n';
 import { fetchQuery as relayFetchQuery, graphql } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewMenu.tsx
@@ -1,6 +1,6 @@
 import React, { UIEvent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVert from '@mui/icons-material/MoreVert';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/import-export/useCustomViewImport.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/import-export/useCustomViewImport.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { handleError, MESSAGING$ } from '../../../../../../relay/environment';
 import useDashboardImport from '../../../../../../components/dashboard/import-export/useDashboardImport';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingHiddenTypesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingHiddenTypesList.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { Box, ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplate.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplate.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import FintelTemplatePreview from './FintelTemplatePreview';
 import { FintelTemplateProvider } from './FintelTemplateContext';
 import FintelTemplateContentEditor from './FintelTemplateContentEditor';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateFormDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateFormDrawer.tsx
@@ -1,7 +1,7 @@
 import Drawer from '@components/common/drawer/Drawer';
 import { useState } from 'react';
 import { type FormikConfig } from 'formik';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { fetchQuery as relayFetchQuery, graphql } from 'react-relay';
 import useFintelTemplateAdd from './useFintelTemplateAdd';
 import useFintelTemplateEdit from './useFintelTemplateEdit';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { Typography } from '@mui/material';
 import { useTheme } from '@mui/styles';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import React, { useEffect } from 'react';
 import ObjectMarkingField from '@components/common/form/ObjectMarkingField';
 import { CONTENT_MAX_MARKINGS_HELPERTEXT, CONTENT_MAX_MARKINGS_TITLE } from '@components/common/files/FileManager';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import EntitySelectField from '@components/common/form/EntitySelectField';
 import { EntityOption } from '@components/common/form/EntitySelect';
 import FintelDesignField, { FintelDesignFieldOption } from '@components/common/form/FintelDesignField';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsList.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { List, Alert, Typography } from '@mui/material';
 import Button from '@common/button/Button';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import FintelTemplateWidgetDefault from './FintelTemplateWidgetDefault';
 import FintelTemplateWidgetAttribute from './FintelTemplateWidgetAttribute';
 import { useFormatter } from '../../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
@@ -4,7 +4,7 @@ import { useSettingsMessagesBannerHeight } from '@components/settings/settings_m
 import { useTheme } from '@mui/styles';
 import { graphql, useFragment } from 'react-relay';
 import { useFintelTemplateContext } from '@components/settings/sub_types/fintel_templates/FintelTemplateContext';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { fintelTemplateVariableNameChecker } from '@components/widgets/useWidgetConfigValidateForm';
 import useFintelTemplateEdit from './useFintelTemplateEdit';
 import { FintelTemplateWidgetsSidebar_template$key } from './__generated__/FintelTemplateWidgetsSidebar_template.graphql';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatesManager.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatesManager.tsx
@@ -5,7 +5,7 @@ import { Add as AddIcon, CloudUploadOutlined } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import { BaseSyntheticEvent, useRef, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import Card from '../../../../../components/common/card/Card';
 import { useFormatter } from '../../../../../components/i18n';
 import { handleError, MESSAGING$ } from '../../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Link, Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, useLazyLoadQuery, usePreloadedQuery, useQueryLoader, useSubscription } from 'react-relay';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -17,7 +17,7 @@ import { useTheme } from '@mui/styles';
 import { ApexOptions } from 'apexcharts';
 import { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import Card from '../../../../components/common/card/Card';
 import Label from '../../../../components/common/label/Label';
 import Tag from '../../../../components/common/tag/Tag';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceLevel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { ReportGmailerrorred } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceOverrides.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserConfidenceOverrides.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EffectiveConfidenceLevelSourceType } from '@components/settings/users/__generated__/User_user.graphql';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 
 type UserConfidenceOverridesProps = {

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
@@ -3,7 +3,7 @@ import Dialog from '@common/dialog/Dialog';
 import { DialogActions } from '@mui/material';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistory.tsx
@@ -7,7 +7,7 @@ import IconButton from '@common/button/IconButton';
 import { StorageOutlined } from '@mui/icons-material';
 import { VectorRadius } from 'mdi-material-ui';
 import { Stack } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { GqlFilterGroup } from '../../../../utils/filters/filtersUtils';
 import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryTab.tsx
@@ -7,7 +7,7 @@ import { useTheme } from '@mui/styles';
 import { LinkVariantPlus, LinkVariantRemove, Merge, VectorRadius } from 'mdi-material-ui';
 import { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { v4 as uuid } from 'uuid';
 import DataTable from '../../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../../components/dataGrid/dataTableTypes';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
@@ -6,7 +6,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
 import { PersonOutlined, AccountCircleOutlined, KeyboardArrowRightOutlined, HorizontalRule, Security, ReportGmailerrorred, ManageAccountsOutlined } from '@mui/icons-material';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import makeStyles from '@mui/styles/makeStyles';
 import { UserLine_node$data } from '@components/settings/users/__generated__/UserLine_node.graphql';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/settings/vocabularies/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/vocabularies/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import Loader from '../../../../components/Loader';
 import LabelsVocabulariesMenu from '../LabelsVocabulariesMenu';
 import useGranted, {

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
@@ -14,7 +14,7 @@ import ProcessLoader from './ProcessLoader';
 import ProcessDialog from './ProcessDialog';
 import type { Theme } from '../../../../components/Theme';
 import { LICENSE_OPTION_TRIAL } from '@components/LicenseBanner';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { XTM_HUB_AUTO_REGISTER_QUERY_PARAM } from '@components/RedirectByPath';
 
 enum ProcessSteps {

--- a/opencti-platform/opencti-front/src/private/components/techniques/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCoursesOfAction.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCoursesOfAction.jsx
@@ -3,7 +3,7 @@ import { filter } from 'ramda';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { Delete } from '@mui/icons-material';
 import { createFragmentContainer, graphql } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDataComponents.tsx
@@ -1,7 +1,7 @@
 import { createFragmentContainer, graphql } from 'react-relay';
 import React, { FunctionComponent } from 'react';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemText from '@mui/material/ListItemText';
 import IconButton from '@common/button/IconButton';
 import { Delete } from '@mui/icons-material';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternParentAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternParentAttackPatterns.jsx
@@ -4,7 +4,7 @@ import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { LockPattern } from 'mdi-material-ui';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternSubAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternSubAttackPatterns.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import * as R from 'ramda';
 import List from '@mui/material/List';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { Delete } from '@mui/icons-material';
 import { createFragmentContainer, graphql } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixColumns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixColumns.tsx
@@ -3,7 +3,7 @@ import { Box, ListItemIcon, ListItemText, Menu, MenuItem, Typography } from '@mu
 import { AddCircleOutlineOutlined, InfoOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AttackPatternsMatrixProps, attackPatternsMatrixQuery } from '@components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrix';
 import AccordionAttackPattern from '@components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixAccordion';
 import AttackPatternsMatrixBadge from '@components/techniques/attack_patterns/attack_patterns_matrix/AttackPatternsMatrixBadge';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionAttackPatterns.jsx
@@ -6,7 +6,7 @@ import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Avatar from '@mui/material/Avatar';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { ExpandLessOutlined, ExpandMoreOutlined, LinkOff } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql, createFragmentContainer } from 'react-relay';
 import withRouter from '../../../../utils/compat_router/withRouter';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CouseOfActionDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CouseOfActionDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import { graphql } from 'react-relay';
-import { Route } from 'react-router-dom';
+import { Route } from 'react-router';
 import * as R from 'ramda';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import withRouter from '../../../../utils/compat_router/withRouter';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentAttackPatterns.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import { LockPattern } from 'mdi-material-ui';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDataSource.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDataSource.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentKnowledge.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { DataComponentKnowledge_dataComponent$key } from './__generated__/DataComponentKnowledge_dataComponent.graphql';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useParams, useLocation, Route } from 'react-router-dom';
+import { useParams, useLocation, Route } from 'react-router';
 import { graphql, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDataComponents.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import List from '@mui/material/List';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { ListItemButton, Tooltip } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceKnowledge.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { DataSourceKnowledge_dataSource$key } from './__generated__/DataSourceKnowledge_dataSource.graphql';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, useParams, useLocation } from 'react-router-dom';
+import { Route, useParams, useLocation } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, CSSProperties } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeParentNarratives.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeParentNarratives.jsx
@@ -4,7 +4,7 @@ import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { SpeakerNotesOutlined } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { ListItemButton } from '@mui/material';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeSubNarratives.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeSubNarratives.jsx
@@ -4,7 +4,7 @@ import { compose, filter } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { SpeakerNotesOutlined, LinkOff } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeWithSubnarrativeLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeWithSubnarrativeLine.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -1,5 +1,5 @@
 import { useMemo, Suspense } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootNarrativeQuery } from '@components/techniques/narratives/__generated__/RootNarrativeQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/threats/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import { useIsHiddenEntity } from '../../../utils/hooks/useEntitySettings';
 import Loader from '../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { MESSAGING$ } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router';
 import { graphql, PreloadedQuery, useSubscription, usePreloadedQuery } from 'react-relay';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { MESSAGING$ } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { getRelationshipTypesForEntityType } from '../../../../utils/Relation';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetLocations.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetLocations.jsx
@@ -6,7 +6,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { Delete } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootThreatActorGroupQuery } from '@components/threats/threat_actors_group/__generated__/RootThreatActorGroupQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { MESSAGING$ } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import useAuth from '../../../../utils/hooks/useAuth';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupLocation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupLocation.jsx
@@ -4,7 +4,7 @@ import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { LinkOff } from '@mui/icons-material';
 import { graphql, createFragmentContainer } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDeletion.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import { MESSAGING$ } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import EntityStixCoreRelationships from '../../common/stix_core_relationships/EntityStixCoreRelationships';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLocation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualLocation.jsx
@@ -4,7 +4,7 @@ import { compose } from 'ramda';
 import List from '@mui/material/List';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import IconButton from '@common/button/IconButton';
 import { LinkOff } from '@mui/icons-material';
 import { createFragmentContainer, graphql } from 'react-relay';

--- a/opencti-platform/opencti-front/src/private/components/trash/DeleteOperationPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/trash/DeleteOperationPopover.tsx
@@ -11,7 +11,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { PopoverProps } from '@mui/material/Popover';
 import React, { useState } from 'react';
 import { graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useFormatter } from '../../../components/i18n';
 import { MESSAGING$ } from '../../../relay/environment';
 import useApiMutation from '../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/trash/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/trash/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 import Loader from '../../../components/Loader';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/Root.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import Workspaces from './Workspaces';
 import RootDashboard from './dashboards/Root';
 import RootInvestigation from './investigations/Root';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
@@ -4,7 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { useContext } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../components/CreateEntityControlledDial';
 import TextField from '../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDeletion.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDeletion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import WorkspacePopoverDeletionMutation from '@components/workspaces/WorkspacePopoverDeletionMutation';
 import { useFormatter } from '../../../components/i18n';
 import useApiMutation from '../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -4,7 +4,7 @@ import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import { FunctionComponent, UIEvent, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { useFormatter } from '../../../components/i18n';
 import { handleError, MESSAGING$ } from '../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceKebabMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceKebabMenu.tsx
@@ -3,7 +3,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import MoreVert from '@mui/icons-material/MoreVert';
 import ToggleButton from '@mui/material/ToggleButton';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import WorkspaceManageAccessDialog from '@components/workspaces/WorkspaceManageAccessDialog';
 import WorkspaceTurnToContainerDialog from '@components/workspaces/WorkspaceTurnToContainerDialog';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspacePopover.tsx
@@ -4,7 +4,7 @@ import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@common/button/IconButton';
 import Box from '@mui/material/Box';
 import MoreVert from '@mui/icons-material/MoreVert';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql, useFragment } from 'react-relay';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import PublicDashboardCreationForm from './dashboards/public_dashboards/PublicDashboardCreationForm';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceTurnToContainerDialog.tsx
@@ -11,7 +11,7 @@ import TextField from '@mui/material/TextField';
 import { useTheme } from '@mui/styles';
 import React, { Dispatch, FunctionComponent, SyntheticEvent, useState } from 'react';
 import { graphql } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useFormatter } from '../../../components/i18n';
 import ItemIcon from '../../../components/ItemIcon';
 import type { Theme } from '../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import CustomDashboard from './CustomDashboard';
 import Loader from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardLineActions.tsx
@@ -2,7 +2,7 @@ import { PublicDashboards_PublicDashboard$data } from '@components/workspaces/da
 import MoreVert from '@mui/icons-material/MoreVert';
 import { IconButton, Menu, MenuItem, MenuProps } from '@mui/material';
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { graphql } from 'react-relay';
 import { PublicDashboardsListQuery$variables } from '@components/workspaces/dashboards/public_dashboards/__generated__/PublicDashboardsListQuery.graphql';
 import { useFormatter } from '../../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/Root.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { graphql } from 'react-relay';
 import withRouter from '../../../../utils/compat_router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/dialog/InvestigationRollBackExpandDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/dialog/InvestigationRollBackExpandDialog.tsx
@@ -1,7 +1,7 @@
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useFormatter } from '../../../../../components/i18n';
 import { useInvestigationState } from '../utils/useInvestigationState';
 

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployBuiltInFeed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployBuiltInFeed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router';
 import { BuiltInIntegrationImport, ImportableBuiltInKind } from '@components/integrations/available/BuiltInIntegrationImport';
 import Loader from '../../../components/Loader';
 

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployCustomDashboard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployCustomDashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { importMutation } from '@components/workspaces/WorkspaceCreation';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { WorkspaceCreationImportMutation } from '@components/workspaces/__generated__/WorkspaceCreationImportMutation.graphql';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
 import { resolveLink } from '../../../utils/Entity';

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployCustomView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployCustomView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { graphql } from 'react-relay';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { DeployCustomViewImportMutation } from '@components/xtm_hub/__generated__/DeployCustomViewImportMutation.graphql';
 import { MESSAGING$ } from '../../../relay/environment';
 import useApiMutation from '../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployPlaybook.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/DeployPlaybook.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { playbookImportMutation } from '@components/data/playbooks/PlaybookCreation';
 import { PlaybookCreationImportMutation } from '@components/data/playbooks/__generated__/PlaybookCreationImportMutation.graphql';
 import XtmHubDialogConnectivityLost from '@components/xtm_hub/dialog/connectivity-lost';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import { resolveLink } from '../../../utils/Entity';
 import { MESSAGING$ } from '../../../relay/environment';
 import useApiMutation from '../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/RegisterPlatformBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/RegisterPlatformBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TopBanner from '../../../components/TopBanner';
 import { useFormatter } from '../../../components/i18n';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { REGISTER_BANNER_DISMISSED_BUS, REGISTER_BANNER_DISMISSED_KEY } from '../../../utils/bannerConstants';
 
 const RegisterPlatformBanner = () => {

--- a/opencti-platform/opencti-front/src/private/components/xtm_hub/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/xtm_hub/Root.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { boundaryWrapper } from '../Error';
 
 const DeployCustomDashboards = lazy(() => import('./DeployCustomDashboard'));

--- a/opencti-platform/opencti-front/src/public/PublicRoot.tsx
+++ b/opencti-platform/opencti-front/src/public/PublicRoot.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { StyledEngineProvider } from '@mui/material/styles';
 import { loadQuery, usePreloadedQuery } from 'react-relay';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { boundaryWrapper } from '@components/Error';
 import { ConnectedThemeProvider } from '../components/AppThemeProvider';
 import { ConnectedIntlProvider } from '../components/AppIntlProvider';

--- a/opencti-platform/opencti-front/src/public/components/PublicDashboard.tsx
+++ b/opencti-platform/opencti-front/src/public/components/PublicDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import ReactGridLayout, { useContainerWidth } from 'react-grid-layout';
 import { ErrorBoundary } from '@components/Error';
 import Loader, { LoaderVariant } from '../../components/Loader';

--- a/opencti-platform/opencti-front/src/public/components/login/__tests__/ForcePasswordChange.test.tsx
+++ b/opencti-platform/opencti-front/src/public/components/login/__tests__/ForcePasswordChange.test.tsx
@@ -4,7 +4,7 @@ import { screen } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { createTheme, ThemeProvider, ThemeOptions } from '@mui/material/styles';
 import AppIntlProvider from '../../../../components/AppIntlProvider';
 import ThemeDark from '../../../../components/ThemeDark';

--- a/opencti-platform/opencti-front/src/utils/SearchUtils.ts
+++ b/opencti-platform/opencti-front/src/utils/SearchUtils.ts
@@ -1,4 +1,4 @@
-import type { NavigateFunction } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router';
 import { emptyFilterGroup } from './filters/filtersUtils';
 
 export const handleSearchByKeyword = (searchKeyword: string, searchScope: string, navigate: NavigateFunction) => {

--- a/opencti-platform/opencti-front/src/utils/compat_router/withRouter.tsx
+++ b/opencti-platform/opencti-front/src/utils/compat_router/withRouter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 
 /** @deprecated Use `React Router hooks` instead */
 export interface WithRouterProps {

--- a/opencti-platform/opencti-front/src/utils/hooks/useDocumentModifier.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDocumentModifier.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { isNotEmptyField } from '../utils';
 
 export const useBaseHrefAbsolute = () => {

--- a/opencti-platform/opencti-front/src/utils/hooks/useSplatLessBasePath.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useSplatLessBasePath.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { Link, MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { Link, MemoryRouter, Outlet, Route, Routes } from 'react-router';
 import useSplatLessBasePath from './useSplatLessBasePath';
 
 const Probe = () => {

--- a/opencti-platform/opencti-front/src/utils/hooks/useSplatLessBasePath.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useSplatLessBasePath.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { UNSAFE_RouteContext } from 'react-router-dom';
+import { UNSAFE_RouteContext } from 'react-router';
 
 /**
  * Base path of the closest matched route, without its splat part nor trailing

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -1,7 +1,7 @@
 import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material/styles';
 import { RelayEnvironmentProvider } from 'react-relay';
 import React, { ReactNode } from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { render, renderHook } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { EnvironmentConfig } from 'relay-runtime';

--- a/opencti-platform/opencti-front/src/utils/widget/widgetCustomAttributesRendererUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetCustomAttributesRendererUtils.tsx
@@ -12,7 +12,7 @@ import ItemOpenVocab from 'src/components/ItemOpenVocab';
 import { EMPTY_VALUE } from 'src/utils/String';
 import SecurityCoverageScores from '@components/analyses/security_coverages/SecurityCoverageScores';
 import ItemIcon from '../../components/ItemIcon';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { WidgetHost } from 'src/utils/widget/widget';
 
 type AttributeRenderer = (

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -11661,7 +11661,7 @@ __metadata:
     react-pdf: "npm:10.5.0"
     react-relay: "npm:21.0.1"
     react-relay-network-modern: "npm:6.2.2"
-    react-router-dom: "npm:7.18.3"
+    react-router: "npm:7.18.3"
     react-syntax-highlighter: "npm:16.1.1"
     react-transition-group: "npm:4.4.5"
     react-virtualized: "npm:9.22.6"
@@ -13032,18 +13032,6 @@ __metadata:
     react: ">= 16.3"
     react-dom: ">= 16.3"
   checksum: 10c0/b589bca0b1135dc4bf875f09dd677821bfe4b468e5c9ec7e37d91a06ca49281f3dec289d5aa41a7cc0f4603872610b0c5d1d077287c3fef73a5c9339d3216598
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:7.18.3":
-  version: 7.18.3
-  resolution: "react-router-dom@npm:7.18.3"
-  dependencies:
-    react-router: "npm:7.18.3"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10c0/1d04bb38f64e9c429d4f162ca6c5ffc163a02c0a5c08748440a58fc0e9b1e8c8edc2bc4509e9966dcd0873e57fc6a090fd356244d581567737aac1ae6236e799
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Proposed changes

Mechanical, behaviour-neutral rename in `opencti-platform/opencti-front`, following the React Router v7 upgrade (#18107):

* every `'react-router-dom'` module specifier in `src` becomes `'react-router'`: 453 static imports, 4 `typeof import('react-router-dom')` and 5 `vi.mock('react-router-dom', …)` in tests (458 files);
* `package.json` depends on `react-router` 7.18.3 instead of `react-router-dom` 7.18.3; `yarn.lock` loses the `react-router-dom` entry, nothing else moves.

In v7 `react-router-dom` is a shell that re-exports `react-router` as is (plus `RouterProvider` / `HydratedRouter` from `react-router/dom`, which the frontend does not use). No version bump, no runtime change; the goal is to keep the future v8 Renovate PR minimal.

### Related issues

* closes #18156

### How to test this PR

```bash
cd opencti-platform/opencti-front
grep -rn "react-router-dom" src package.json   # nothing
yarn install --immutable && yarn why react-router-dom   # not found
yarn relay && yarn check-ts && yarn lint && yarn build && yarn test
```

Verified locally on this branch: `yarn install`, `yarn relay`, `yarn check-ts`, `yarn lint`, `yarn build`, and the whole unit suite (153 files, 1351 tests) green, `src/utils/Time.test.ts` run with `TZ=UTC` like the CI (it depends on the local timezone, pre-existing and untouched here).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e) — pure rename, the existing suite covers it
- [x] I added/updated the relevant documentation (either on GitHub or on Notion) — nothing to document
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

The only remaining `react-router-dom` string in the built bundle is an invariant message inside `react-router`'s own code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
