### PR TITLE
feat(ui): Fix Filigran new design system introduction issues (#17664)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/NavBar.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/NavBar.test.tsx
@@ -41,6 +41,7 @@ const renderNav = (overrides: Partial<NavBarViewProps> = {}, route = '/dashboard
     submenuShowIcons={false}
     topOffset="0px"
     bottomOffset="0px"
+    flowOffset="0px"
     header={null}
     footer={null}
     navLabel="Main navigation"
@@ -135,10 +136,13 @@ describe('NavBarView', () => {
   it('pins the rail to the viewport, full height, below the banners', () => {
     // The library lays its <nav> out in flow and sizes it with a percentage height; the fixed-
     // position drawer it replaces was full height and did not scroll away with the page.
-    const { container } = renderNav({ topOffset: '50px', bottomOffset: '20px' });
+    const { container } = renderNav({ topOffset: '50px', bottomOffset: '20px', flowOffset: '30px' });
     const nav = container.querySelector('nav') as HTMLElement;
     expect(nav.style.position).toBe('sticky');
     expect(nav.style.top).toBe('50px');
+    // The platform message banner is a fixed overlay the app shell does not reserve flow space for, so the rail
+    // reserves it itself to keep the ProductSwitcher (Filigran logo) from being hidden while unscrolled.
+    expect(nav.style.marginTop).toBe('30px');
     // jsdom reorders the terms of a calc(), so assert on its parts: the rail
     // is one viewport tall minus the space the banners take.
     expect(nav.style.height).toContain('100dvh');

--- a/opencti-platform/opencti-front/src/private/components/nav/NavBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/NavBar.tsx
@@ -18,6 +18,7 @@ import useGranted, { SETTINGS_SETMANAGEXTMHUB } from '../../../utils/hooks/useGr
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { isNotEmptyField } from '../../../utils/utils';
 import { NavBarQuery } from './__generated__/NavBarQuery.graphql';
+import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
 import MadeByFiligran from './MadeByFiligran';
 import { readNavOpen, readSelectedMenu, writeNavOpen, writeSelectedMenu } from './navBarConstants';
 import useNavMenu, { NavGroup, NavItem, NavSubItem } from './useNavMenu';
@@ -51,6 +52,7 @@ export interface NavBarViewProps {
   accentColor?: string;
   topOffset: string;
   bottomOffset: string;
+  flowOffset: string;
   header: React.ReactNode;
   footer: React.ReactNode;
   navLabel: string;
@@ -68,6 +70,7 @@ export const NavBarView: React.FC<NavBarViewProps> = ({
   accentColor,
   topOffset,
   bottomOffset,
+  flowOffset,
   header,
   footer,
   navLabel,
@@ -76,6 +79,7 @@ export const NavBarView: React.FC<NavBarViewProps> = ({
   const navStyle: React.CSSProperties & Record<string, string | undefined> = {
     position: 'sticky',
     top: topOffset,
+    marginTop: flowOffset,
     alignSelf: 'flex-start',
     height: `calc(100dvh - ${topOffset} - ${bottomOffset})`,
   };
@@ -178,10 +182,16 @@ const NavBarComponent: React.FC<NavBarComponentProps> = ({ queryRef }) => {
     bannerSettings: { bannerHeightNumber },
   } = useAuth();
   const { height: topBannerHeight } = useTopBanner();
-  // Mirrors the app shell's own offsets (private/Index.tsx): the classification banners take the banner height at
-  // the top and at the bottom, the notification banner `topBannerHeight` at the top only.
-  const topOffset = `${topBannerHeight + bannerHeightNumber}px`;
+  const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+  // Mirrors the app shell's own offsets (private/Index.tsx and nav/TopBar.tsx): the classification banners take the
+  // banner height at the top and at the bottom, the notification banner `topBannerHeight` and the platform message
+  // banner `settingsMessagesBannerHeight` at the top only. Without the platform message banner height the fixed
+  // banner overlaps the top of the rail and hides the Filigran logo.
+  const topOffset = `${topBannerHeight + bannerHeightNumber + settingsMessagesBannerHeight}px`;
   const bottomOffset = `${bannerHeightNumber}px`;
+  // The parent shell (private/Index.tsx) reserves flow space for the classification and notification banners via its
+  // own margins; only the platform message banner is left for the rail to reserve here.
+  const flowOffset = `${settingsMessagesBannerHeight}px`;
   const hasXtmHubAccess = useGranted([SETTINGS_SETMANAGEXTMHUB]);
   const data = usePreloadedQuery<NavBarQuery>(navBarQuery, queryRef);
   const groups = useNavMenu();
@@ -241,6 +251,7 @@ const NavBarComponent: React.FC<NavBarComponentProps> = ({ queryRef }) => {
       accentColor={accentColor}
       topOffset={topOffset}
       bottomOffset={bottomOffset}
+      flowOffset={flowOffset}
       navLabel={t_i18n('Main navigation')}
       header={(
         <ProductSwitcher

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
@@ -3,7 +3,7 @@ import { Field, useFormikContext } from 'formik';
 import Box from '@mui/material/Box';
 
 import FormHelperText from '@mui/material/FormHelperText';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
+import { Select, SelectContent, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@filigran/design-system';
 import { useTheme } from '@mui/styles';
 import TextField from '../../../../components/TextField';
 import Tag from '../../../../components/common/tag/Tag';
@@ -60,9 +60,7 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
   if (isExternal && !isEditing) {
     return (
       <Box sx={style}>
-        <label className="font-sans-plex font-medium text-2 text-input-label" style={{ display: 'block', marginBottom: 8 }}>
-          {label}
-        </label>
+        <SelectLabel>{label}</SelectLabel>
         <Tag
           label={displayLabel ? `${t_i18n('External secret')}: ${displayLabel}` : t_i18n('Externally managed')}
           color={theme.palette.primary.main}
@@ -75,9 +73,7 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
 
   return (
     <Box sx={style}>
-      <label className="font-sans-plex font-medium text-2 text-input-label" style={{ display: 'block', marginBottom: 8 }}>
-        {label}
-      </label>
+      <SelectLabel>{label}</SelectLabel>
       <Box
         sx={{
           display: 'flex',

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
@@ -87,7 +87,6 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
         }}
       >
         <Select
-          aria-label={label}
           value={isExternal && action === 'keep' ? 'use_external_secret' : action}
           onValueChange={(value) => {
             const v = value as SecretAction;
@@ -100,7 +99,7 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
             }
           }}
         >
-          <SelectTrigger>
+          <SelectTrigger aria-label={label}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent aria-label={label}>
@@ -132,11 +131,10 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
         {action === 'use_external_secret' && (
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Select
-              aria-label={t_i18n('External secret')}
               value={secretName || (availableSecrets[0]?.secret_name ?? '')}
               onValueChange={(value) => setFieldValue(`${namePrefix}_secret_name`, value)}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger className="w-full" aria-label={t_i18n('External secret')}>
                 <SelectValue placeholder={t_i18n('External secret')} />
               </SelectTrigger>
               <SelectContent aria-label={t_i18n('External secret')}>

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SecretFieldControl.tsx
@@ -3,8 +3,7 @@ import { Field, useFormikContext } from 'formik';
 import Box from '@mui/material/Box';
 
 import FormHelperText from '@mui/material/FormHelperText';
-import InputLabel from '@mui/material/InputLabel';
-import { Select, SelectContent, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@filigran/design-system';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@filigran/design-system';
 import { useTheme } from '@mui/styles';
 import TextField from '../../../../components/TextField';
 import Tag from '../../../../components/common/tag/Tag';
@@ -61,9 +60,9 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
   if (isExternal && !isEditing) {
     return (
       <Box sx={style}>
-        <InputLabel shrink sx={{ position: 'relative', mb: 0.5, display: 'block' }}>
+        <label className="font-sans-plex font-medium text-2 text-input-label" style={{ display: 'block', marginBottom: 8 }}>
           {label}
-        </InputLabel>
+        </label>
         <Tag
           label={displayLabel ? `${t_i18n('External secret')}: ${displayLabel}` : t_i18n('Externally managed')}
           color={theme.palette.primary.main}
@@ -76,6 +75,9 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
 
   return (
     <Box sx={style}>
+      <label className="font-sans-plex font-medium text-2 text-input-label" style={{ display: 'block', marginBottom: 8 }}>
+        {label}
+      </label>
       <Box
         sx={{
           display: 'flex',
@@ -85,6 +87,7 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
         }}
       >
         <Select
+          aria-label={label}
           value={isExternal && action === 'keep' ? 'use_external_secret' : action}
           onValueChange={(value) => {
             const v = value as SecretAction;
@@ -97,7 +100,6 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
             }
           }}
         >
-          <SelectLabel>{label}</SelectLabel>
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
@@ -128,26 +130,28 @@ export const SecretFieldControl: React.FC<SecretFieldControlProps> = ({
           </Box>
         )}
         {action === 'use_external_secret' && (
-          <Select
-            value={secretName || (availableSecrets[0]?.secret_name ?? '')}
-            onValueChange={(value) => setFieldValue(`${namePrefix}_secret_name`, value)}
-          >
-            <SelectLabel>{t_i18n('External secret')}</SelectLabel>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent aria-label={t_i18n('External secret')}>
-              {availableSecrets.length === 0 ? (
-                <SelectItem value="" disabled>{t_i18n('No external secrets configured')}</SelectItem>
-              ) : (
-                availableSecrets.map((s) => (
-                  <SelectItem key={s.secret_name} value={s.secret_name}>
-                    {s.secret_name} ({s.provider_name})
-                  </SelectItem>
-                ))
-              )}
-            </SelectContent>
-          </Select>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Select
+              aria-label={t_i18n('External secret')}
+              value={secretName || (availableSecrets[0]?.secret_name ?? '')}
+              onValueChange={(value) => setFieldValue(`${namePrefix}_secret_name`, value)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={t_i18n('External secret')} />
+              </SelectTrigger>
+              <SelectContent aria-label={t_i18n('External secret')}>
+                {availableSecrets.length === 0 ? (
+                  <SelectItem value="" disabled>{t_i18n('No external secrets configured')}</SelectItem>
+                ) : (
+                  availableSecrets.map((s) => (
+                    <SelectItem key={s.secret_name} value={s.secret_name}>
+                      {s.secret_name} ({s.provider_name})
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </Box>
         )}
       </Box>
     </Box>


### PR DESCRIPTION
### Proposed changes
Fix some issues following the introduction of filigran design system:
- The filigran icon at the top of the left bar should not be hidden by banner messages
<img width="955" height="252" alt="image" src="https://github.com/user-attachments/assets/3c5300c7-5105-4ef1-829a-b2d28fc011ef" />


- Fix design for the 'bind credentials' of the LDAP authentication creation form
<img width="833" height="419" alt="image" src="https://github.com/user-attachments/assets/c5c0aac9-6e53-4cf3-9128-74ffa8c47618" />


### Related issues
fixes #17664