### PR TITLE
fix(observable): throws a warning message when no entity found on delete observable (#18194)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCyberObservable.js
@@ -257,8 +257,7 @@ export const addStixCyberObservable = async (context, user, input) => {
 };
 
 export const stixCyberObservableDelete = async (context, user, stixCyberObservableId) => {
-  const sco = await findById(context, user, stixCyberObservableId);
-  await deleteElementById(context, user, stixCyberObservableId, sco.entity_type);
+  await deleteElementById(context, user, stixCyberObservableId, ABSTRACT_STIX_CYBER_OBSERVABLE);
   return stixCyberObservableId;
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove findById since deleteElementById is already doing that to save a call to ES
* Pass directly the type ABSTRACT_STIX_CYBER_OBSERVABLE to deleteElementById, this function throws a ALREADY_DELETED_ERROR and will set the log as warning  

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #18194 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
- call the mutation with an existing ID twice, or with an unknown ID
mutation DeleteObs($id: ID!) {
stixCyberObservableEdit(id: $id) {
delete
}}

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
