### PR TITLE
test(e2e): wait for the PIR top author widgets before asserting them (flaky test) (#17152)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/pir/pir.spec.ts
@@ -83,11 +83,17 @@ test('Pir CRUD', { tag: ['@pir', '@mutation', '@ee', '@group1'] }, async ({ page
   // region Control tab Overview after flagging
   // ------------------------------------------
 
+  // The entity type count and the two top author widgets are fed by separate aggregations,
+  // which do not necessarily land on the same refresh. Waiting on the count alone left the
+  // top author assertions racing against their own aggregation, so poll on all three.
   const waitForFlagging = async () => {
     await pirPage.navigateFromMenu();
     await pirPage.getItemFromList(pirName).click();
     const text = await pirDetails.getEntityTypeCount('Malware').innerText();
-    return text === '1';
+    if (text !== '1') return false;
+    const hasTopAuthorEntities = await pirDetails.getTopAuthorEntities('John Doe').isVisible();
+    const hasTopAuthorRelationships = await pirDetails.getTopAuthorRelationships('ANSSI').isVisible();
+    return hasTopAuthorEntities && hasTopAuthorRelationships;
   };
   await awaitUntilCondition(waitForFlagging, 5000, 20);
   await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('1');


### PR DESCRIPTION
## Proposed changes

- Fix the flaky e2e test `Pir CRUD` (`tests_e2e/pir/pir.spec.ts`, group1) — see #17152.
- After flagging an entity into the PIR, the test polled until the Malware entity type count read `1`, then asserted three things at once: that count, and the two top author widgets.

```js
const waitForFlagging = async () => {
  ...
  const text = await pirDetails.getEntityTypeCount('Malware').innerText();
  return text === '1';
};
await awaitUntilCondition(waitForFlagging, 5000, 20);
await expect(pirDetails.getEntityTypeCount('Malware')).toContainText('1');
await expect(pirDetails.getTopAuthorEntities('John Doe')).toBeVisible();      // ← flaky
await expect(pirDetails.getTopAuthorRelationships('ANSSI')).toBeVisible();
```

- The three come from separate aggregations that do not necessarily land on the same refresh, so the top author assertions were racing against their own aggregation with no wait of their own. Since the polling loop re-navigates on each attempt, a later refresh could have shown them — but the loop had already returned.
- The polled condition now covers the three signals the test goes on to assert. The assertions themselves are unchanged, and the polling budget (20 attempts of 5s) is untouched.

## Related issues

- Closes #17152

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (eslint on the changed file, all e2e specs load; e2e group1 validated by CI)
- [ ] I added test cases if relevant and possible
- [x] I have read the [CONTRIBUTING](https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md) document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
