### PR TITLE
fix(report): preserve published date when set to epoch placeholder (#17947)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
@@ -436,7 +436,7 @@ export const convertReportToStix = (instance: StoreEntity): SDO.StixReport => {
     name: instance.name,
     description: instance.description,
     report_types: instance.report_types,
-    published: convertToStixDate(instance.published),
+    published: convertToStixDate(instance.published, { allowEpoch: true }),
     object_refs: convertObjectReferences(instance),
     x_opencti_reliability: instance.x_opencti_reliability,
   };

--- a/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
@@ -569,7 +569,7 @@ const convertReportToStix = (instance: StoreEntity, type: string): SDO.StixRepor
     name: instance.name,
     description: instance.description,
     report_types: instance.report_types,
-    published: convertToStixDate(instance.published),
+    published: convertToStixDate(instance.published, { allowEpoch: true }),
     object_refs: convertObjectReferences(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({

--- a/opencti-platform/opencti-graphql/src/database/stix-converter-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-converter-utils.ts
@@ -13,20 +13,30 @@ export const assertType = (type: string, instanceType: string) => {
     throw UnsupportedError('Incompatible type', { instanceType, type });
   }
 };
-export const convertToStixDate = (date: Date | string | undefined): S.StixDate | S2.StixDate => {
+export const convertToStixDate = (
+  date: Date | string | undefined,
+  options: { allowEpoch?: boolean } = {},
+): S.StixDate | S2.StixDate => {
   if (date === undefined) {
     return undefined;
   }
+  const { allowEpoch = false } = options;
   // date type from graphql
   if (date instanceof Date) {
     const time = date.getTime();
-    if (time === FROM_START || time === UNTIL_END) {
+    if (!allowEpoch && time === FROM_START) {
+      return undefined;
+    }
+    if (time === UNTIL_END) {
       return undefined;
     }
     return date.toISOString();
   }
   // date string from the database
-  if (date === FROM_START_STR || date === UNTIL_END_STR) {
+  if (!allowEpoch && date === FROM_START_STR) {
+    return undefined;
+  }
+  if (date === UNTIL_END_STR) {
     return undefined;
   }
   return date;

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-0-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-0-converter-test.ts
@@ -264,7 +264,7 @@ describe('Stix 2.0 opencti converter', () => {
   });
   it('should convert Report with epoch published date', async () => {
     const reportWithEpoch = { ...REPORT_INSTANCE, published: '1970-01-01T00:00:00.000Z' };
-    const result = convertReportToStix(reportWithEpoch);
+    const result = convertReportToStix(reportWithEpoch as any);
     expect(result.published).toEqual('1970-01-01T00:00:00.000Z');
   });
   it('should convert Note', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-0-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-0-converter-test.ts
@@ -262,6 +262,11 @@ describe('Stix 2.0 opencti converter', () => {
     const result = convertReportToStix(REPORT_INSTANCE);
     expect(result).toEqual(EXPECTED_REPORT);
   });
+  it('should convert Report with epoch published date', async () => {
+    const reportWithEpoch = { ...REPORT_INSTANCE, published: '1970-01-01T00:00:00.000Z' };
+    const result = convertReportToStix(reportWithEpoch);
+    expect(result.published).toEqual('1970-01-01T00:00:00.000Z');
+  });
   it('should convert Note', async () => {
     const result = convertNoteToStix(NOTE_INSTANCE);
     expect(result).toEqual(EXPECTED_NOTE);

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-1-converter-report-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-1-converter-report-test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import '../../../src/modules/index';
+import { convertStoreToStix_2_1 } from '../../../src/database/stix-2-1-converter';
+import type { StixReport } from '../../../src/types/stix-2-1-sdo';
+import { REPORT_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/containers/report';
+
+// Regression test for #17947: Report updates silently dropped when published
+// is the epoch placeholder (1970-01-01).
+describe('STIX 2.1 converter - Report published date', () => {
+  it('should preserve epoch published date on Report', () => {
+    const reportWithEpoch = {
+      ...REPORT_INSTANCE,
+      published: '1970-01-01T00:00:00.000Z',
+    };
+    const stix = convertStoreToStix_2_1(reportWithEpoch as any) as StixReport;
+    expect(stix.published).toBe('1970-01-01T00:00:00.000Z');
+  });
+
+  it('should preserve standard published date on Report', () => {
+    const stix = convertStoreToStix_2_1(REPORT_INSTANCE as any) as StixReport;
+    expect(stix.published).toBe('2025-06-26T14:32:10.000Z');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/stix-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/stix-converter-test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { idsValuesRemap } from '../../../src/database/stix-2-1-converter';
 import type { BasicStoreObject } from '../../../src/types/store';
+import { convertToStixDate } from '../../../src/database/stix-converter-utils';
+import { FROM_START, FROM_START_STR, UNTIL_END, UNTIL_END_STR } from '../../../src/utils/format';
 
 describe('Stix converter utils: idsValuesRemap', () => {
   const standardId1 = 'identity--8c641a55-16b5-503d-9cc3-bf68ef0c40cc';
@@ -70,5 +72,40 @@ describe('Stix converter utils: idsValuesRemap', () => {
     expect(remappedIds[1]).toEqual('name');
     expect(remappedIds[2]).toEqual(internalId1);
     expect(remappedIds[3]).toEqual(fakeId);
+  });
+});
+
+describe('Stix converter utils: convertToStixDate', () => {
+  it('should return undefined when date is undefined', () => {
+    expect(convertToStixDate(undefined)).toBeUndefined();
+    expect(convertToStixDate(undefined, { allowEpoch: true })).toBeUndefined();
+  });
+
+  it('should format valid date strings and Date objects as ISO strings', () => {
+    const dateStr = '2025-06-26T14:32:10.000Z';
+    const dateObj = new Date(dateStr);
+    expect(convertToStixDate(dateStr)).toBe(dateStr);
+    expect(convertToStixDate(dateObj)).toBe(dateStr);
+  });
+
+  it('should convert FROM_START / epoch date to undefined by default', () => {
+    expect(convertToStixDate(FROM_START_STR)).toBeUndefined();
+    expect(convertToStixDate(new Date(FROM_START))).toBeUndefined();
+    expect(convertToStixDate('1970-01-01T00:00:00.000Z')).toBeUndefined();
+    expect(convertToStixDate(new Date(0))).toBeUndefined();
+  });
+
+  it('should convert UNTIL_END date to undefined by default and with allowEpoch', () => {
+    expect(convertToStixDate(UNTIL_END_STR)).toBeUndefined();
+    expect(convertToStixDate(new Date(UNTIL_END))).toBeUndefined();
+    expect(convertToStixDate(UNTIL_END_STR, { allowEpoch: true })).toBeUndefined();
+    expect(convertToStixDate(new Date(UNTIL_END), { allowEpoch: true })).toBeUndefined();
+  });
+
+  it('should preserve epoch date when allowEpoch is true', () => {
+    expect(convertToStixDate(FROM_START_STR, { allowEpoch: true })).toBe(FROM_START_STR);
+    expect(convertToStixDate(new Date(FROM_START), { allowEpoch: true })).toBe('1970-01-01T00:00:00.000Z');
+    expect(convertToStixDate('1970-01-01T00:00:00.000Z', { allowEpoch: true })).toBe('1970-01-01T00:00:00.000Z');
+    expect(convertToStixDate(new Date(0), { allowEpoch: true })).toBe('1970-01-01T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add an `allowEpoch` option to `convertToStixDate` (defaulting to `false`) to allow preserving Unix epoch dates (`1970-01-01T00:00:00.000Z` / `FROM_START`) when required.
* Update STIX 2.0 and STIX 2.1 `convertReportToStix` converters to pass `{ allowEpoch: true }` for the mandatory `published` date.
* Add unit tests for `convertToStixDate` covering edge cases, as well as STIX 2.0 and STIX 2.1 regression tests for report serialization with epoch published dates.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17947

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

1. **Automated unit tests**:
   ```bash
   yarn test:ci-unit tests/01-unit/utils/stix-converter-test.ts
   yarn test:ci-unit tests/01-unit/database/stix-2-0-converter-test.ts
   yarn test:ci-unit tests/01-unit/database/stix-2-1-converter-report-test.ts
   ```
   
 2. **Functional testing**:
  Create or ingest a Report with its `published` date set to `1970-01-01T00:00:00.000Z` (e.g., from an unpublished MISP event or an RSS feed fallback).
  Update the report or trigger a playbook / draft workspace approval involving it.
  Verify that python workers process the update bundle without throwing `[opencti_report] Missing parameters: name and published.`

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
`convertToStixDate` strips `FROM_START` (`1970-01-01T00:00:00.000Z`) and `UNTIL_END` (`5138-11-16T09:46:40.000Z`) by default to avoid exporting internal sentinel dates on optional interval fields (`first_seen`, `start_time`, `stop_time`, etc.).

However, for `Report`, `published` is an OASIS STIX-mandatory attribute. Stripping it converted the value to `undefined`, which was then removed by `cleanObject`, generating an invalid STIX report and causing python workers to fail with `Missing parameters: name and published`.

Using an optional `allowEpoch: true` flag preserves valid epoch publication dates on reports while guaranteeing no regression on existing sentinel stripping for other interval fields.
