### PR TITLE
fix(rabbitmq): cap infinite retry loop on nacked message publish (#18231)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -76,6 +76,10 @@ let isIntentionalClose = false; // Flag to prevent reconnection during intention
 const RECONNECT_INITIAL_DELAY = 1000; // 1 second
 const RECONNECT_MAX_DELAY = 30000; // 30 seconds max
 const RECONNECT_MULTIPLIER = 2; // Exponential backoff
+// Cap on send() retries: without this, a persistently nacked publish (e.g. broker
+// resource alarm on an oversized queue) blocks its caller forever instead of failing.
+// 20 attempts with the backoff above is ~8 minutes of retrying before giving up.
+const SEND_MAX_ATTEMPTS = 20;
 
 /**
  * Create a new connection to RabbitMQ with automatic reconnection
@@ -454,17 +458,27 @@ const amqpExecute = async (execute) => {
  * In rare edge cases around connection failures, duplicate delivery
  * is possible (at-least-once semantics). Consumers should be idempotent.
  *
+ * Retries are capped (SEND_MAX_ATTEMPTS): a persistently nacked publish throws instead of
+ * retrying forever, so a single stuck message can't block its caller indefinitely (e.g. a
+ * congested queue nacking every publish). Each call keeps its own attempt/delay counters,
+ * so concurrent callers retrying against different (or the same) queues don't interfere.
+ *
  * Not exported on purpose: callers must go through pushToConnector or pushBundleToWorker.
  */
 const send = async (exchangeName, routingKey, message) => {
   let attemptNumber = 0;
   let retryDelay = RECONNECT_INITIAL_DELAY;
 
-  while (true) {
+  while (attemptNumber < SEND_MAX_ATTEMPTS) {
     try {
       return await sendPersistent(exchangeName, routingKey, message);
     } catch (err) {
-      logApp.warn(`[RABBITMQ] Send failed (attempt ${++attemptNumber}), retrying in ${retryDelay}ms`, { cause: err, exchangeName, routingKey });
+      attemptNumber += 1;
+      if (attemptNumber === SEND_MAX_ATTEMPTS) {
+        logApp.error(`[RABBITMQ] Send failed after ${attemptNumber} attempts, giving up`, { cause: err, exchangeName, routingKey });
+        throw DatabaseError('RabbitMQ send failed after max retries', { cause: err, exchangeName, routingKey });
+      }
+      logApp.warn(`[RABBITMQ] Send failed (attempt ${attemptNumber}), retrying in ${retryDelay}ms`, { cause: err, exchangeName, routingKey });
 
       // If channel was lost, wait for reconnection before retry
       if (!persistentChannel) {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -95,7 +95,7 @@ vi.mock('lru-cache', () => {
 });
 
 import { updateExpectationsNumber } from '../../../src/domain/work';
-import { buildSplitMessages, getConnectorQueueSize, metrics, pushBundleToWorker } from '../../../src/database/rabbitmq';
+import { buildSplitMessages, getConnectorQueueSize, metrics, pushBundleToWorker, pushToConnector } from '../../../src/database/rabbitmq';
 
 describe('rabbitmq: metrics', () => {
   const context = {};
@@ -617,5 +617,42 @@ describe('rabbitmq: pushBundleToWorker (centralized expectations tracking)', () 
 
     expect(updateExpectationsNumber).not.toHaveBeenCalled();
     expect(mockChannelPublish).not.toHaveBeenCalled();
+  });
+});
+
+describe('rabbitmq: send() retry cap on persistently nacked publish', () => {
+  const context = {};
+  const user = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnection.createConfirmChannel.mockImplementation((cb: (err: unknown, channel: unknown) => void) => cb(null, mockChannel));
+  });
+
+  it('gives up and throws instead of retrying forever when every publish is nacked', async () => {
+    // Every publish attempt is nacked by the broker (e.g. queue congested / resource alarm).
+    mockChannelPublish.mockImplementation((_exchange, _routingKey, _content, _options, callback) => {
+      callback(new Error('message nacked'));
+      return true;
+    });
+    const message = { type: 'bundle', content: Buffer.from(JSON.stringify({ id: 'bundle--1', type: 'bundle', objects: [{ id: 'malware--a' }] }), 'utf-8').toString('base64'), work_id: 'work-1' };
+
+    await expect(pushBundleToWorker(context, user, 'connector-1', message)).rejects.toThrow(/RabbitMQ send failed after max retries/);
+
+    // Bounded: not an infinite loop.
+    expect(mockChannelPublish.mock.calls.length).toBeGreaterThan(1);
+    expect(mockChannelPublish.mock.calls.length).toBeLessThan(50);
+  });
+
+  it('resolves normally once the broker starts acking again within the retry budget', async () => {
+    let callCount = 0;
+    mockChannelPublish.mockImplementation((_exchange, _routingKey, _content, _options, callback) => {
+      callCount += 1;
+      callback(callCount < 3 ? new Error('message nacked') : null);
+      return true;
+    });
+
+    await expect(pushToConnector('connector-1', { type: 'event' })).resolves.not.toThrow();
+    expect(callCount).toBe(3);
   });
 });


### PR DESCRIPTION
### Proposed changes

* Cap `send()`'s retry loop in `rabbitmq.js` at 20 attempts (~8 minutes with the existing exponential backoff) instead of looping `while (true)` forever; once exhausted it throws a `DatabaseError` and logs at error level.
* Add unit tests in `rabbitmq-test.ts` covering both the exhausted-retries failure path and successful recovery within the retry budget.

### Related issues

* closes #18231

### How to test this PR

Run `yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/database/rabbitmq-test.ts` (38 tests, including the 2 new ones covering the retry cap).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

`send()` previously had no upper bound on retries, so a persistently nacked publish (e.g. broker resource alarm on an oversized queue) blocked its caller forever. Callers await it sequentially per object (`taskManager.js`), so one stuck publish froze the whole task processing loop while the queue kept growing unbounded. This fix only bounds the retry; it does not add dead-letter routing for exhausted messages, that's an open follow-up decision (accept the loss with logging vs. wire into the existing `too-large-bundle` dead-letter queue).
