### PR TITLE
docs(fips): point the MinIO FIPS images to Quay.io (#18242)

### DIFF
--- a/docs/docs/reference/fips.md
+++ b/docs/docs/reference/fips.md
@@ -53,7 +53,7 @@ Alternatively, you can use a [Stunnel](https://www.stunnel.org/) TLS endpoint to
 
 ### S3 Bucket / MinIO
 
-If you cannot use an S3 endpoint already deployed in your FIPS 140 compliant environment, MinIO provides [FIPS 140 compliant Docker images](https://hub.docker.com/r/minio/minio/tags?page=1&name=fips) which then are very easy to deploy within your environment.
+If you cannot use an S3 endpoint already deployed in your FIPS 140 compliant environment, MinIO published [FIPS 140 compliant Docker images](https://quay.io/repository/minio/minio?tab=tags) on Quay.io (tags suffixed with `.fips`, the last one being `RELEASE.2025-01-18T00-31-37Z.fips`). These images are no longer maintained upstream and Silo does not publish FIPS builds, so check them against your compliance requirements before deploying them.
 
 ## OpenCTI stack
 


### PR DESCRIPTION
### Proposed changes

* `docs/docs/reference/fips.md`: the MinIO FIPS images link now points to `quay.io/minio/minio` instead of the removed Docker Hub repository, names the last FIPS tag (`RELEASE.2025-01-18T00-31-37Z.fips`), and states that these images are frozen upstream and that Silo publishes no FIPS build, so that readers check them against their compliance requirements.

Follow-up of #18239, whose description wrongly stated that the existing MinIO images remain downloadable: `docker.io/minio/minio` answers 404 and anonymous pulls are denied, only the Quay.io copy is left.

### Related issues

* closes #18242

### How to test this PR

Open the rendered page and follow the link: the Quay.io tags page lists the `.fips` tags.

```bash
podman pull quay.io/minio/minio:RELEASE.2025-01-18T00-31-37Z.fips   # works
podman pull docker.io/minio/minio:RELEASE.2025-01-18T00-31-37Z.fips # denied
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e) — documentation only
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
