### PR TITLE
chore(dev): replace the MinIO image by pgsty/silo in the development and CI stacks (#18238)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,7 +79,7 @@ yarn graphql
 The `:venv` variants wrap the command with a Python virtual environment — use them when working on `client-python` or `opencti-worker` and running the backend app.
 
 ### 4. Local Development Stack
-Start the necessary infrastructure (Elastic, Redis, RabbitMQ, MinIO):
+Start the necessary infrastructure (Elastic, Redis, RabbitMQ, Silo):
 ```bash
 cd opencti-platform/opencti-dev
 docker compose up -d

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -10,7 +10,7 @@ The `opencti-graphql` module is the core API server for the OpenCTI platform. It
 - GraphQL API requests (Apollo Server)
 - Data persistence (ElasticSearch/OpenSearch)
 - Message queuing (RabbitMQ)
-- File storage (MinIO/S3)
+- File storage (S3, served by Silo in the development stack)
 - Cache (Redis)
 - Authentication & Authorization
 
@@ -22,7 +22,7 @@ The `opencti-graphql` module is the core API server for the OpenCTI platform. It
 - **API**: GraphQL (Apollo Server)
 - **Database**: ElasticSearch or OpenSearch
 - **Messaging**: RabbitMQ
-- **Object Storage**: MinIO (S3 compatible)
+- **Object Storage**: S3 compatible (Silo, a MinIO fork, in the development stack)
 - **Cache**: Redis
 
 ### Key Directories

--- a/docs/docs/deployment/advanced/clustering.md
+++ b/docs/docs/deployment/advanced/clustering.md
@@ -51,9 +51,9 @@ For the RabbitMQ cluster, you will need a TCP load balancer on top of the nodes 
     
     OpenCTI is also compatible with Amazon MQ, CloudAMQP and AWS / GCP / Azure native services based on the AMQP protocol.
 
-#### S3 bucket / MinIO
+#### S3 bucket / Silo
 
-MinIO is an open source server able to serve S3 buckets. It can be deployed in cluster mode and is compatible with several storage backend. OpenCTI is compatible with any tool following the S3 standard.
+[Silo](https://github.com/pgsty/silo), the community-maintained fork of MinIO, is an open source server able to serve S3 buckets. It can be deployed in cluster mode and is compatible with several storage backends. OpenCTI is compatible with any tool following the S3 standard.
 
 ## Platform
 

--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -446,9 +446,9 @@ ElasticSearch is also a JAVA process. In order to setup the JAVA memory allocati
 
 Redis has a very small footprint on keys but will consume memory for the stream. By default the size of the stream is limited to 2 millions which represents a memory footprint around `8 GB`. You can find more information in the [Redis docker hub](https://hub.docker.com/_/redis).
 
-#### MinIO / S3 Bucket
+#### S3 bucket / Silo
 
-MinIO is a small process and does not require a high amount of memory. More information are available for Linux here on the [Kernel tuning guide](https://github.com/minio/minio/tree/master/docs/deployment/kernel-tuning).
+Silo, the community-maintained fork of MinIO, is a small process and does not require a high amount of memory. More information is available in the [Silo documentation](https://silo.pgsty.com/docs/).
 
 #### RabbitMQ
 

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -50,7 +50,7 @@ roles on the platform:
 | ElasticSearch / OpenSearch | >= 8.0 / >= 2.9    | 2 cores   | ≥ 8GB        | SSD                          | ≥ 16GB          |
 | Redis                      | >= 7.1             | 1 core    | ≥ 1GB        | SSD                          | ≥ 16GB          |
 | RabbitMQ                   | >= 3.11            | 1 core    | ≥ 512MB      | Standard                     | ≥ 2GB           |
-| S3 / MinIO                 | >= RELEASE.2023-02 | 1 core    | ≥ 128MB      | SSD                          | ≥ 16GB          |
+| S3 / Silo / MinIO          | >= RELEASE.2023-02 | 1 core    | ≥ 128MB      | SSD                          | ≥ 16GB          |
 
 
 ### Platform

--- a/docs/docs/development/platform.md
+++ b/docs/docs/development/platform.md
@@ -89,7 +89,7 @@ You should have:
 - redis
 - redis insight
 - rabbitmq
-- minio
+- silo (S3 object storage)
 
 #### Start backend
 

--- a/opencti-platform/opencti-dev/README.md
+++ b/opencti-platform/opencti-dev/README.md
@@ -10,7 +10,7 @@ podman compose up -d
 Will start:
 - elasticsearch + Kibana (`opencti-dev-elasticsearch` & `opencti-dev-kibana`)
 - rabbitMq (`opencti-dev-rabbitmq`)
-- MinIO (`opencti-dev-minio`)
+- Silo, S3 object storage (`opencti-dev-minio`)
 - Redis + redis insight (`opencti-dev-redis` & `opencti-dev-redis-insight`)
 - [Fake smtp server](#fake-smtp-server) (`opencti-dev-smtp`)
 

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -96,7 +96,7 @@ services:
 
   opencti-dev-minio:
     container_name: opencti-dev-minio
-    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    image: pgsty/silo:RELEASE.2026-09-03T13-18-01Z
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   minio:
     container_name: minio
     profiles: ["backend"]
-    image: minio/minio:latest
+    image: pgsty/silo:latest
     networks:
       - runner-docker-network
     ports:


### PR DESCRIPTION
### Proposed changes

The `minio/minio` image is no longer maintained: the upstream repository was archived on 25 April 2026 and the community edition is now source-only, the published images being frozen. This PR moves the development and CI stacks to [Silo](https://github.com/pgsty/silo), the community-maintained fork of the MinIO server published by Pigsty, which keeps the S3 API, the `MINIO_*` variables, the `server /data --console-address` command, the `/minio/health/live` route and the on-disk format unchanged.

* `opencti-platform/opencti-dev/docker-compose.yml`: `minio/minio:RELEASE.2025-06-13T11-33-47Z` becomes `pgsty/silo:RELEASE.2026-09-03T13-18-01Z` (pinned, so Renovate keeps following the dated tags as it does for the other images of the file);
* `scripts/ci/docker-compose.yml`: `minio/minio:latest` becomes `pgsty/silo:latest`;
* documentation and contributor guides that named MinIO as the object storage of the stack now name Silo (deployment overview, installation, clustering, development guide, dev README, Copilot instructions).

Service and container names (`opencti-dev-minio`, `minio`), ports, credentials, command and healthcheck are untouched, so the CI workflows (`docker logs minio`, `MINIO__ENDPOINT=minio`) and local configurations keep working as they are. The platform itself is not modified: the `minio:*` configuration keys and the S3 client stay the same, and any S3-compatible service remains supported.

### Related issues

* closes #18238

### How to test this PR

```bash
cd opencti-platform/opencti-dev
docker compose up -d opencti-dev-minio
docker compose ps opencti-dev-minio          # healthy
curl -f http://localhost:9000/minio/health/live
```

Then start the backend as usual and upload a file on any entity: it lands in the bucket exactly as before.

Verified locally with podman on `pgsty/silo:RELEASE.2026-09-03T13-18-01Z` with the exact compose settings: the health route answers 200, the console answers on 9001, and a bucket create / upload / read round trip works with the bundled `mcli` client. The CI backend and end-to-end jobs of this PR exercise the `latest` tag.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e) — infrastructure change, covered by the existing backend and e2e suites running on the new image
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

`docs/docs/reference/fips.md` still points to the MinIO FIPS images on purpose: Silo does not publish FIPS-tagged images, and the existing MinIO ones remain downloadable.

The production `docker-compose.yml` lives in the [docker](https://github.com/OpenCTI-Platform/docker) repository and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
