### PR TITLE
test(backend): do not start the telemetry manager during the tests (flaky test) (#18142)

### DIFF
--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -489,7 +489,7 @@ Environment variables:
 | garbage_collection_manager:batch_size                | GARBAGE_COLLECTION_MANAGER__BATCH_SIZE                | 10000                            | Number of trash elements to delete at once                                                                                                     |
 | garbage_collection_manager:deleted_retention_days    | GARBAGE_COLLECTION_MANAGER__DELETED_RETENTION_DAYS    | 7                                | Days after which elements in trash are deleted                                                                                                 |
 | -                                                    | -                                                     | -                                | -                                                                                                                                              |
-| telemetry_manager:lock_key                           | TELEMETRY_MANAGER__LOCK_LOCK                          | telemetry_manager_lock           | Lock key for the manager in Redis                                                                                                              |
+| telemetry_manager:lock_key                           | TELEMETRY_MANAGER__LOCK_KEY                           | telemetry_manager_lock           | Lock key for the manager in Redis                                                                                                              |
 
 
 !!! note "Manager's duties"

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -110,6 +110,9 @@
   "ingestion_manager": {
     "enabled": false
   },
+  "telemetry_manager": {
+    "enabled": false
+  },
   "providers": {
     "local": {
       "strategy": "LocalStrategy"

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -2,7 +2,7 @@ import { defaultResource, resourceFromAttributes } from '@opentelemetry/resource
 import { ATTR_SERVICE_INSTANCE_ID, ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { AggregationTemporality, ConsoleMetricExporter, InstrumentType, MeterProvider, type IMetricReader } from '@opentelemetry/sdk-metrics';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
-import conf, { DEV_MODE, logApp, PLATFORM_VERSION } from '../config/conf';
+import conf, { booleanConf, DEV_MODE, logApp, PLATFORM_VERSION } from '../config/conf';
 import { executionContext, SYSTEM_USER, TELEMETRY_MANAGER_USER } from '../utils/access';
 import { getClusterInformation } from '../database/cluster-module';
 import {
@@ -107,6 +107,7 @@ const booleanTrueFilter = (key: string) => ({
 });
 const TELEMETRY_CONSOLE_DEBUG = conf.get('telemetry_manager:console_debug') ?? false;
 const SCHEDULE_TIME = conf.get('telemetry_manager:interval') || 60000; // 1 minute default
+const TELEMETRY_MANAGER_ENABLED = booleanConf('telemetry_manager:enabled', true);
 const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
   ? 'https://telemetry.staging.filigran.io/v1/metrics'
   : 'https://telemetry.filigran.io/v1/metrics';
@@ -820,7 +821,7 @@ const TELEMETRY_MANAGER_DEFINITION: ManagerDefinition = {
     interval: SCHEDULE_TIME,
     lockKey: TELEMETRY_MANAGER_KEY,
   },
-  enabledByConfig: true,
+  enabledByConfig: TELEMETRY_MANAGER_ENABLED,
   enabledToStart(): boolean {
     return this.enabledByConfig;
   },

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -64,6 +64,11 @@ describe('Telemetry manager test coverage', () => {
     let shareWithCreatorFilterId: string;
 
     beforeAll(async () => {
+      // The permission changes counter is a cumulative Redis gauge, and other tests of the
+      // suite feed it. Start from a clean state so it reflects this test only, the way the
+      // other telemetry tests of this file already do.
+      await redisClearTelemetry();
+
       // create shared saved filters
 
       const savedFilter = JSON.stringify({


### PR DESCRIPTION
## Proposed changes

The platform telemetry manager runs during the integration tests and clears **every** telemetry gauge in Redis on a timer, which wipes the counters the tests write and read back. See #18142 for the full analysis.

`telemetryInitializer` registers a collect callback calling `redisClearTelemetry()`, wired on a `BatchExportingMetricReader` whose interval is `DEV_MODE ? ONE_MINUTE : ONE_HOUR`. The tests start the platform managers and run with `DEV_MODE` true, so every gauge was cleared once a minute for the whole run. A test that writes counters, waits for them in Redis, then reads them back through `fetchTelemetryData()` found zero whenever the collector fired in between — and the values were lost for good, since they are not written again.

### 1. The manager no longer starts in the test platform

It now reads a `telemetry_manager:enabled` flag through `booleanConf(..., true)`, following the convention already used by the other managers, and `config/test.json` sets it to `false` next to `ingestion_manager`, which is already disabled there.

A disabled manager is never started — `startAllManagers()` only calls `.start()` on `getAllEnabledManagers()` — so `telemetryInitializer` never runs, no metric reader is created, and the collect callback that clears the gauges never comes into existence. The only remaining calls to `redisClearTelemetry()` during a test run are the explicit ones the tests make themselves.

Production behaviour is unchanged. The default lives in the code, so the flag appears neither in `config/default.json` nor in the configuration reference: it exists to keep the manager out of the test platform, not as a deployment knob.

### 2. A test was depending on the collector

Turning it off made `shared saved filters count and permission changes are collected` fail deterministically, at 60 attempts. `sharedSavedFiltersPermissionChangesCount` is a **cumulative** Redis gauge (`redisSetTelemetryAdd(..., 1)` on every permission change) that other tests of the suite also feed, and the test asserts it equals exactly 1. It was only ever reaching that value because the collector happened to clear the gauge somewhere during the run — the test was passing on the collector's timing, which is also why it was among the flakiest of the suite.

Its `beforeAll` now starts from a clean state with `redisClearTelemetry()`, the way the two other telemetry tests of the same file already do. The assertions are unchanged.

### 3. A typo spotted in passing

The configuration reference documented `TELEMETRY_MANAGER__LOCK_LOCK` for `telemetry_manager:lock_key`, while the code reads that key and every other manager documents `__LOCK_KEY`.

## Follow-up, deliberately not in this PR

#18110 and #18134 raised several telemetry polling budgets to 60 seconds to compensate for failures this collector was causing. Once it is gone from the test platform, those budgets no longer compensate for anything and are worth bringing back towards the helper default. That is a separate change, better made after a few runs of master confirm this one, so that only one variable moves at a time.

## Related issues

- Closes #18142

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed sources; JSON config validated; integration suite validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
