### PR TITLE
fix(ci): replace deprecated circleci/node:current image with cimg/node (#18159)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
   tag_package:
     working_directory: ~/opencti
     docker:
-      - image: circleci/node:current
+      - image: cimg/node:22.23.2
     resource_class: medium+
     steps:
       - attach_workspace:
@@ -222,7 +222,7 @@ jobs:
   package_rolling_musl:
     working_directory: ~/opencti_musl
     docker:
-      - image: circleci/node:current
+      - image: cimg/node:22.23.2
     resource_class: medium+
     steps:
       - attach_workspace:
@@ -249,7 +249,7 @@ jobs:
   tag_package_musl:
     working_directory: ~/opencti_musl
     docker:
-      - image: circleci/node:current
+      - image: cimg/node:22.23.2
     resource_class: medium+
     steps:
       - attach_workspace:


### PR DESCRIPTION
## Summary
- `tag_package`, `package_rolling_musl` and `tag_package_musl` CircleCI jobs use the legacy, unmaintained `circleci/node:current` image, which is based on Debian Bullseye
- Bullseye is now EOL, so its `bullseye-security` apt repository is no longer updated, and `apt-get update` fails with an expired `Release` file, breaking these jobs
- Replace `circleci/node:current` with `cimg/node:22.23.2` (maintained image, matches the Node 22 version used elsewhere in the project)

Fixes #18159

## Test plan
- [x] CircleCI run on this PR: `tag_package`, `package_rolling_musl`, `tag_package_musl` no longer fail on `apt-get update`