### PR TITLE
fix(backend): pingConnector echoes stale connector_state under ES latency read-after-write race (#17472)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1064,9 +1064,9 @@ class PingAlive(threading.Thread):
                     else None
                 )
                 if initial_state != remote_state:
-                    self.set_state(result["connector_state"])
+                    self.set_state(remote_state)
                     self.connector_logger.info(
-                        "Connector state has been remotely reset",
+                        "Connector state has been remotely updated",
                         {"state": self.get_state()},
                     )
 

--- a/client-python/tests/01-unit/connector/test_ping_alive_state_sync.py
+++ b/client-python/tests/01-unit/connector/test_ping_alive_state_sync.py
@@ -1,0 +1,96 @@
+"""Regression tests for PingAlive.ping() connector_state handling.
+
+Covers the bug described in OpenCTI-Platform/opencti#17472 (client-side part):
+whenever the platform's echoed ``connector_state`` differs from the local
+``initial_state``, ``PingAlive.ping()`` used to call ``set_state()`` with the
+*raw JSON string* returned by the API instead of the already-parsed
+``remote_state`` dict. Since ``set_state()`` only accepts a ``Dict`` (anything
+else resolves the local state to ``None``), any mismatch - whatever its cause,
+including a stale echo caused by ES read-after-write latency on the server
+side - silently wiped the connector's local state to ``None``, forcing a full
+re-import on the connector's next run.
+"""
+
+import logging
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from pycti.connector.opencti_connector_helper import ConnectorInfo, PingAlive
+
+
+class TestPingAliveStateSync(TestCase):
+    """Verify PingAlive.ping() adopts the platform state without data loss."""
+
+    def _run_single_ping(self, initial_state, remote_connector_state_json):
+        """Run exactly one iteration of PingAlive.ping() and return the instance.
+
+        :param initial_state: the dict returned by get_state() before pinging
+        :param remote_connector_state_json: the raw `connector_state` string
+            (JSON-encoded, or None/"") the fake API echoes back in the ping response
+        """
+        state_holder = {"state": initial_state}
+
+        def fake_get_state():
+            return state_holder["state"]
+
+        def fake_set_state(state):
+            # Mirrors the real OpenCTIConnectorHelper.set_state behavior:
+            # only a Dict is kept, anything else (e.g. a raw JSON string) is dropped.
+            if isinstance(state, dict):
+                state_holder["state"] = state
+            else:
+                state_holder["state"] = None
+
+        fake_api = MagicMock()
+
+        def fake_ping(connector_id, state, connector_info):
+            # Let exactly one loop iteration run, then stop the daemon loop.
+            ping_alive.exit_event.set()
+            return {"connector_state": remote_connector_state_json}
+
+        fake_api.connector.ping.side_effect = fake_ping
+
+        ping_alive = PingAlive(
+            connector_logger=logging.getLogger("test-ping-alive"),
+            connector_id="test-connector-id",
+            api=fake_api,
+            get_state=fake_get_state,
+            set_state=fake_set_state,
+            metric=MagicMock(),
+            connector_info=ConnectorInfo(run_and_terminate=False),
+        )
+        ping_alive.ping()
+        return state_holder
+
+    def test_stale_echo_does_not_wipe_local_state(self):
+        """A mismatch caused by a stale/different echoed state must be adopted
+        as the parsed dict, never as None because of a raw-string type error."""
+        initial_state = {"last_run": "2026-01-01T00:00:00Z"}
+        remote_state_dict = {"last_run": "2025-12-31T23:59:00Z"}
+        remote_state_json = '{"last_run": "2025-12-31T23:59:00Z"}'
+
+        result_state = self._run_single_ping(initial_state, remote_state_json)
+
+        self.assertEqual(
+            result_state["state"],
+            remote_state_dict,
+            "connector_state must be adopted as the parsed remote dict, not wiped to None",
+        )
+
+    def test_actual_remote_reset_sets_state_to_none(self):
+        """When the platform genuinely has no state (empty/None), local state
+        should become None - this is the only legitimate case for a reset."""
+        initial_state = {"last_run": "2026-01-01T00:00:00Z"}
+
+        result_state = self._run_single_ping(initial_state, None)
+
+        self.assertIsNone(result_state["state"])
+
+    def test_matching_state_is_left_untouched(self):
+        """No mismatch, no state churn."""
+        initial_state = {"last_run": "2026-01-01T00:00:00Z"}
+        remote_state_json = '{"last_run": "2026-01-01T00:00:00Z"}'
+
+        result_state = self._run_single_ping(initial_state, remote_state_json)
+
+        self.assertEqual(result_state["state"], initial_state)

--- a/opencti-platform/opencti-graphql/src/domain/connector.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector.ts
@@ -137,7 +137,8 @@ export const updateConnectorWithConnectorInfo = async (
 
     connectorPatch = { ...connectorPatch, connector_info: connectorInfoData };
   }
-  await patchAttribute(context, user, connectorEntity.id, ENTITY_TYPE_CONNECTOR, connectorPatch);
+  const { element } = await patchAttribute<BasicStoreEntityConnector>(context, user, connectorEntity.id, ENTITY_TYPE_CONNECTOR, connectorPatch);
+  return element;
 };
 
 export const pingConnector = async (context: AuthContext, user: AuthUser, id: string, state: string, connectorInfo: ConnectorInfo) => {
@@ -149,8 +150,8 @@ export const pingConnector = async (context: AuthContext, user: AuthUser, id: st
   const scopes = connectorEntity.connector_scope ? connectorEntity.connector_scope.split(',') : [];
   await registerConnectorQueues(connectorEntity.id, connectorEntity.name, connectorEntity.connector_type, scopes);
 
-  await updateConnectorWithConnectorInfo(context, user, connectorEntity, state, connectorInfo);
-  return storeLoadById(context, user, id, 'Connector').then((data) => completeConnector(data));
+  const updatedConnector = await updateConnectorWithConnectorInfo(context, user, connectorEntity, state, connectorInfo);
+  return completeConnector(updatedConnector);
 };
 export const resetStateConnector = async (context: AuthContext, user: AuthUser, id: string) => {
   const patch = { connector_state: '', connector_state_reset: true, connector_state_timestamp: now() };
@@ -164,7 +165,7 @@ export const resetStateConnector = async (context: AuthContext, user: AuthUser, 
     context_data: { id, entity_type: ENTITY_TYPE_CONNECTOR, input: patch },
   });
   await purgeConnectorQueues(element);
-  return storeLoadById(context, user, id, ENTITY_TYPE_CONNECTOR).then((data) => completeConnector(data));
+  return completeConnector(element);
 };
 interface RegisterOptions {
   built_in?: boolean;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/connector-ping-state-consistency-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/connector-ping-state-consistency-test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { pingConnector, resetStateConnector } from '../../../src/domain/connector';
+import { patchAttribute } from '../../../src/database/middleware';
+import { storeLoadById } from '../../../src/database/middleware-loader';
+import { registerConnectorQueues, purgeConnectorQueues } from '../../../src/database/rabbitmq';
+import { publishUserAction } from '../../../src/listener/UserActionListener';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
+
+// ---------------------------------------------------------------------------
+// Regression tests for OpenCTI-Platform/opencti#17472 (server-side part):
+// pingConnector/resetStateConnector used to write the new connector_state via
+// patchAttribute(...) then discard the already-consistent `element` it
+// returns, performing a second, independent storeLoadById read to build the
+// response. Under Elasticsearch read-after-write latency, that second read
+// can return a stale copy of the document, so the response echoes back an
+// out-of-date connector_state even though the write just succeeded.
+//
+// These tests simulate that latency by making the mocked storeLoadById
+// return a document older than the one patchAttribute just persisted, and
+// assert the returned connector reflects the freshly written state instead.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/database/middleware', () => ({
+  patchAttribute: vi.fn(),
+  createEntity: vi.fn(),
+  deleteElementById: vi.fn(),
+  internalDeleteElementById: vi.fn(),
+  updateAttribute: vi.fn(),
+}));
+
+vi.mock('../../../src/database/middleware-loader', () => ({
+  storeLoadById: vi.fn(),
+  fullEntitiesList: vi.fn(),
+  internalLoadById: vi.fn(),
+  pageEntitiesConnection: vi.fn(),
+}));
+
+vi.mock('../../../src/database/rabbitmq', () => ({
+  registerConnectorQueues: vi.fn(),
+  purgeConnectorQueues: vi.fn(),
+  getConnectorQueueDetails: vi.fn(),
+  unregisterConnector: vi.fn(),
+  unregisterExchanges: vi.fn(),
+  connectorConfig: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../../src/listener/UserActionListener', () => ({
+  publishUserAction: vi.fn(),
+  completeContextDataForEntity: vi.fn(),
+}));
+
+const testContext = { source: 'test' } as unknown as AuthContext;
+const testUser = { id: 'test-user-id' } as unknown as AuthUser;
+
+const baseConnector = {
+  id: 'connector-1',
+  internal_id: 'connector-1',
+  name: 'Test Connector',
+  connector_type: 'EXTERNAL_IMPORT',
+  connector_scope: 'Report',
+  built_in: false,
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+describe('pingConnector / resetStateConnector state consistency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(registerConnectorQueues).mockResolvedValue(undefined as never);
+    vi.mocked(purgeConnectorQueues).mockResolvedValue(undefined as never);
+    vi.mocked(publishUserAction).mockResolvedValue(undefined as never);
+  });
+
+  it('pingConnector should return the freshly written connector_state, not a stale re-read under ES latency', async () => {
+    // First storeLoadById call: initial load of the connector before the write.
+    vi.mocked(storeLoadById).mockResolvedValueOnce({ ...baseConnector, connector_state: 'old-state' } as never);
+    // patchAttribute performs the write and returns the already up-to-date element.
+    vi.mocked(patchAttribute).mockResolvedValueOnce({
+      element: { ...baseConnector, connector_state: 'new-state' },
+    } as never);
+    // Simulate ES read-after-write latency: a subsequent read still returns the old document.
+    vi.mocked(storeLoadById).mockResolvedValueOnce({ ...baseConnector, connector_state: 'old-state' } as never);
+
+    const result = await pingConnector(testContext, testUser, 'connector-1', 'new-state', undefined as never);
+
+    expect(result.connector_state).toBe('new-state');
+  });
+
+  it('resetStateConnector should return the freshly reset connector_state, not a stale re-read under ES latency', async () => {
+    vi.mocked(patchAttribute).mockResolvedValueOnce({
+      element: { ...baseConnector, connector_state: '', connector_state_reset: true },
+    } as never);
+    // Simulate ES read-after-write latency: a subsequent read still returns the pre-reset document.
+    vi.mocked(storeLoadById).mockResolvedValueOnce({ ...baseConnector, connector_state: 'old-state', connector_state_reset: false } as never);
+
+    const result = await resetStateConnector(testContext, testUser, 'connector-1');
+
+    expect(result.connector_state).toBe('');
+    expect(result.connector_state_reset).toBe(true);
+  });
+});


### PR DESCRIPTION
### Proposed changes

* `pingConnector` and `resetStateConnector` (`opencti-platform/opencti-graphql/src/domain/connector.ts`) now return the `element` already produced by `patchAttribute` instead of performing a second, independent `storeLoadById` read, removing the window where Elasticsearch read-after-write latency could echo back a stale `connector_state`.
* `PingAlive.ping()` (`client-python/pycti/connector/opencti_connector_helper.py`) now calls `self.set_state(remote_state)` with the already-parsed dict instead of the raw JSON string, so a state mismatch no longer fails `set_state`'s `isinstance(state, Dict)` check and silently nulls the connector's local state; the log message now reads "Connector state has been remotely updated" since not every mismatch is a reset.

### Related issues
* closes #17472

### How to test this PR

Backend:

```
cd opencti-platform/opencti-graphql
npx vitest run tests/01-unit/domain/connector-ping-state-consistency-test.ts
```

Mocks `storeLoadById` to simulate ES latency (stale document on the post-write read) and asserts `pingConnector`/`resetStateConnector` return the freshly written `connector_state` instead.

Client:

```
cd client-python
python3 -m pytest tests/01-unit/connector/test_ping_alive_state_sync.py -q
```
Runs a single `PingAlive.ping()` iteration with a mocked API and asserts local state is adopted correctly on a stale-echo mismatch, nulled only on a genuine reset (`connector_state` empty/None), and left untouched when states match.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The two fixes are independent: the server-side fix removes the primary cause of false mismatches (ES latency), and the client-side fix ensures any remaining mismatch, whatever its cause, degrades gracefully instead of wiping state. Both new tests were confirmed to fail against the pre-fix code before the fix was applied, then confirmed to pass after; the full `tests/01-unit/domain/` suite (480 tests) and `tsc --noEmit` were also run with no regressions.
