### PR TITLE
docs(deployment): finish the MinIO to Silo rename after #18239 - FIPS, map and configuration pages (#18244)

### DIFF
--- a/docs/docs/deployment/advanced/map.md
+++ b/docs/docs/deployment/advanced/map.md
@@ -11,7 +11,7 @@ The platform serves map tiles from a backend endpoint (`/maps/world.pmtiles`) th
 Two sources are available:
 
 - **Bundled** (default) — A PMTiles file shipped inside the Docker image.
-- **Custom** — A custom PMTiles file uploaded by an administrator and stored in S3/MinIO.
+- **Custom** — A custom PMTiles file uploaded by an administrator and stored in the S3 bucket (Silo or any S3-compatible storage).
 
 When a custom file has been uploaded, it is used; otherwise, the bundled file is used.
 
@@ -31,7 +31,7 @@ Administrators can upload a custom `.pmtiles` file to replace the bundled map da
 2. Go to **Settings > Parameters > Map configuration**.
 3. Click **Upload** to upload the file.
 
-The custom file is used immediately — no additional step required. It is stored in S3/MinIO; only one custom file can exist at a time, uploading a new file replaces the previous one.
+The custom file is used immediately — no additional step required. It is stored in the S3 bucket; only one custom file can exist at a time, uploading a new file replaces the previous one.
 
 ### Reverting to the bundled map
 

--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -234,13 +234,13 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 
 | Parameter           | Environment variable | Default value  | Description                                                                                                                                                                                                                 |
 |:--------------------|:---------------------|:---------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| minio:endpoint      | MINIO__ENDPOINT      | localhost      | Hostname of the S3 Service. Example if you use AWS Bucket S3: __s3.us-east-1.amazonaws.com__ (if `minio:bucket_region` value is _us-east-1_). This parameter value can be omitted if you use Minio as an S3 Bucket Service. |
+| minio:endpoint      | MINIO__ENDPOINT      | localhost      | Hostname of the S3 Service. Example if you use AWS Bucket S3: __s3.us-east-1.amazonaws.com__ (if `minio:bucket_region` value is _us-east-1_). This parameter value can be omitted if you use Silo as an S3 Bucket Service.  |
 | minio:port          | MINIO__PORT          | 9000           | Port of the S3 Service. For AWS Bucket S3 over HTTPS, this value can be changed (usually __443__).                                                                                                                          |
 | minio:use_ssl       | MINIO__USE_SSL       | `false`        | Indicates whether the S3 Service has TLS enabled. For AWS Bucket S3 over HTTPS, this value could be `true`.                                                                                                                 |
 | minio:access_key    | MINIO__ACCESS_KEY    | ChangeMe       | Access key for the S3 Service.                                                                                                                                                                                              |
 | minio:secret_key    | MINIO__SECRET_KEY    | ChangeMe       | Secret key for the S3 Service.                                                                                                                                                                                              |
 | minio:bucket_name   | MINIO__BUCKET_NAME   | opencti-bucket | S3 bucket name. Useful to change if you use AWS.                                                                                                                                                                            |
-| minio:bucket_region | MINIO__BUCKET_REGION | us-east-1      | Region of the S3 bucket if you are using AWS. This parameter value can be omitted if you use Minio as an S3 Bucket Service.                                                                                                 |
+| minio:bucket_region | MINIO__BUCKET_REGION | us-east-1      | Region of the S3 bucket if you are using AWS. This parameter value can be omitted if you use Silo as an S3 Bucket Service.                                                                                                  |
 | minio:use_aws_role  | MINIO__USE_AWS_ROLE  | `false`        | Indicates whether to use AWS role auto credentials. When this parameter is configured, the `minio:access_key` and `minio:secret_key` parameters are not necessary.                                                          |
 
 !!! note "Using a proxy for AWS S3"
@@ -398,7 +398,7 @@ JSON version:
 }
 ```
 
-Another example for MinIo (S3) using certificate:
+Another example for the S3 storage (`minio` section) using certificate:
 
 Environment variables:
 ```yaml

--- a/docs/docs/reference/fips.md
+++ b/docs/docs/reference/fips.md
@@ -53,7 +53,9 @@ Alternatively, you can use a [Stunnel](https://www.stunnel.org/) TLS endpoint to
 
 ### S3 Bucket / MinIO
 
-If you cannot use an S3 endpoint already deployed in your FIPS 140 compliant environment, MinIO provides [FIPS 140 compliant Docker images](https://hub.docker.com/r/minio/minio/tags?page=1&name=fips) which then are very easy to deploy within your environment.
+MinIO used to provide FIPS 140 compliant Docker images, but the project has been archived and Docker Hub no longer serves the `minio/minio` repository. Silo ([pgsty/silo](https://github.com/pgsty/silo)), the community-maintained fork of MinIO used by the OpenCTI development and CI stacks, does not publish FIPS-validated builds either.
+
+In a FIPS 140 compliant environment, use an S3 endpoint that is already validated, for example the [AWS S3 FIPS endpoints](https://aws.amazon.com/compliance/fips/) or the object storage service of your platform, rather than a self-deployed MinIO or Silo container.
 
 ## OpenCTI stack
 


### PR DESCRIPTION
## Proposed changes

* `docs/docs/reference/fips.md`, section "S3 Bucket / MinIO": the sentence that pointed FIPS 140 deployments at the MinIO FIPS tags on Docker Hub (`https://hub.docker.com/r/minio/minio/tags?name=fips`, now a dead link: the repository was removed and the project is archived) is replaced by two short paragraphs. They say that the MinIO FIPS images are gone, that Silo (`pgsty/silo`, the fork used by the development and CI stacks since #18239) has no FIPS-validated build, and direct FIPS 140 deployments to an S3 endpoint that is already validated in their environment (AWS S3 FIPS endpoints or the platform's own object storage) rather than a self-deployed container. The heading is kept so existing anchors keep working.
* `docs/docs/deployment/advanced/map.md`: the custom PMTiles file is now said to be stored in "the S3 bucket (Silo or any S3-compatible storage)" instead of "S3/MinIO" (two mentions).
* `docs/docs/deployment/configuration.md`: the `minio:endpoint` and `minio:bucket_region` rows say "if you use Silo as an S3 Bucket Service" instead of "Minio" (table alignment preserved), and the credentials-provider example is titled "Another example for the S3 storage (`minio` section) using certificate" instead of "for MinIo (S3)".

These are the last prose mentions of MinIO as the stack's object storage after #18239 (full `git grep -i minio` over `master`, details in #18244). Everything else that matches is the contract Silo keeps and is untouched on purpose: the `minio` service / container names and the `docker logs minio` CI steps, the `MINIO_*` / `MINIO__*` variables, the `minio:` configuration section and its `S3 Storage | minio` prefix row, the `/minio/health/live` healthcheck route, the "fork of MinIO" wording introduced by #18239, and the MinIO CVE fixtures of the CISA mapper test.

## Related issues

* Closes #18244
* Follow-up of #18238 / #18239

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (documentation only: Markdown renders, table alignment checked, links checked)
- [ ] I wrote test cases for the relevant uses case (N/A, documentation)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality (N/A)

## Further comments

Silo publishes only `latest`, `distroless` and dated `RELEASE.*` tags (checked on Docker Hub), which is why the FIPS page cannot simply be re-pointed at it. The orphan `"MinIO"` key in `opencti-front/lang/front/*.json` (no component uses it anymore) is left alone here; say if you want it dropped from the bundles.